### PR TITLE
Add realtime notification listener

### DIFF
--- a/src/components/layout/NotificationDropdown.tsx
+++ b/src/components/layout/NotificationDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { formatDistanceToNow } from 'date-fns';
@@ -20,6 +20,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui2/tabs';
 import { Button } from '../ui2/button';
 import { Badge } from '../ui2/badge';
 import { useNavigate } from 'react-router-dom';
+import { useNotificationListener } from '../../hooks/useNotificationListener';
 
 type Notification = {
   id: string;
@@ -36,6 +37,7 @@ export default function NotificationDropdown() {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  useNotificationListener();
 
   // Fetch notifications
   const { data: notifications = [], isLoading } = useQuery({
@@ -45,11 +47,10 @@ export default function NotificationDropdown() {
         .from('notifications')
         .select('*')
         .order('created_at', { ascending: false });
-      
+
       if (error) throw error;
       return data as Notification[];
     },
-    enabled: open, // Only fetch when dropdown is open
   });
 
   // Count unread notifications

--- a/src/hooks/useNotificationListener.ts
+++ b/src/hooks/useNotificationListener.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../lib/supabase';
+import { useAuthStore } from '../stores/authStore';
+
+export function useNotificationListener() {
+  const { user } = useAuthStore();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!user) return;
+
+    const channel = supabase
+      .channel('notification-listener')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
+        () => {
+          queryClient.invalidateQueries({ queryKey: ['notifications'] });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [user, queryClient]);
+}


### PR DESCRIPTION
## Summary
- update NotificationDropdown to listen for realtime updates
- fetch notifications continuously and trigger updates on new entries
- provide `useNotificationListener` hook for managing the subscription

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855b237d9148326ae90d25858719c02