### PR TITLE
Add shared theme switcher and provider wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,23 +11,32 @@
     <script type="module" src="/src/main.tsx"></script>
     <script>
       const defaultThemeMode = 'light'; // light|dark|system
-         let themeMode;
-   
-         if ( document.documentElement ) {
-           if ( localStorage.getItem('theme')) {
-               themeMode = localStorage.getItem('theme');
-           } else if ( document.documentElement.hasAttribute('data-theme-mode')) {
-             themeMode = document.documentElement.getAttribute('data-theme-mode');
-           } else {
-             themeMode = defaultThemeMode;
-           }
-   
-           if (themeMode === 'system') {
-             themeMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-           }
-   
-           document.documentElement.classList.add(themeMode);
-         }
+      let themeMode;
+
+      if (document.documentElement) {
+        const storedSettings = localStorage.getItem('settings-configs');
+        if (storedSettings) {
+          try {
+            themeMode = JSON.parse(storedSettings).themeMode;
+          } catch (e) {
+            console.error('Failed to parse settings-configs', e);
+          }
+        }
+
+        if (!themeMode && document.documentElement.hasAttribute('data-theme-mode')) {
+          themeMode = document.documentElement.getAttribute('data-theme-mode');
+        }
+
+        if (!themeMode) {
+          themeMode = defaultThemeMode;
+        }
+
+        if (themeMode === 'system') {
+          themeMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+
+        document.documentElement.classList.add(themeMode);
+      }
      </script>
   </body>
 </html>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -3,6 +3,8 @@ import { Menu, AlignJustify, Bell, User } from 'lucide-react';
 import { Button } from '../ui2/button';
 import { Avatar, AvatarImage, AvatarFallback } from '../ui2/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '../ui2/dropdown-menu';
+import { Switch } from '../ui2/switch';
+import { useThemeSwitcher } from '@/hooks';
 import { useAuthStore } from '../../stores/authStore';
 import { useNavigate } from 'react-router-dom';
 import ChurchBranding from '../ChurchBranding';
@@ -15,6 +17,7 @@ interface TopbarProps {
 function Topbar({ setSidebarOpen }: TopbarProps) {
   const { user, signOut } = useAuthStore();
   const navigate = useNavigate();
+  const { settings, handleThemeToggle } = useThemeSwitcher();
 
   const handleSignOut = async () => {
     await signOut();
@@ -43,6 +46,12 @@ function Topbar({ setSidebarOpen }: TopbarProps) {
         </div>
         
         <div className="ml-auto flex items-center space-x-4">
+          {/* Theme switch */}
+          <Switch
+            checked={settings.themeMode === 'dark'}
+            onCheckedChange={handleThemeToggle}
+          />
+
           {/* Notification dropdown */}
           <NotificationDropdown />
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,4 @@ export * from './useFeatures';
 export * from './usePagination';
 export * from './usePermissions';
 export * from './useSubscriptionLimits';
+export * from './useThemeSwitcher';

--- a/src/hooks/useThemeSwitcher.ts
+++ b/src/hooks/useThemeSwitcher.ts
@@ -1,0 +1,25 @@
+import { ChangeEvent } from 'react';
+import { useSettings } from '@/providers/SettingsProvider';
+
+const useThemeSwitcher = () => {
+  const { settings, storeSettings } = useSettings();
+
+  const applyTheme = (theme: 'light' | 'dark') => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+  };
+
+  const handleThemeToggle = (
+    e: ChangeEvent<HTMLInputElement> | boolean
+  ) => {
+    const checked = typeof e === 'boolean' ? e : e.target.checked;
+    const newThemeMode = checked ? 'dark' : 'light';
+    storeSettings({ themeMode: newThemeMode });
+    applyTheme(newThemeMode);
+  };
+
+  return { settings, handleThemeToggle };
+};
+
+export { useThemeSwitcher };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { SettingsProvider } from './providers/SettingsProvider';
 import './styles/globals.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </StrictMode>
 );

--- a/src/partials/dropdowns/user/DropdownUser.tsx
+++ b/src/partials/dropdowns/user/DropdownUser.tsx
@@ -1,11 +1,11 @@
-import { ChangeEvent, Fragment } from 'react';
+import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { useAuthContext } from '@/auth';
 import { useLanguage } from '@/i18n';
 import { toAbsoluteUrl } from '@/utils';
 import { DropdownUserLanguages } from './DropdownUserLanguages';
-import { useSettings } from '@/providers/SettingsProvider';
+import { useThemeSwitcher } from '@/hooks';
 import { DefaultTooltip, KeenIcon } from '@/components';
 import {
   MenuItem,
@@ -22,17 +22,9 @@ interface IDropdownUserProps {
 }
 
 const DropdownUser = ({ menuItemRef }: IDropdownUserProps) => {
-  const { settings, storeSettings } = useSettings();
+  const { settings, handleThemeToggle } = useThemeSwitcher();
   const { logout } = useAuthContext();
   const { isRTL } = useLanguage();
-
-  const handleThemeMode = (event: ChangeEvent<HTMLInputElement>) => {
-    const newThemeMode = event.target.checked ? 'dark' : 'light';
-
-    storeSettings({
-      themeMode: newThemeMode
-    });
-  };
 
   const buildHeader = () => {
     return (
@@ -231,7 +223,7 @@ const DropdownUser = ({ menuItemRef }: IDropdownUserProps) => {
                 name="theme"
                 type="checkbox"
                 checked={settings.themeMode === 'dark'}
-                onChange={handleThemeMode}
+                onChange={handleThemeToggle}
                 value="1"
               />
             </label>


### PR DESCRIPTION
## Summary
- use unified `settings-configs` entry in `index.html`
- create `useThemeSwitcher` hook for consistent theme toggling
- update user dropdown to use the new hook
- add theme switch to the topbar
- wrap the app with `SettingsProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559456f3d883268a8d90811524c08d