### PR TITLE
Fix MemberAddEdit tabs

### DIFF
--- a/src/pages/members/MemberAddEdit.tsx
+++ b/src/pages/members/MemberAddEdit.tsx
@@ -134,25 +134,25 @@ function MemberAddEdit() {
       id: 'basic',
       label: 'Basic Info',
       badge: formErrors.basic?.length,
-      content: <BasicInfoTab formData={formData} onChange={handleInputChange} />,
+      content: <BasicInfoTab member={formData} />,
     },
     {
       id: 'contact',
       label: 'Contact Info',
       badge: formErrors.contact?.length,
-      content: <ContactInfoTab formData={formData} onChange={handleInputChange} />,
+      content: <ContactInfoTab member={formData} />,
     },
     {
       id: 'ministry',
       label: 'Ministry Info',
       badge: formErrors.ministry?.length,
-      content: <MinistryInfoTab formData={formData} onChange={handleInputChange} />,
+      content: <MinistryInfoTab member={formData} />,
     },
     {
       id: 'notes',
       label: 'Notes',
       badge: formErrors.notes?.length,
-      content: <NotesTab formData={formData} onChange={handleInputChange} />,
+      content: <NotesTab member={formData} />,
     },
   ];
 


### PR DESCRIPTION
## Summary
- pass member prop instead of formData
- clean up unused onChange props

## Testing
- `tsc --noEmit`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855c101ed6c8326bb2dcff7977ccab3