### PR TITLE
Add null guards for member tabs

### DIFF
--- a/src/pages/members/tabs/BasicInfoTab.tsx
+++ b/src/pages/members/tabs/BasicInfoTab.tsx
@@ -6,6 +6,7 @@ interface BasicInfoTabProps {
 }
 
 function BasicInfoTab({ member }: BasicInfoTabProps) {
+  if (!member) return null;
   return (
     <Card>
       <CardContent className="p-6">

--- a/src/pages/members/tabs/ContactInfoTab.tsx
+++ b/src/pages/members/tabs/ContactInfoTab.tsx
@@ -7,6 +7,7 @@ interface ContactInfoTabProps {
 }
 
 function ContactInfoTab({ member }: ContactInfoTabProps) {
+  if (!member) return null;
   return (
     <Card>
       <CardContent className="p-6">

--- a/src/pages/members/tabs/MinistryInfoTab.tsx
+++ b/src/pages/members/tabs/MinistryInfoTab.tsx
@@ -7,6 +7,7 @@ interface MinistryInfoTabProps {
 }
 
 function MinistryInfoTab({ member }: MinistryInfoTabProps) {
+  if (!member) return null;
   return (
     <Card>
       <CardContent className="p-6">

--- a/src/pages/members/tabs/NotesTab.tsx
+++ b/src/pages/members/tabs/NotesTab.tsx
@@ -11,10 +11,12 @@ interface NotesTabProps {
 }
 
 function NotesTab({ member }: NotesTabProps) {
-  const [notes, setNotes] = useState(member.pastoral_notes || '');
-  const [prayerRequests, setPrayerRequests] = useState<string[]>(member.prayer_requests || []);
+  const [notes, setNotes] = useState(member?.pastoral_notes || '');
+  const [prayerRequests, setPrayerRequests] = useState<string[]>(member?.prayer_requests || []);
   const [newPrayerRequest, setNewPrayerRequest] = useState('');
   const queryClient = useQueryClient();
+
+  if (!member) return null;
 
   // Update notes mutation
   const updateNotesMutation = useMutation({


### PR DESCRIPTION
## Summary
- prevent crashes when `member` prop is missing in tab components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855c21791c08326960dbf782e35c260