### PR TITLE
Fix member tabs export style

### DIFF
--- a/src/pages/members/MemberAddEdit.tsx
+++ b/src/pages/members/MemberAddEdit.tsx
@@ -21,10 +21,10 @@ import {
 import { Save, ArrowLeft, Loader2 } from 'lucide-react';
 
 // Import tabs
-import { BasicInfoTab } from './tabs/BasicInfoTab';
-import { ContactInfoTab } from './tabs/ContactInfoTab';
-import { MinistryInfoTab } from './tabs/MinistryInfoTab';
-import { NotesTab } from './tabs/NotesTab';
+import BasicInfoTab from './tabs/BasicInfoTab';
+import ContactInfoTab from './tabs/ContactInfoTab';
+import MinistryInfoTab from './tabs/MinistryInfoTab';
+import NotesTab from './tabs/NotesTab';
 
 function MemberAddEdit() {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/members/tabs/BasicInfoTab.tsx
+++ b/src/pages/members/tabs/BasicInfoTab.tsx
@@ -89,5 +89,3 @@ function BasicInfoTab({ member }: BasicInfoTabProps) {
 }
 
 export default BasicInfoTab;
-
-export { BasicInfoTab }

--- a/src/pages/members/tabs/ContactInfoTab.tsx
+++ b/src/pages/members/tabs/ContactInfoTab.tsx
@@ -94,5 +94,3 @@ function ContactInfoTab({ member }: ContactInfoTabProps) {
 }
 
 export default ContactInfoTab;
-
-export { ContactInfoTab }

--- a/src/pages/members/tabs/MinistryInfoTab.tsx
+++ b/src/pages/members/tabs/MinistryInfoTab.tsx
@@ -131,5 +131,3 @@ function MinistryInfoTab({ member }: MinistryInfoTabProps) {
 }
 
 export default MinistryInfoTab;
-
-export { MinistryInfoTab }

--- a/src/pages/members/tabs/NotesTab.tsx
+++ b/src/pages/members/tabs/NotesTab.tsx
@@ -154,5 +154,3 @@ function NotesTab({ member }: NotesTabProps) {
 }
 
 export default NotesTab;
-
-export { NotesTab }


### PR DESCRIPTION
## Summary
- unify exports in member tabs to use default export
- update MemberAddEdit imports
- add trailing newline to each tab file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855c30949c88326ad51cc73360a6a70