### PR TITLE
Extract TYPES constant to dedicated module

### DIFF
--- a/src/adapters/account.adapter.ts
+++ b/src/adapters/account.adapter.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { Account } from '../models/account.model';
 import { AuditService } from '../services/AuditService';
-import { TYPES } from '../lib/container';
+import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IAccountAdapter extends BaseAdapter<Account> {}

--- a/src/adapters/chartOfAccount.adapter.ts
+++ b/src/adapters/chartOfAccount.adapter.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { ChartOfAccount } from '../models/chartOfAccount.model';
 import { AuditService } from '../services/AuditService';
-import { TYPES } from '../lib/container';
+import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {}

--- a/src/adapters/financialSource.adapter.ts
+++ b/src/adapters/financialSource.adapter.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { FinancialSource } from '../models/financialSource.model';
 import { AuditService } from '../services/AuditService';
-import { TYPES } from '../lib/container';
+import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IFinancialSourceAdapter extends BaseAdapter<FinancialSource> {}

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
 import { AuditService } from '../services/AuditService';
-import { TYPES } from '../lib/container';
+import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IFinancialTransactionHeaderAdapter

--- a/src/adapters/member.adapter.ts
+++ b/src/adapters/member.adapter.ts
@@ -3,7 +3,7 @@ import { injectable, inject } from 'inversify';
 import { BaseAdapter, QueryOptions } from './base.adapter';
 import { Member } from '../models/member.model';
 import { AuditService } from '../services/AuditService';
-import { TYPES } from '../lib/container';
+import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IMemberAdapter extends BaseAdapter<Member> {}

--- a/src/hooks/useAccountRepository.ts
+++ b/src/hooks/useAccountRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { IAccountRepository } from '../repositories/account.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/hooks/useChartOfAccountRepository.ts
+++ b/src/hooks/useChartOfAccountRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { IChartOfAccountRepository } from '../repositories/chartOfAccount.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/hooks/useFinancialSourceRepository.ts
+++ b/src/hooks/useFinancialSourceRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { IFinancialSourceRepository } from '../repositories/financialSource.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/hooks/useFinancialTransactionHeaderRepository.ts
+++ b/src/hooks/useFinancialTransactionHeaderRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { IFinancialTransactionHeaderRepository } from '../repositories/financialTransactionHeader.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/hooks/useMemberRepository.ts
+++ b/src/hooks/useMemberRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { IMemberRepository } from '../repositories/member.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/hooks/useNotificationRepository.ts
+++ b/src/hooks/useNotificationRepository.ts
@@ -1,4 +1,5 @@
-import { container, TYPES } from '../lib/container';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
 import type { INotificationRepository } from '../repositories/notification.repository';
 import { useBaseRepository } from './useBaseRepository';
 

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -37,24 +37,9 @@ import {
   type IFinancialTransactionHeaderRepository
 } from '../repositories/financialTransactionHeader.repository';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
+import { TYPES } from './types';
 
 const container = new Container();
-
-const TYPES = {
-  IMemberAdapter: 'IMemberAdapter',
-  INotificationAdapter: 'INotificationAdapter',
-  IAccountAdapter: 'IAccountAdapter',
-  IFinancialSourceAdapter: 'IFinancialSourceAdapter',
-  IChartOfAccountAdapter: 'IChartOfAccountAdapter',
-  IFinancialTransactionHeaderAdapter: 'IFinancialTransactionHeaderAdapter',
-  IMemberRepository: 'IMemberRepository',
-  INotificationRepository: 'INotificationRepository',
-  IAccountRepository: 'IAccountRepository',
-  IFinancialSourceRepository: 'IFinancialSourceRepository',
-  IChartOfAccountRepository: 'IChartOfAccountRepository',
-  IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository',
-  AuditService: 'AuditService'
-};
 
 // Register adapters
 container
@@ -116,4 +101,4 @@ container
   .to(FinancialTransactionHeaderRepository)
   .inSingletonScope();
 
-export { container, TYPES };
+export { container };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,15 @@
+export const TYPES = {
+  IMemberAdapter: 'IMemberAdapter',
+  INotificationAdapter: 'INotificationAdapter',
+  IAccountAdapter: 'IAccountAdapter',
+  IFinancialSourceAdapter: 'IFinancialSourceAdapter',
+  IChartOfAccountAdapter: 'IChartOfAccountAdapter',
+  IFinancialTransactionHeaderAdapter: 'IFinancialTransactionHeaderAdapter',
+  IMemberRepository: 'IMemberRepository',
+  INotificationRepository: 'INotificationRepository',
+  IAccountRepository: 'IAccountRepository',
+  IFinancialSourceRepository: 'IFinancialSourceRepository',
+  IChartOfAccountRepository: 'IChartOfAccountRepository',
+  IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository',
+  AuditService: 'AuditService'
+};


### PR DESCRIPTION
## Summary
- extract `TYPES` constant to `src/lib/types.ts`
- update DI container to import `TYPES` from new file
- update all adapters and repository hooks to use new `TYPES` import

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558f880fd48326957a950f0c105a7b