### PR TITLE
Refactor validation into dedicated validators

### DIFF
--- a/src/adapters/account.adapter.ts
+++ b/src/adapters/account.adapter.ts
@@ -38,9 +38,6 @@ export class AccountAdapter extends BaseAdapter<Account> {
   ];
 
   protected override async onBeforeCreate(data: Partial<Account>): Promise<Partial<Account>> {
-    // Validate account data
-    this.validateAccountData(data);
-    
     // Set default values
     if (data.is_active === undefined) {
       data.is_active = true;
@@ -55,11 +52,7 @@ export class AccountAdapter extends BaseAdapter<Account> {
   }
 
   protected override async onBeforeUpdate(id: string, data: Partial<Account>): Promise<Partial<Account>> {
-    // Validate account data if fields are being updated
-    if (data.name || data.account_number || data.email) {
-      this.validateAccountData(data);
-    }
-    
+    // Repositories perform validation
     return data;
   }
 
@@ -87,17 +80,4 @@ export class AccountAdapter extends BaseAdapter<Account> {
     await logAuditEvent('delete', 'account', id, { id });
   }
 
-  private validateAccountData(data: Partial<Account>): void {
-    if (data.name !== undefined && !data.name.trim()) {
-      throw new Error('Account name is required');
-    }
-    
-    if (data.account_number !== undefined && !data.account_number.trim()) {
-      throw new Error('Account number is required');
-    }
-    
-    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      throw new Error('Invalid email format');
-    }
-  }
 }

--- a/src/adapters/chartOfAccount.adapter.ts
+++ b/src/adapters/chartOfAccount.adapter.ts
@@ -33,9 +33,6 @@ export class ChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {
   ];
 
   protected override async onBeforeCreate(data: Partial<ChartOfAccount>): Promise<Partial<ChartOfAccount>> {
-    // Validate account data
-    this.validateAccountData(data);
-    
     // Set default values
     if (data.is_active === undefined) {
       data.is_active = true;
@@ -50,11 +47,7 @@ export class ChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {
   }
 
   protected override async onBeforeUpdate(id: string, data: Partial<ChartOfAccount>): Promise<Partial<ChartOfAccount>> {
-    // Validate account data if fields are being updated
-    if (data.code || data.name || data.account_type) {
-      this.validateAccountData(data);
-    }
-    
+    // Repositories handle validation
     return data;
   }
 
@@ -94,22 +87,6 @@ export class ChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {
     await logAuditEvent('delete', 'chart_of_account', id, { id });
   }
 
-  private validateAccountData(data: Partial<ChartOfAccount>): void {
-    if (data.code !== undefined && !data.code.trim()) {
-      throw new Error('Account code is required');
-    }
-    
-    if (data.name !== undefined && !data.name.trim()) {
-      throw new Error('Account name is required');
-    }
-    
-    if (data.account_type !== undefined) {
-      const validTypes = ['asset', 'liability', 'equity', 'revenue', 'expense'];
-      if (!validTypes.includes(data.account_type)) {
-        throw new Error('Invalid account type. Must be one of: asset, liability, equity, revenue, expense');
-      }
-    }
-  }
 
   public async getHierarchy(): Promise<ChartOfAccount[]> {
     const { data, error } = await supabase.rpc('get_chart_of_accounts_hierarchy');

--- a/src/adapters/financialSource.adapter.ts
+++ b/src/adapters/financialSource.adapter.ts
@@ -23,9 +23,6 @@ export class FinancialSourceAdapter extends BaseAdapter<FinancialSource> {
   `;
 
   protected override async onBeforeCreate(data: Partial<FinancialSource>): Promise<Partial<FinancialSource>> {
-    // Validate source data
-    this.validateSourceData(data);
-    
     // Set default values
     if (data.is_active === undefined) {
       data.is_active = true;
@@ -40,11 +37,7 @@ export class FinancialSourceAdapter extends BaseAdapter<FinancialSource> {
   }
 
   protected override async onBeforeUpdate(id: string, data: Partial<FinancialSource>): Promise<Partial<FinancialSource>> {
-    // Validate source data if fields are being updated
-    if (data.name || data.source_type) {
-      this.validateSourceData(data);
-    }
-    
+    // Repositories handle validation
     return data;
   }
 
@@ -72,16 +65,4 @@ export class FinancialSourceAdapter extends BaseAdapter<FinancialSource> {
     await logAuditEvent('delete', 'financial_source', id, { id });
   }
 
-  private validateSourceData(data: Partial<FinancialSource>): void {
-    if (data.name !== undefined && !data.name.trim()) {
-      throw new Error('Source name is required');
-    }
-    
-    if (data.source_type !== undefined) {
-      const validTypes = ['bank', 'fund', 'wallet', 'cash', 'online', 'other'];
-      if (!validTypes.includes(data.source_type)) {
-        throw new Error('Invalid source type. Must be one of: bank, fund, wallet, cash, online, other');
-      }
-    }
-  }
 }

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -37,9 +37,6 @@ export class FinancialTransactionHeaderAdapter extends BaseAdapter<FinancialTran
   ];
 
   protected override async onBeforeCreate(data: Partial<FinancialTransactionHeader>): Promise<Partial<FinancialTransactionHeader>> {
-    // Validate header data
-    this.validateHeaderData(data);
-    
     // Set default values
     if (!data.status) {
       data.status = 'draft';
@@ -140,22 +137,6 @@ export class FinancialTransactionHeaderAdapter extends BaseAdapter<FinancialTran
     await logAuditEvent('delete', 'financial_transaction_header', id, { id });
   }
 
-  private validateHeaderData(data: Partial<FinancialTransactionHeader>): void {
-    if (data.transaction_date === undefined) {
-      throw new Error('Transaction date is required');
-    }
-    
-    if (data.description !== undefined && !data.description.trim()) {
-      throw new Error('Description is required');
-    }
-    
-    if (data.status !== undefined) {
-      const validStatuses = ['draft', 'posted', 'voided'];
-      if (!validStatuses.includes(data.status)) {
-        throw new Error('Invalid status. Must be one of: draft, posted, voided');
-      }
-    }
-  }
 
   private async generateTransactionNumber(date: string, prefix: string): Promise<string> {
     // Format: PREFIX-YYYYMM-SEQUENCE

--- a/src/adapters/member.adapter.ts
+++ b/src/adapters/member.adapter.ts
@@ -86,27 +86,8 @@ export class MemberAdapter extends BaseAdapter<Member> {
     await logAuditEvent('delete', 'member', id, { id });
   }
 
-  protected async validateMember(data: Partial<Member>): Promise<void> {
-    if (!data.first_name?.trim()) {
-      throw new Error('First name is required');
-    }
-    if (!data.last_name?.trim()) {
-      throw new Error('Last name is required');
-    }
-    if (!data.contact_number?.trim()) {
-      throw new Error('Contact number is required');
-    }
-    if (!data.address?.trim()) {
-      throw new Error('Address is required');
-    }
-    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      throw new Error('Invalid email format');
-    }
-  }
-
   protected override async onBeforeCreate(data: Partial<Member>): Promise<Partial<Member>> {
-    // Validate member data
-    await this.validateMember(data);
+    // Repositories handle validation
 
     // Check for duplicate email if provided
     if (data.email) {

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -3,6 +3,7 @@ import { BaseRepository } from './base.repository';
 import { Account } from '../models/account.model';
 import { AccountAdapter } from '../adapters/account.adapter';
 import { NotificationService } from '../services/NotificationService';
+import { AccountValidator } from '../validators/account.validator';
 
 @injectable()
 export class AccountRepository extends BaseRepository<Account> {
@@ -11,8 +12,8 @@ export class AccountRepository extends BaseRepository<Account> {
   }
 
   protected override async beforeCreate(data: Partial<Account>): Promise<Partial<Account>> {
-    // Additional repository-level validation
-    this.validateAccountData(data);
+    // Validate account data
+    AccountValidator.validate(data);
     
     // Format data before creation
     return this.formatAccountData(data);
@@ -24,8 +25,8 @@ export class AccountRepository extends BaseRepository<Account> {
   }
 
   protected override async beforeUpdate(id: string, data: Partial<Account>): Promise<Partial<Account>> {
-    // Additional repository-level validation
-    this.validateAccountData(data);
+    // Validate account data
+    AccountValidator.validate(data);
     
     // Format data before update
     return this.formatAccountData(data);
@@ -50,34 +51,6 @@ export class AccountRepository extends BaseRepository<Account> {
   }
 
   // Private helper methods
-  private validateAccountData(data: Partial<Account>): void {
-    const errors: string[] = [];
-
-    // Basic validation
-    if (data.name !== undefined && !data.name.trim()) {
-      errors.push('Account name is required');
-    }
-    
-    if (data.account_number !== undefined && !data.account_number.trim()) {
-      errors.push('Account number is required');
-    }
-    
-    if (data.account_type !== undefined && 
-        !['organization', 'person'].includes(data.account_type)) {
-      errors.push('Account type must be either "organization" or "person"');
-    }
-
-    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      errors.push('Invalid email format');
-    }
-
-    if (errors.length > 0) {
-      errors.forEach(error => {
-        NotificationService.showError(error, 5000);
-      });
-      throw new Error('Validation failed: ' + errors.join(', '));
-    }
-  }
 
   private formatAccountData(data: Partial<Account>): Partial<Account> {
     const formattedData = { ...data };

--- a/src/repositories/chartOfAccount.repository.ts
+++ b/src/repositories/chartOfAccount.repository.ts
@@ -3,6 +3,7 @@ import { BaseRepository } from './base.repository';
 import { ChartOfAccount } from '../models/chartOfAccount.model';
 import { ChartOfAccountAdapter } from '../adapters/chartOfAccount.adapter';
 import { NotificationService } from '../services/NotificationService';
+import { ChartOfAccountValidator } from '../validators/chartOfAccount.validator';
 
 @injectable()
 export class ChartOfAccountRepository extends BaseRepository<ChartOfAccount> {
@@ -11,8 +12,8 @@ export class ChartOfAccountRepository extends BaseRepository<ChartOfAccount> {
   }
 
   protected override async beforeCreate(data: Partial<ChartOfAccount>): Promise<Partial<ChartOfAccount>> {
-    // Additional repository-level validation
-    this.validateAccountData(data);
+    // Validate account data
+    ChartOfAccountValidator.validate(data);
     
     // Format data before creation
     return this.formatAccountData(data);
@@ -24,8 +25,8 @@ export class ChartOfAccountRepository extends BaseRepository<ChartOfAccount> {
   }
 
   protected override async beforeUpdate(id: string, data: Partial<ChartOfAccount>): Promise<Partial<ChartOfAccount>> {
-    // Additional repository-level validation
-    this.validateAccountData(data);
+    // Validate account data
+    ChartOfAccountValidator.validate(data);
     
     // Format data before update
     return this.formatAccountData(data);
@@ -50,32 +51,6 @@ export class ChartOfAccountRepository extends BaseRepository<ChartOfAccount> {
   }
 
   // Private helper methods
-  private validateAccountData(data: Partial<ChartOfAccount>): void {
-    const errors: string[] = [];
-
-    // Basic validation
-    if (data.code !== undefined && !data.code.trim()) {
-      errors.push('Account code is required');
-    }
-    
-    if (data.name !== undefined && !data.name.trim()) {
-      errors.push('Account name is required');
-    }
-    
-    if (data.account_type !== undefined) {
-      const validTypes = ['asset', 'liability', 'equity', 'revenue', 'expense'];
-      if (!validTypes.includes(data.account_type)) {
-        errors.push('Invalid account type. Must be one of: asset, liability, equity, revenue, expense');
-      }
-    }
-
-    if (errors.length > 0) {
-      errors.forEach(error => {
-        NotificationService.showError(error, 5000);
-      });
-      throw new Error('Validation failed: ' + errors.join(', '));
-    }
-  }
 
   private formatAccountData(data: Partial<ChartOfAccount>): Partial<ChartOfAccount> {
     const formattedData = { ...data };

--- a/src/repositories/financialSource.repository.ts
+++ b/src/repositories/financialSource.repository.ts
@@ -3,6 +3,7 @@ import { BaseRepository } from './base.repository';
 import { FinancialSource } from '../models/financialSource.model';
 import { FinancialSourceAdapter } from '../adapters/financialSource.adapter';
 import { NotificationService } from '../services/NotificationService';
+import { FinancialSourceValidator } from '../validators/financialSource.validator';
 
 @injectable()
 export class FinancialSourceRepository extends BaseRepository<FinancialSource> {
@@ -11,8 +12,8 @@ export class FinancialSourceRepository extends BaseRepository<FinancialSource> {
   }
 
   protected override async beforeCreate(data: Partial<FinancialSource>): Promise<Partial<FinancialSource>> {
-    // Additional repository-level validation
-    this.validateSourceData(data);
+    // Validate source data
+    FinancialSourceValidator.validate(data);
     
     // Format data before creation
     return this.formatSourceData(data);
@@ -24,8 +25,8 @@ export class FinancialSourceRepository extends BaseRepository<FinancialSource> {
   }
 
   protected override async beforeUpdate(id: string, data: Partial<FinancialSource>): Promise<Partial<FinancialSource>> {
-    // Additional repository-level validation
-    this.validateSourceData(data);
+    // Validate source data
+    FinancialSourceValidator.validate(data);
     
     // Format data before update
     return this.formatSourceData(data);
@@ -50,28 +51,6 @@ export class FinancialSourceRepository extends BaseRepository<FinancialSource> {
   }
 
   // Private helper methods
-  private validateSourceData(data: Partial<FinancialSource>): void {
-    const errors: string[] = [];
-
-    // Basic validation
-    if (data.name !== undefined && !data.name.trim()) {
-      errors.push('Source name is required');
-    }
-    
-    if (data.source_type !== undefined) {
-      const validTypes = ['bank', 'fund', 'wallet', 'cash', 'online', 'other'];
-      if (!validTypes.includes(data.source_type)) {
-        errors.push('Invalid source type. Must be one of: bank, fund, wallet, cash, online, other');
-      }
-    }
-
-    if (errors.length > 0) {
-      errors.forEach(error => {
-        NotificationService.showError(error, 5000);
-      });
-      throw new Error('Validation failed: ' + errors.join(', '));
-    }
-  }
 
   private formatSourceData(data: Partial<FinancialSource>): Partial<FinancialSource> {
     const formattedData = { ...data };

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -3,6 +3,7 @@ import { BaseRepository } from './base.repository';
 import { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
 import { FinancialTransactionHeaderAdapter } from '../adapters/financialTransactionHeader.adapter';
 import { NotificationService } from '../services/NotificationService';
+import { FinancialTransactionHeaderValidator } from '../validators/financialTransactionHeader.validator';
 
 @injectable()
 export class FinancialTransactionHeaderRepository extends BaseRepository<FinancialTransactionHeader> {
@@ -11,8 +12,8 @@ export class FinancialTransactionHeaderRepository extends BaseRepository<Financi
   }
 
   protected override async beforeCreate(data: Partial<FinancialTransactionHeader>): Promise<Partial<FinancialTransactionHeader>> {
-    // Additional repository-level validation
-    this.validateHeaderData(data);
+    // Validate header data
+    FinancialTransactionHeaderValidator.validate(data);
     
     // Format data before creation
     return this.formatHeaderData(data);
@@ -24,8 +25,8 @@ export class FinancialTransactionHeaderRepository extends BaseRepository<Financi
   }
 
   protected override async beforeUpdate(id: string, data: Partial<FinancialTransactionHeader>): Promise<Partial<FinancialTransactionHeader>> {
-    // Additional repository-level validation
-    this.validateHeaderData(data);
+    // Validate header data
+    FinancialTransactionHeaderValidator.validate(data);
     
     // Format data before update
     return this.formatHeaderData(data);
@@ -54,32 +55,6 @@ export class FinancialTransactionHeaderRepository extends BaseRepository<Financi
   }
 
   // Private helper methods
-  private validateHeaderData(data: Partial<FinancialTransactionHeader>): void {
-    const errors: string[] = [];
-
-    // Basic validation
-    if (data.transaction_date !== undefined && !data.transaction_date) {
-      errors.push('Transaction date is required');
-    }
-    
-    if (data.description !== undefined && !data.description.trim()) {
-      errors.push('Description is required');
-    }
-    
-    if (data.status !== undefined) {
-      const validStatuses = ['draft', 'posted', 'voided'];
-      if (!validStatuses.includes(data.status)) {
-        errors.push('Invalid status. Must be one of: draft, posted, voided');
-      }
-    }
-
-    if (errors.length > 0) {
-      errors.forEach(error => {
-        NotificationService.showError(error, 5000);
-      });
-      throw new Error('Validation failed: ' + errors.join(', '));
-    }
-  }
 
   private formatHeaderData(data: Partial<FinancialTransactionHeader>): Partial<FinancialTransactionHeader> {
     const formattedData = { ...data };

--- a/src/repositories/member.repository.ts
+++ b/src/repositories/member.repository.ts
@@ -3,6 +3,7 @@ import { BaseRepository } from './base.repository';
 import { Member } from '../models/member.model';
 import { MemberAdapter } from '../adapters/member.adapter';
 import { NotificationService } from '../services/NotificationService';
+import { MemberValidator } from '../validators/member.validator';
 
 @injectable()
 export class MemberRepository extends BaseRepository<Member> {
@@ -11,8 +12,8 @@ export class MemberRepository extends BaseRepository<Member> {
   }
 
   protected override async beforeCreate(data: Partial<Member>): Promise<Partial<Member>> {
-    // Additional repository-level validation
-    this.validateMemberData(data);
+    // Validate member data
+    MemberValidator.validate(data);
     
     // Format data before creation
     return this.formatMemberData(data);
@@ -24,8 +25,8 @@ export class MemberRepository extends BaseRepository<Member> {
   }
 
   protected override async beforeUpdate(id: string, data: Partial<Member>): Promise<Partial<Member>> {
-    // Additional repository-level validation
-    this.validateMemberData(data);
+    // Validate member data
+    MemberValidator.validate(data);
     
     // Format data before update
     return this.formatMemberData(data);
@@ -47,41 +48,6 @@ export class MemberRepository extends BaseRepository<Member> {
   }
 
   // Private helper methods
-  private validateMemberData(data: Partial<Member>): void {
-    const errors: string[] = [];
-
-    // Basic Info validation
-    if (!data.first_name?.trim()) {
-      errors.push('First name is required');
-    }
-    if (!data.last_name?.trim()) {
-      errors.push('Last name is required');
-    }
-    if (!data.gender) {
-      errors.push('Gender is required');
-    }
-    if (!data.marital_status) {
-      errors.push('Marital status is required');
-    }
-
-    // Contact Info validation
-    if (!data.contact_number?.trim()) {
-      errors.push('Contact number is required');
-    }
-    if (!data.address?.trim()) {
-      errors.push('Address is required');
-    }
-    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      errors.push('Invalid email format');
-    }
-
-    if (errors.length > 0) {
-      errors.forEach(error => {
-        NotificationService.showError(error, 5000);
-      });
-      throw new Error('Validation failed: ' + errors.join(', '));
-    }
-  }
 
   private formatMemberData(data: Partial<Member>): Partial<Member> {
     return {

--- a/src/validators/account.validator.ts
+++ b/src/validators/account.validator.ts
@@ -1,0 +1,22 @@
+import { Account } from '../models/account.model';
+
+export class AccountValidator {
+  static validate(data: Partial<Account>): void {
+    if (data.name !== undefined && !data.name.trim()) {
+      throw new Error('Account name is required');
+    }
+
+    if (data.account_number !== undefined && !data.account_number.trim()) {
+      throw new Error('Account number is required');
+    }
+
+    if (data.account_type !== undefined &&
+        !['organization', 'person'].includes(data.account_type)) {
+      throw new Error('Account type must be either "organization" or "person"');
+    }
+
+    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+      throw new Error('Invalid email format');
+    }
+  }
+}

--- a/src/validators/chartOfAccount.validator.ts
+++ b/src/validators/chartOfAccount.validator.ts
@@ -1,0 +1,20 @@
+import { ChartOfAccount } from '../models/chartOfAccount.model';
+
+export class ChartOfAccountValidator {
+  static validate(data: Partial<ChartOfAccount>): void {
+    if (data.code !== undefined && !data.code.trim()) {
+      throw new Error('Account code is required');
+    }
+
+    if (data.name !== undefined && !data.name.trim()) {
+      throw new Error('Account name is required');
+    }
+
+    if (data.account_type !== undefined) {
+      const validTypes = ['asset', 'liability', 'equity', 'revenue', 'expense'];
+      if (!validTypes.includes(data.account_type)) {
+        throw new Error('Invalid account type. Must be one of: asset, liability, equity, revenue, expense');
+      }
+    }
+  }
+}

--- a/src/validators/financialSource.validator.ts
+++ b/src/validators/financialSource.validator.ts
@@ -1,0 +1,16 @@
+import { FinancialSource } from '../models/financialSource.model';
+
+export class FinancialSourceValidator {
+  static validate(data: Partial<FinancialSource>): void {
+    if (data.name !== undefined && !data.name.trim()) {
+      throw new Error('Source name is required');
+    }
+
+    if (data.source_type !== undefined) {
+      const validTypes = ['bank', 'fund', 'wallet', 'cash', 'online', 'other'];
+      if (!validTypes.includes(data.source_type)) {
+        throw new Error('Invalid source type. Must be one of: bank, fund, wallet, cash, online, other');
+      }
+    }
+  }
+}

--- a/src/validators/financialTransactionHeader.validator.ts
+++ b/src/validators/financialTransactionHeader.validator.ts
@@ -1,0 +1,20 @@
+import { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
+
+export class FinancialTransactionHeaderValidator {
+  static validate(data: Partial<FinancialTransactionHeader>): void {
+    if (data.transaction_date !== undefined && !data.transaction_date) {
+      throw new Error('Transaction date is required');
+    }
+
+    if (data.description !== undefined && !data.description.trim()) {
+      throw new Error('Description is required');
+    }
+
+    if (data.status !== undefined) {
+      const validStatuses = ['draft', 'posted', 'voided'];
+      if (!validStatuses.includes(data.status)) {
+        throw new Error('Invalid status. Must be one of: draft, posted, voided');
+      }
+    }
+  }
+}

--- a/src/validators/member.validator.ts
+++ b/src/validators/member.validator.ts
@@ -1,0 +1,27 @@
+import { Member } from '../models/member.model';
+
+export class MemberValidator {
+  static validate(data: Partial<Member>): void {
+    if (!data.first_name?.trim()) {
+      throw new Error('First name is required');
+    }
+    if (!data.last_name?.trim()) {
+      throw new Error('Last name is required');
+    }
+    if (!data.gender) {
+      throw new Error('Gender is required');
+    }
+    if (!data.marital_status) {
+      throw new Error('Marital status is required');
+    }
+    if (!data.contact_number?.trim()) {
+      throw new Error('Contact number is required');
+    }
+    if (!data.address?.trim()) {
+      throw new Error('Address is required');
+    }
+    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+      throw new Error('Invalid email format');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create validators for account, chart of account, financial source, transaction header and member
- remove validation logic from adapters
- invoke validators from repositories before delegating to adapters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68557db052008326ac808c06f4545e51