### PR TITLE
Implement DM Sans heading font

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,4 +10,14 @@
 @import 'shadcn.ui';
 
 @import '@fontsource/urbanist';
-@import '@fontsource/inter';
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap');
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,8 +190,8 @@ module.exports = {
         }
       },
       fontFamily: {
-        sans: ['Urbanist', ...defaultTheme.fontFamily.sans],
-        secondary: ['Inter', ...defaultTheme.fontFamily.sans],
+        sans: ['DM Sans', ...defaultTheme.fontFamily.sans],
+        heading: ['Urbanist', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         //begin: Shadcn UI Colors


### PR DESCRIPTION
## Summary
- import DM Sans and set as default font via Tailwind base layer
- keep Urbanist for headings with new `font-heading` utility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855ae51c960832680530329ca3abf97