### PR TITLE
Fix notifications auto update fallback

### DIFF
--- a/src/components/layout/NotificationDropdown.tsx
+++ b/src/components/layout/NotificationDropdown.tsx
@@ -51,6 +51,9 @@ export default function NotificationDropdown() {
       if (error) throw error;
       return data as Notification[];
     },
+    // Poll as a fallback in case realtime events fail
+    refetchInterval: 5000,
+    refetchIntervalInBackground: true,
   });
 
   // Count unread notifications


### PR DESCRIPTION
## Summary
- poll notification endpoint every 5 seconds so the bell indicator updates even when realtime events fail

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855b6ea171c83268d64c963f4e4f97f