### PR TITLE
Fix mui datagrid pagination

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { 
-  DataGrid as MuiDataGrid, 
+import {
+  DataGrid as MuiDataGrid,
   DataGridProps as MuiDataGridProps,
-  GridColDef,
   GridFilterModel,
   GridPaginationModel,
   GridSortModel,
@@ -20,6 +19,9 @@ export interface DataGridProps extends Omit<MuiDataGridProps, 'rows'> {
   onPageSizeChange?: (pageSize: number) => void;
   onSortChange?: (model: GridSortModel) => void;
   onFilterChange?: (model: GridFilterModel) => void;
+  page?: number;
+  pageSize?: number;
+  pageSizeOptions?: number[];
   loading?: boolean;
   error?: string;
 }
@@ -150,6 +152,9 @@ export function DataGrid({
   onPageSizeChange,
   onSortChange,
   onFilterChange,
+  page = 0,
+  pageSize = 10,
+  pageSizeOptions = [5, 10, 25, 50, 100],
   loading = false,
   error,
   columns,
@@ -183,7 +188,7 @@ export function DataGrid({
         columns={columns}
         rowCount={totalRows}
         loading={loading}
-        pageSizeOptions={[5, 10, 25, 50, 100]}
+        pageSizeOptions={pageSizeOptions}
         paginationMode="server"
         sortingMode="server"
         filterMode="server"
@@ -202,13 +207,7 @@ export function DataGrid({
         onPaginationModelChange={handlePaginationModelChange}
         onSortModelChange={onSortChange}
         onFilterModelChange={onFilterChange}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 10,
-            },
-          },
-        }}
+        paginationModel={{ page, pageSize }}
         getRowClassName={() => 'cursor-pointer hover:bg-muted/50'}
         {...props}
       />

--- a/src/pages/accounts/AccountList.tsx
+++ b/src/pages/accounts/AccountList.tsx
@@ -244,14 +244,8 @@ function AccountList() {
                 disableColumnFilter={false}
                 disableColumnSelector={false}
                 disableDensitySelector={false}
-                initialState={{
-                  pagination: {
-                    paginationModel: {
-                      pageSize: pageSize,
-                      page: page,
-                    },
-                  },
-                }}
+                page={page}
+                pageSize={pageSize}
                 slots={{
                   toolbar: () => (
                     <div className="flex justify-between items-center p-4">

--- a/src/pages/accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/ChartOfAccountProfile.tsx
@@ -539,10 +539,9 @@ function ChartOfAccountProfile() {
               enabled: true,
               fileName: `account_${account.code}_transactions`,
             }}
-            pagination={{
-              pageSize: 10,
-              pageSizeOptions: [5, 10, 25, 50, 100],
-            }}
+            pageSize={10}
+            page={0}
+            pageSizeOptions={[5, 10, 25, 50, 100]}
           />
         </CardContent>
       </Card>

--- a/src/pages/accounts/FinancialSourceList.tsx
+++ b/src/pages/accounts/FinancialSourceList.tsx
@@ -226,14 +226,8 @@ function FinancialSourceList() {
                 disableColumnFilter={false}
                 disableColumnSelector={false}
                 disableDensitySelector={false}
-                initialState={{
-                  pagination: {
-                    paginationModel: {
-                      pageSize: pageSize,
-                      page: page,
-                    },
-                  },
-                }}
+                page={page}
+                pageSize={pageSize}
                 slots={{
                   toolbar: () => (
                     <div className="flex justify-between items-center p-4">

--- a/src/pages/finances/TransactionList.tsx
+++ b/src/pages/finances/TransactionList.tsx
@@ -389,33 +389,27 @@ function TransactionList() {
           </CardHeader>
           
           <CardContent className="p-0">
-            <DataGrid
-              columns={columns}
-              data={filteredTransactions}
-              totalRows={filteredTransactions.length}
-              loading={isLoading}
-              onPageChange={setPage}
-              onPageSizeChange={setPageSize}
-              getRowId={(row) => row.id}
-              onRowClick={(params) => navigate(`/finances/transactions/${params.id}`)}
-              autoHeight
-              disableColumnMenu={false}
-              disableColumnFilter={false}
-              disableColumnSelector={false}
-              disableDensitySelector={false}
-              initialState={{
-                pagination: {
-                  paginationModel: {
-                    pageSize: pageSize,
-                    page: page,
-                  },
-                },
-              }}
-              toolbar={{
-                showQuickFilter: true,
-                quickFilterProps: { debounceMs: 500 },
-              }}
-            />
+          <DataGrid
+            columns={columns}
+            data={filteredTransactions}
+            totalRows={filteredTransactions.length}
+            loading={isLoading}
+            onPageChange={setPage}
+            onPageSizeChange={setPageSize}
+            getRowId={(row) => row.id}
+            onRowClick={(params) => navigate(`/finances/transactions/${params.id}`)}
+            autoHeight
+            disableColumnMenu={false}
+            disableColumnFilter={false}
+            disableColumnSelector={false}
+            disableDensitySelector={false}
+            page={page}
+            pageSize={pageSize}
+            toolbar={{
+              showQuickFilter: true,
+              quickFilterProps: { debounceMs: 500 },
+            }}
+          />
           </CardContent>
         </Card>
       </div>

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -231,6 +231,8 @@ function MemberList() {
             onSortChange={setSortModel}
             onFilterChange={setFilterModel}
             onRowClick={(params) => navigate(`/members/${params.row.id}`)}
+            page={page}
+            pageSize={pageSize}
             disableRowSelectionOnClick
           />
         </div>


### PR DESCRIPTION
## Summary
- use controlled pagination API in `mui-datagrid`
- hook page and pageSize props to grid users
- simplify ChartOfAccountProfile datagrid usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855ba2ccb348326839456382839a5fb