### PR TITLE
Introduce account DI interfaces

### DIFF
--- a/src/adapters/account.adapter.ts
+++ b/src/adapters/account.adapter.ts
@@ -5,8 +5,13 @@ import { Account } from '../models/account.model';
 import { AuditService, SupabaseAuditService } from '../services/AuditService';
 import { supabase } from '../lib/supabase';
 
+export interface IAccountAdapter extends BaseAdapter<Account> {}
+
 @injectable()
-export class AccountAdapter extends BaseAdapter<Account> {
+export class AccountAdapter
+  extends BaseAdapter<Account>
+  implements IAccountAdapter
+{
   constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
     super();
   }

--- a/src/adapters/chartOfAccount.adapter.ts
+++ b/src/adapters/chartOfAccount.adapter.ts
@@ -5,8 +5,13 @@ import { ChartOfAccount } from '../models/chartOfAccount.model';
 import { AuditService, SupabaseAuditService } from '../services/AuditService';
 import { supabase } from '../lib/supabase';
 
+export interface IChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {}
+
 @injectable()
-export class ChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {
+export class ChartOfAccountAdapter
+  extends BaseAdapter<ChartOfAccount>
+  implements IChartOfAccountAdapter
+{
   constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
     super();
   }

--- a/src/adapters/financialSource.adapter.ts
+++ b/src/adapters/financialSource.adapter.ts
@@ -5,8 +5,13 @@ import { FinancialSource } from '../models/financialSource.model';
 import { AuditService, SupabaseAuditService } from '../services/AuditService';
 import { supabase } from '../lib/supabase';
 
+export interface IFinancialSourceAdapter extends BaseAdapter<FinancialSource> {}
+
 @injectable()
-export class FinancialSourceAdapter extends BaseAdapter<FinancialSource> {
+export class FinancialSourceAdapter
+  extends BaseAdapter<FinancialSource>
+  implements IFinancialSourceAdapter
+{
   constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
     super();
   }

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -5,8 +5,14 @@ import { FinancialTransactionHeader } from '../models/financialTransactionHeader
 import { AuditService, SupabaseAuditService } from '../services/AuditService';
 import { supabase } from '../lib/supabase';
 
+export interface IFinancialTransactionHeaderAdapter
+  extends BaseAdapter<FinancialTransactionHeader> {}
+
 @injectable()
-export class FinancialTransactionHeaderAdapter extends BaseAdapter<FinancialTransactionHeader> {
+export class FinancialTransactionHeaderAdapter
+  extends BaseAdapter<FinancialTransactionHeader>
+  implements IFinancialTransactionHeaderAdapter
+{
   constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
     super();
   }

--- a/src/adapters/member.adapter.ts
+++ b/src/adapters/member.adapter.ts
@@ -5,8 +5,13 @@ import { Member } from '../models/member.model';
 import { AuditService, SupabaseAuditService } from '../services/AuditService';
 import { supabase } from '../lib/supabase';
 
+export interface IMemberAdapter extends BaseAdapter<Member> {}
+
 @injectable()
-export class MemberAdapter extends BaseAdapter<Member> {
+export class MemberAdapter
+  extends BaseAdapter<Member>
+  implements IMemberAdapter
+{
   constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
     super();
   }

--- a/src/adapters/notification.adapter.ts
+++ b/src/adapters/notification.adapter.ts
@@ -4,8 +4,17 @@ import { BaseAdapter, QueryOptions } from './base.adapter';
 import { Notification } from '../models/notification.model';
 import { supabase } from '../lib/supabase';
 
+export interface INotificationAdapter extends BaseAdapter<Notification> {
+  markAsRead(id: string): Promise<void>;
+  markAllAsRead(userId: string): Promise<void>;
+  deleteExpired(): Promise<void>;
+}
+
 @injectable()
-export class NotificationAdapter extends BaseAdapter<Notification> {
+export class NotificationAdapter
+  extends BaseAdapter<Notification>
+  implements INotificationAdapter
+{
   protected tableName = 'notifications';
   
   protected defaultSelect = `

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -1,38 +1,115 @@
 import 'reflect-metadata';
 import { Container } from 'inversify';
-import { MemberAdapter } from '../adapters/member.adapter';
-import { NotificationAdapter } from '../adapters/notification.adapter';
-import { AccountAdapter } from '../adapters/account.adapter';
-import { FinancialSourceAdapter } from '../adapters/financialSource.adapter';
-import { ChartOfAccountAdapter } from '../adapters/chartOfAccount.adapter';
-import { FinancialTransactionHeaderAdapter } from '../adapters/financialTransactionHeader.adapter';
-import { MemberRepository } from '../repositories/member.repository';
-import { NotificationRepository } from '../repositories/notification.repository';
-import { AccountRepository } from '../repositories/account.repository';
-import { FinancialSourceRepository } from '../repositories/financialSource.repository';
-import { ChartOfAccountRepository } from '../repositories/chartOfAccount.repository';
-import { FinancialTransactionHeaderRepository } from '../repositories/financialTransactionHeader.repository';
+import { MemberAdapter, type IMemberAdapter } from '../adapters/member.adapter';
+import {
+  NotificationAdapter,
+  type INotificationAdapter
+} from '../adapters/notification.adapter';
+import { AccountAdapter, type IAccountAdapter } from '../adapters/account.adapter';
+import {
+  FinancialSourceAdapter,
+  type IFinancialSourceAdapter
+} from '../adapters/financialSource.adapter';
+import {
+  ChartOfAccountAdapter,
+  type IChartOfAccountAdapter
+} from '../adapters/chartOfAccount.adapter';
+import {
+  FinancialTransactionHeaderAdapter,
+  type IFinancialTransactionHeaderAdapter
+} from '../adapters/financialTransactionHeader.adapter';
+import { MemberRepository, type IMemberRepository } from '../repositories/member.repository';
+import {
+  NotificationRepository,
+  type INotificationRepository
+} from '../repositories/notification.repository';
+import { AccountRepository, type IAccountRepository } from '../repositories/account.repository';
+import {
+  FinancialSourceRepository,
+  type IFinancialSourceRepository
+} from '../repositories/financialSource.repository';
+import {
+  ChartOfAccountRepository,
+  type IChartOfAccountRepository
+} from '../repositories/chartOfAccount.repository';
+import {
+  FinancialTransactionHeaderRepository,
+  type IFinancialTransactionHeaderRepository
+} from '../repositories/financialTransactionHeader.repository';
 import { SupabaseAuditService } from '../services/AuditService';
 
 const container = new Container();
 
+const TYPES = {
+  IMemberAdapter: 'IMemberAdapter',
+  INotificationAdapter: 'INotificationAdapter',
+  IAccountAdapter: 'IAccountAdapter',
+  IFinancialSourceAdapter: 'IFinancialSourceAdapter',
+  IChartOfAccountAdapter: 'IChartOfAccountAdapter',
+  IFinancialTransactionHeaderAdapter: 'IFinancialTransactionHeaderAdapter',
+  IMemberRepository: 'IMemberRepository',
+  INotificationRepository: 'INotificationRepository',
+  IAccountRepository: 'IAccountRepository',
+  IFinancialSourceRepository: 'IFinancialSourceRepository',
+  IChartOfAccountRepository: 'IChartOfAccountRepository',
+  IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository'
+};
+
 // Register adapters
-container.bind(MemberAdapter).toSelf().inSingletonScope();
-container.bind(NotificationAdapter).toSelf().inSingletonScope();
-container.bind(AccountAdapter).toSelf().inSingletonScope();
-container.bind(FinancialSourceAdapter).toSelf().inSingletonScope();
-container.bind(ChartOfAccountAdapter).toSelf().inSingletonScope();
-container.bind(FinancialTransactionHeaderAdapter).toSelf().inSingletonScope();
+container
+  .bind<IMemberAdapter>(TYPES.IMemberAdapter)
+  .to(MemberAdapter)
+  .inSingletonScope();
+container
+  .bind<INotificationAdapter>(TYPES.INotificationAdapter)
+  .to(NotificationAdapter)
+  .inSingletonScope();
+container
+  .bind<IAccountAdapter>(TYPES.IAccountAdapter)
+  .to(AccountAdapter)
+  .inSingletonScope();
+container
+  .bind<IFinancialSourceAdapter>(TYPES.IFinancialSourceAdapter)
+  .to(FinancialSourceAdapter)
+  .inSingletonScope();
+container
+  .bind<IChartOfAccountAdapter>(TYPES.IChartOfAccountAdapter)
+  .to(ChartOfAccountAdapter)
+  .inSingletonScope();
+container
+  .bind<IFinancialTransactionHeaderAdapter>(TYPES.IFinancialTransactionHeaderAdapter)
+  .to(FinancialTransactionHeaderAdapter)
+  .inSingletonScope();
 
 // Register services
 container.bind(SupabaseAuditService).toSelf().inSingletonScope();
 
 // Register repositories
-container.bind(MemberRepository).toSelf().inSingletonScope();
-container.bind(NotificationRepository).toSelf().inSingletonScope();
-container.bind(AccountRepository).toSelf().inSingletonScope();
-container.bind(FinancialSourceRepository).toSelf().inSingletonScope();
-container.bind(ChartOfAccountRepository).toSelf().inSingletonScope();
-container.bind(FinancialTransactionHeaderRepository).toSelf().inSingletonScope();
+container
+  .bind<IMemberRepository>(TYPES.IMemberRepository)
+  .to(MemberRepository)
+  .inSingletonScope();
+container
+  .bind<INotificationRepository>(TYPES.INotificationRepository)
+  .to(NotificationRepository)
+  .inSingletonScope();
+container
+  .bind<IAccountRepository>(TYPES.IAccountRepository)
+  .to(AccountRepository)
+  .inSingletonScope();
+container
+  .bind<IFinancialSourceRepository>(TYPES.IFinancialSourceRepository)
+  .to(FinancialSourceRepository)
+  .inSingletonScope();
+container
+  .bind<IChartOfAccountRepository>(TYPES.IChartOfAccountRepository)
+  .to(ChartOfAccountRepository)
+  .inSingletonScope();
+container
+  .bind<IFinancialTransactionHeaderRepository>(
+    TYPES.IFinancialTransactionHeaderRepository
+  )
+  .to(FinancialTransactionHeaderRepository)
+  .inSingletonScope();
 
 export { container };

--- a/src/repositories/account.repository.ts
+++ b/src/repositories/account.repository.ts
@@ -1,13 +1,18 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { Account } from '../models/account.model';
-import { AccountAdapter } from '../adapters/account.adapter';
+import type { IAccountAdapter } from '../adapters/account.adapter';
 import { NotificationService } from '../services/NotificationService';
 import { AccountValidator } from '../validators/account.validator';
 
+export interface IAccountRepository extends BaseRepository<Account> {}
+
 @injectable()
-export class AccountRepository extends BaseRepository<Account> {
-  constructor(@inject(AccountAdapter) adapter: AccountAdapter) {
+export class AccountRepository
+  extends BaseRepository<Account>
+  implements IAccountRepository
+{
+  constructor(@inject('IAccountAdapter') adapter: IAccountAdapter) {
     super(adapter);
   }
 

--- a/src/repositories/chartOfAccount.repository.ts
+++ b/src/repositories/chartOfAccount.repository.ts
@@ -1,13 +1,20 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { ChartOfAccount } from '../models/chartOfAccount.model';
-import { ChartOfAccountAdapter } from '../adapters/chartOfAccount.adapter';
+import type { IChartOfAccountAdapter } from '../adapters/chartOfAccount.adapter';
 import { NotificationService } from '../services/NotificationService';
 import { ChartOfAccountValidator } from '../validators/chartOfAccount.validator';
 
+export interface IChartOfAccountRepository extends BaseRepository<ChartOfAccount> {}
+
 @injectable()
-export class ChartOfAccountRepository extends BaseRepository<ChartOfAccount> {
-  constructor(@inject(ChartOfAccountAdapter) adapter: ChartOfAccountAdapter) {
+export class ChartOfAccountRepository
+  extends BaseRepository<ChartOfAccount>
+  implements IChartOfAccountRepository
+{
+  constructor(
+    @inject('IChartOfAccountAdapter') adapter: IChartOfAccountAdapter
+  ) {
     super(adapter);
   }
 

--- a/src/repositories/financialSource.repository.ts
+++ b/src/repositories/financialSource.repository.ts
@@ -1,13 +1,20 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { FinancialSource } from '../models/financialSource.model';
-import { FinancialSourceAdapter } from '../adapters/financialSource.adapter';
+import type { IFinancialSourceAdapter } from '../adapters/financialSource.adapter';
 import { NotificationService } from '../services/NotificationService';
 import { FinancialSourceValidator } from '../validators/financialSource.validator';
 
+export interface IFinancialSourceRepository extends BaseRepository<FinancialSource> {}
+
 @injectable()
-export class FinancialSourceRepository extends BaseRepository<FinancialSource> {
-  constructor(@inject(FinancialSourceAdapter) adapter: FinancialSourceAdapter) {
+export class FinancialSourceRepository
+  extends BaseRepository<FinancialSource>
+  implements IFinancialSourceRepository
+{
+  constructor(
+    @inject('IFinancialSourceAdapter') adapter: IFinancialSourceAdapter
+  ) {
     super(adapter);
   }
 

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -1,13 +1,22 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
-import { FinancialTransactionHeaderAdapter } from '../adapters/financialTransactionHeader.adapter';
+import type { IFinancialTransactionHeaderAdapter } from '../adapters/financialTransactionHeader.adapter';
 import { NotificationService } from '../services/NotificationService';
 import { FinancialTransactionHeaderValidator } from '../validators/financialTransactionHeader.validator';
 
+export interface IFinancialTransactionHeaderRepository
+  extends BaseRepository<FinancialTransactionHeader> {}
+
 @injectable()
-export class FinancialTransactionHeaderRepository extends BaseRepository<FinancialTransactionHeader> {
-  constructor(@inject(FinancialTransactionHeaderAdapter) adapter: FinancialTransactionHeaderAdapter) {
+export class FinancialTransactionHeaderRepository
+  extends BaseRepository<FinancialTransactionHeader>
+  implements IFinancialTransactionHeaderRepository
+{
+  constructor(
+    @inject('IFinancialTransactionHeaderAdapter')
+    adapter: IFinancialTransactionHeaderAdapter
+  ) {
     super(adapter);
   }
 

--- a/src/repositories/member.repository.ts
+++ b/src/repositories/member.repository.ts
@@ -1,13 +1,18 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { Member } from '../models/member.model';
-import { MemberAdapter } from '../adapters/member.adapter';
+import type { IMemberAdapter } from '../adapters/member.adapter';
 import { NotificationService } from '../services/NotificationService';
 import { MemberValidator } from '../validators/member.validator';
 
+export interface IMemberRepository extends BaseRepository<Member> {}
+
 @injectable()
-export class MemberRepository extends BaseRepository<Member> {
-  constructor(@inject(MemberAdapter) adapter: MemberAdapter) {
+export class MemberRepository
+  extends BaseRepository<Member>
+  implements IMemberRepository
+{
+  constructor(@inject('IMemberAdapter') adapter: IMemberAdapter) {
     super(adapter);
   }
 

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -1,24 +1,29 @@
 import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { Notification } from '../models/notification.model';
-import { NotificationAdapter } from '../adapters/notification.adapter';
+import type { INotificationAdapter } from '../adapters/notification.adapter';
+
+export interface INotificationRepository extends BaseRepository<Notification> {}
 
 @injectable()
-export class NotificationRepository extends BaseRepository<Notification> {
-  constructor(@inject(NotificationAdapter) adapter: NotificationAdapter) {
+export class NotificationRepository
+  extends BaseRepository<Notification>
+  implements INotificationRepository
+{
+  constructor(@inject('INotificationAdapter') adapter: INotificationAdapter) {
     super(adapter);
   }
 
   async markAsRead(id: string): Promise<void> {
-    await (this.adapter as NotificationAdapter).markAsRead(id);
+    await (this.adapter as INotificationAdapter).markAsRead(id);
   }
 
   async markAllAsRead(userId: string): Promise<void> {
-    await (this.adapter as NotificationAdapter).markAllAsRead(userId);
+    await (this.adapter as INotificationAdapter).markAllAsRead(userId);
   }
 
   async deleteExpired(): Promise<void> {
-    await (this.adapter as NotificationAdapter).deleteExpired();
+    await (this.adapter as INotificationAdapter).deleteExpired();
   }
 
   protected override async beforeCreate(data: Partial<Notification>): Promise<Partial<Notification>> {


### PR DESCRIPTION
## Summary
- add `IAccountAdapter` interface and implement it in `AccountAdapter`
- expose `IAccountRepository` and depend on interface in the repository
- bind new interfaces to their concrete classes in the IoC container
- extend DI pattern to all adapters and repositories

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855827034408326934b39bf9e42726f