### PR TITLE
Fix Sidebar submenu active state for nested paths

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -308,7 +308,7 @@ function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps) {
                             className={`
                               group flex items-center rounded-lg pl-11 pr-3 py-2 text-sm font-medium
                               transition-colors duration-200
-                              ${location.pathname === subitem.href
+                              ${location.pathname.startsWith(subitem.href)
                                 ? 'bg-primary text-white'
                                 : searchTerm && subitem.name.toLowerCase().includes(searchTerm.toLowerCase())
                                 ? 'bg-primary/20 text-white'
@@ -318,7 +318,7 @@ function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps) {
                           >
                             <subitem.icon className={`
                               mr-3 h-4 w-4 flex-shrink-0 transition-colors
-                              ${location.pathname === subitem.href
+                              ${location.pathname.startsWith(subitem.href)
                                 ? 'text-white'
                                 : 'text-gray-400 group-hover:text-white'
                               }


### PR DESCRIPTION
## Summary
- keep submenu items active on nested routes by checking `pathname.startsWith`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855aa0a45a88326bdb6829770f34b34