### PR TITLE
Refactor DI bindings

### DIFF
--- a/src/adapters/account.adapter.ts
+++ b/src/adapters/account.adapter.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { Account } from '../models/account.model';
-import { AuditService, SupabaseAuditService } from '../services/AuditService';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/container';
 import { supabase } from '../lib/supabase';
 
 export interface IAccountAdapter extends BaseAdapter<Account> {}
@@ -12,7 +13,7 @@ export class AccountAdapter
   extends BaseAdapter<Account>
   implements IAccountAdapter
 {
-  constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
     super();
   }
   protected tableName = 'accounts';

--- a/src/adapters/chartOfAccount.adapter.ts
+++ b/src/adapters/chartOfAccount.adapter.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { ChartOfAccount } from '../models/chartOfAccount.model';
-import { AuditService, SupabaseAuditService } from '../services/AuditService';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/container';
 import { supabase } from '../lib/supabase';
 
 export interface IChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {}
@@ -12,7 +13,7 @@ export class ChartOfAccountAdapter
   extends BaseAdapter<ChartOfAccount>
   implements IChartOfAccountAdapter
 {
-  constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
     super();
   }
   protected tableName = 'chart_of_accounts';

--- a/src/adapters/financialSource.adapter.ts
+++ b/src/adapters/financialSource.adapter.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { FinancialSource } from '../models/financialSource.model';
-import { AuditService, SupabaseAuditService } from '../services/AuditService';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/container';
 import { supabase } from '../lib/supabase';
 
 export interface IFinancialSourceAdapter extends BaseAdapter<FinancialSource> {}
@@ -12,7 +13,7 @@ export class FinancialSourceAdapter
   extends BaseAdapter<FinancialSource>
   implements IFinancialSourceAdapter
 {
-  constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
     super();
   }
   protected tableName = 'financial_sources';

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
-import { AuditService, SupabaseAuditService } from '../services/AuditService';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/container';
 import { supabase } from '../lib/supabase';
 
 export interface IFinancialTransactionHeaderAdapter
@@ -13,7 +14,7 @@ export class FinancialTransactionHeaderAdapter
   extends BaseAdapter<FinancialTransactionHeader>
   implements IFinancialTransactionHeaderAdapter
 {
-  constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
     super();
   }
   protected tableName = 'financial_transaction_headers';

--- a/src/adapters/member.adapter.ts
+++ b/src/adapters/member.adapter.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { Member } from '../models/member.model';
-import { AuditService, SupabaseAuditService } from '../services/AuditService';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/container';
 import { supabase } from '../lib/supabase';
 
 export interface IMemberAdapter extends BaseAdapter<Member> {}
@@ -12,7 +13,7 @@ export class MemberAdapter
   extends BaseAdapter<Member>
   implements IMemberAdapter
 {
-  constructor(@inject(SupabaseAuditService) private auditService: AuditService) {
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
     super();
   }
   protected tableName = 'members';

--- a/src/hooks/useAccountRepository.ts
+++ b/src/hooks/useAccountRepository.ts
@@ -1,8 +1,8 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { IAccountRepository } from '../repositories/account.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useAccountRepository() {
-  const repository = container.get<IAccountRepository>('IAccountRepository');
+  const repository = container.get<IAccountRepository>(TYPES.IAccountRepository);
   return useBaseRepository(repository, 'Account', 'accounts');
 }

--- a/src/hooks/useChartOfAccountRepository.ts
+++ b/src/hooks/useChartOfAccountRepository.ts
@@ -1,9 +1,9 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { IChartOfAccountRepository } from '../repositories/chartOfAccount.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useChartOfAccountRepository() {
-  const repository = container.get<IChartOfAccountRepository>('IChartOfAccountRepository');
+  const repository = container.get<IChartOfAccountRepository>(TYPES.IChartOfAccountRepository);
   return {
     ...useBaseRepository(repository, 'Chart of Account', 'chart_of_accounts'),
     getHierarchy: async () => {

--- a/src/hooks/useFinancialSourceRepository.ts
+++ b/src/hooks/useFinancialSourceRepository.ts
@@ -1,8 +1,8 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { IFinancialSourceRepository } from '../repositories/financialSource.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useFinancialSourceRepository() {
-  const repository = container.get<IFinancialSourceRepository>('IFinancialSourceRepository');
+  const repository = container.get<IFinancialSourceRepository>(TYPES.IFinancialSourceRepository);
   return useBaseRepository(repository, 'Financial Source', 'financial_sources');
 }

--- a/src/hooks/useFinancialTransactionHeaderRepository.ts
+++ b/src/hooks/useFinancialTransactionHeaderRepository.ts
@@ -1,9 +1,9 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { IFinancialTransactionHeaderRepository } from '../repositories/financialTransactionHeader.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useFinancialTransactionHeaderRepository() {
-  const repository = container.get<IFinancialTransactionHeaderRepository>('IFinancialTransactionHeaderRepository');
+  const repository = container.get<IFinancialTransactionHeaderRepository>(TYPES.IFinancialTransactionHeaderRepository);
   return {
     ...useBaseRepository(repository, 'Transaction', 'financial_transaction_headers'),
     postTransaction: async (id: string) => {

--- a/src/hooks/useMemberRepository.ts
+++ b/src/hooks/useMemberRepository.ts
@@ -1,8 +1,8 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { IMemberRepository } from '../repositories/member.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useMemberRepository() {
-  const repository = container.get<IMemberRepository>('IMemberRepository');
+  const repository = container.get<IMemberRepository>(TYPES.IMemberRepository);
   return useBaseRepository(repository, 'Member', 'members');
 }

--- a/src/hooks/useNotificationRepository.ts
+++ b/src/hooks/useNotificationRepository.ts
@@ -1,8 +1,8 @@
-import { container } from '../lib/container';
+import { container, TYPES } from '../lib/container';
 import type { INotificationRepository } from '../repositories/notification.repository';
 import { useBaseRepository } from './useBaseRepository';
 
 export function useNotificationRepository() {
-  const repository = container.get<INotificationRepository>('INotificationRepository');
+  const repository = container.get<INotificationRepository>(TYPES.INotificationRepository);
   return useBaseRepository(repository, 'Notification', 'notifications');
 }

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -36,7 +36,7 @@ import {
   FinancialTransactionHeaderRepository,
   type IFinancialTransactionHeaderRepository
 } from '../repositories/financialTransactionHeader.repository';
-import { SupabaseAuditService } from '../services/AuditService';
+import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 
 const container = new Container();
 
@@ -52,7 +52,8 @@ const TYPES = {
   IAccountRepository: 'IAccountRepository',
   IFinancialSourceRepository: 'IFinancialSourceRepository',
   IChartOfAccountRepository: 'IChartOfAccountRepository',
-  IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository'
+  IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository',
+  AuditService: 'AuditService'
 };
 
 // Register adapters
@@ -82,7 +83,10 @@ container
   .inSingletonScope();
 
 // Register services
-container.bind(SupabaseAuditService).toSelf().inSingletonScope();
+container
+  .bind<AuditService>(TYPES.AuditService)
+  .to(SupabaseAuditService)
+  .inSingletonScope();
 
 // Register repositories
 container
@@ -112,4 +116,4 @@ container
   .to(FinancialTransactionHeaderRepository)
   .inSingletonScope();
 
-export { container };
+export { container, TYPES };


### PR DESCRIPTION
## Summary
- export `TYPES` from the DI container
- bind `AuditService` interface in the container
- update adapters to inject the audit service interface
- request repositories via interface tokens in hooks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68558b765ab88326baa5d4a7f6a929af