### PR TITLE
Add form editing modes for member tabs

### DIFF
--- a/src/pages/members/MemberAddEdit.tsx
+++ b/src/pages/members/MemberAddEdit.tsx
@@ -129,30 +129,56 @@ function MemberAddEdit() {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
+  const mode = id ? 'edit' : 'add';
+
   const tabs = [
     {
       id: 'basic',
       label: 'Basic Info',
       badge: formErrors.basic?.length,
-      content: <BasicInfoTab member={formData} />,
+      content: (
+        <BasicInfoTab
+          mode={mode}
+          member={formData}
+          onChange={handleInputChange}
+        />
+      ),
     },
     {
       id: 'contact',
       label: 'Contact Info',
       badge: formErrors.contact?.length,
-      content: <ContactInfoTab member={formData} />,
+      content: (
+        <ContactInfoTab
+          mode={mode}
+          member={formData}
+          onChange={handleInputChange}
+        />
+      ),
     },
     {
       id: 'ministry',
       label: 'Ministry Info',
       badge: formErrors.ministry?.length,
-      content: <MinistryInfoTab member={formData} />,
+      content: (
+        <MinistryInfoTab
+          mode={mode}
+          member={formData}
+          onChange={handleInputChange}
+        />
+      ),
     },
     {
       id: 'notes',
       label: 'Notes',
       badge: formErrors.notes?.length,
-      content: <NotesTab member={formData} />,
+      content: (
+        <NotesTab
+          mode={mode}
+          member={formData}
+          onChange={handleInputChange}
+        />
+      ),
     },
   ];
 
@@ -322,3 +348,4 @@ function MemberAddEdit() {
 }
 
 export default MemberAddEdit;
+

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -271,19 +271,19 @@ function MemberProfile() {
             </TabsList>
             
             <TabsContent value="basic">
-              <BasicInfoTab member={member} />
+              <BasicInfoTab mode="view" member={member} onChange={() => {}} />
             </TabsContent>
-            
+
             <TabsContent value="contact">
-              <ContactInfoTab member={member} />
+              <ContactInfoTab mode="view" member={member} onChange={() => {}} />
             </TabsContent>
-            
+
             <TabsContent value="ministry">
-              <MinistryInfoTab member={member} />
+              <MinistryInfoTab mode="view" member={member} onChange={() => {}} />
             </TabsContent>
-            
+
             <TabsContent value="notes">
-              <NotesTab member={member} />
+              <NotesTab mode="view" member={member} onChange={() => {}} />
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/pages/members/tabs/BasicInfoTab.tsx
+++ b/src/pages/members/tabs/BasicInfoTab.tsx
@@ -1,19 +1,31 @@
 import React from 'react';
 import { Card, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '../../../components/ui2/select';
+import { Member } from '../../../models/member.model';
 
 interface BasicInfoTabProps {
-  member: any;
+  member: Partial<Member>;
+  onChange: (field: string, value: any) => void;
+  mode?: 'view' | 'edit' | 'add';
 }
 
-function BasicInfoTab({ member }: BasicInfoTabProps) {
+function BasicInfoTab({ member, onChange, mode = 'view' }: BasicInfoTabProps) {
   if (!member) return null;
-  return (
-    <Card>
-      <CardContent className="p-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <h3 className="text-lg font-medium mb-4">Personal Information</h3>
-            <dl className="space-y-4">
+  if (mode === 'view') {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-lg font-medium mb-4">Personal Information</h3>
+              <dl className="space-y-4">
               <div>
                 <dt className="text-sm font-medium text-muted-foreground">Full Name</dt>
                 <dd className="mt-1">
@@ -85,7 +97,102 @@ function BasicInfoTab({ member }: BasicInfoTabProps) {
         </div>
       </CardContent>
     </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            <Input
+              label="First Name"
+              value={member.first_name || ''}
+              onChange={e => onChange('first_name', e.target.value)}
+            />
+            <Input
+              label="Middle Name"
+              value={member.middle_name || ''}
+              onChange={e => onChange('middle_name', e.target.value)}
+            />
+            <Input
+              label="Last Name"
+              value={member.last_name || ''}
+              onChange={e => onChange('last_name', e.target.value)}
+            />
+            <Input
+              label="Preferred Name"
+              value={member.preferred_name || ''}
+              onChange={e => onChange('preferred_name', e.target.value)}
+            />
+            <Select
+              value={member.gender || ''}
+              onValueChange={value => onChange('gender', value)}
+            >
+              <SelectTrigger label="Gender">
+                <SelectValue placeholder="Select gender" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="male">Male</SelectItem>
+                <SelectItem value="female">Female</SelectItem>
+                <SelectItem value="other">Other</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={member.marital_status || ''}
+              onValueChange={value => onChange('marital_status', value)}
+            >
+              <SelectTrigger label="Marital Status">
+                <SelectValue placeholder="Select status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="single">Single</SelectItem>
+                <SelectItem value="married">Married</SelectItem>
+                <SelectItem value="widowed">Widowed</SelectItem>
+                <SelectItem value="divorced">Divorced</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              type="date"
+              label="Birthday"
+              value={member.birthday || ''}
+              onChange={e => onChange('birthday', e.target.value)}
+            />
+          </div>
+          <div className="space-y-4">
+            <Input
+              label="Membership Category"
+              value={member.membership_category_id || ''}
+              onChange={e => onChange('membership_category_id', e.target.value)}
+            />
+            <Input
+              label="Status Category"
+              value={member.status_category_id || ''}
+              onChange={e => onChange('status_category_id', e.target.value)}
+            />
+            <Input
+              type="date"
+              label="Membership Date"
+              value={member.membership_date || ''}
+              onChange={e => onChange('membership_date', e.target.value)}
+            />
+            <Input
+              type="date"
+              label="Baptism Date"
+              value={member.baptism_date || ''}
+              onChange={e => onChange('baptism_date', e.target.value)}
+            />
+            <Input
+              label="Envelope Number"
+              value={member.envelope_number || ''}
+              onChange={e => onChange('envelope_number', e.target.value)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
 export default BasicInfoTab;
+

--- a/src/pages/members/tabs/ContactInfoTab.tsx
+++ b/src/pages/members/tabs/ContactInfoTab.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Mail, Phone, MapPin, User } from 'lucide-react';
+import { Input } from '../../../components/ui2/input';
+import { Textarea } from '../../../components/ui2/textarea';
+import { Member } from '../../../models/member.model';
 
 interface ContactInfoTabProps {
-  member: any;
+  member: Partial<Member>;
+  onChange: (field: string, value: any) => void;
+  mode?: 'view' | 'edit' | 'add';
 }
 
-function ContactInfoTab({ member }: ContactInfoTabProps) {
+function ContactInfoTab({ member, onChange, mode = 'view' }: ContactInfoTabProps) {
   if (!member) return null;
-  return (
-    <Card>
-      <CardContent className="p-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <h3 className="text-lg font-medium mb-4">Contact Information</h3>
-            <dl className="space-y-4">
+  if (mode === 'view') {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-lg font-medium mb-4">Contact Information</h3>
+              <dl className="space-y-4">
               {member.email && (
                 <div className="flex items-start">
                   <Mail className="h-5 w-5 text-muted-foreground mt-0.5 mr-2" />
@@ -90,7 +96,48 @@ function ContactInfoTab({ member }: ContactInfoTabProps) {
         </div>
       </CardContent>
     </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            <Input
+              label="Email"
+              value={member.email || ''}
+              onChange={e => onChange('email', e.target.value)}
+            />
+            <Input
+              label="Phone"
+              value={member.contact_number || ''}
+              onChange={e => onChange('contact_number', e.target.value)}
+            />
+            <Textarea
+              value={member.address || ''}
+              onChange={e => onChange('address', e.target.value)}
+              placeholder="Address"
+              className="min-h-[80px]"
+            />
+          </div>
+          <div className="space-y-4">
+            <Input
+              label="Emergency Contact Name"
+              value={member.emergency_contact_name || ''}
+              onChange={e => onChange('emergency_contact_name', e.target.value)}
+            />
+            <Input
+              label="Emergency Contact Phone"
+              value={member.emergency_contact_phone || ''}
+              onChange={e => onChange('emergency_contact_phone', e.target.value)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
 export default ContactInfoTab;
+

--- a/src/pages/members/tabs/MinistryInfoTab.tsx
+++ b/src/pages/members/tabs/MinistryInfoTab.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Badge } from '../../../components/ui2/badge';
+import { Input } from '../../../components/ui2/input';
+import { Member } from '../../../models/member.model';
 
 interface MinistryInfoTabProps {
-  member: any;
+  member: Partial<Member>;
+  onChange: (field: string, value: any) => void;
+  mode?: 'view' | 'edit' | 'add';
 }
 
-function MinistryInfoTab({ member }: MinistryInfoTabProps) {
+function MinistryInfoTab({ member, onChange, mode = 'view' }: MinistryInfoTabProps) {
   if (!member) return null;
-  return (
-    <Card>
-      <CardContent className="p-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <h3 className="text-lg font-medium mb-4">Ministry Involvement</h3>
+  if (mode === 'view') {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-lg font-medium mb-4">Ministry Involvement</h3>
             
             <div className="space-y-4">
               {member.leadership_position && (
@@ -127,7 +132,73 @@ function MinistryInfoTab({ member }: MinistryInfoTabProps) {
         </div>
       </CardContent>
     </Card>
+    );
+  }
+
+  const listToString = (arr?: string[]) => (arr ? arr.join(', ') : '');
+  const handleListChange = (field: string, value: string) => {
+    const parsed = value
+      .split(',')
+      .map(v => v.trim())
+      .filter(Boolean);
+    onChange(field, parsed);
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            <Input
+              label="Leadership Position"
+              value={member.leadership_position || ''}
+              onChange={e => onChange('leadership_position', e.target.value)}
+            />
+            <Input
+              label="Ministries (comma separated)"
+              value={listToString(member.ministries)}
+              onChange={e => handleListChange('ministries', e.target.value)}
+            />
+            <Input
+              label="Small Groups (comma separated)"
+              value={listToString(member.small_groups)}
+              onChange={e => handleListChange('small_groups', e.target.value)}
+            />
+            <Input
+              label="Volunteer Roles (comma separated)"
+              value={listToString(member.volunteer_roles)}
+              onChange={e => handleListChange('volunteer_roles', e.target.value)}
+            />
+          </div>
+          <div className="space-y-4">
+            <Input
+              label="Spiritual Gifts (comma separated)"
+              value={listToString(member.spiritual_gifts)}
+              onChange={e => handleListChange('spiritual_gifts', e.target.value)}
+            />
+            <Input
+              label="Ministry Interests (comma separated)"
+              value={listToString(member.ministry_interests)}
+              onChange={e => handleListChange('ministry_interests', e.target.value)}
+            />
+            <Input
+              type="number"
+              label="Attendance Rate"
+              value={member.attendance_rate ?? ''}
+              onChange={e => onChange('attendance_rate', Number(e.target.value))}
+            />
+            <Input
+              type="date"
+              label="Last Attendance"
+              value={member.last_attendance_date || ''}
+              onChange={e => onChange('last_attendance_date', e.target.value)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
 export default MinistryInfoTab;
+

--- a/src/pages/members/tabs/NotesTab.tsx
+++ b/src/pages/members/tabs/NotesTab.tsx
@@ -5,12 +5,15 @@ import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { Textarea } from '../../../components/ui2/textarea';
 import { Loader2, Save } from 'lucide-react';
+import { Member } from '../../../models/member.model';
 
 interface NotesTabProps {
-  member: any;
+  member: Partial<Member>;
+  onChange: (field: string, value: any) => void;
+  mode?: 'view' | 'edit' | 'add';
 }
 
-function NotesTab({ member }: NotesTabProps) {
+function NotesTab({ member, onChange, mode = 'view' }: NotesTabProps) {
   const [notes, setNotes] = useState(member?.pastoral_notes || '');
   const [prayerRequests, setPrayerRequests] = useState<string[]>(member?.prayer_requests || []);
   const [newPrayerRequest, setNewPrayerRequest] = useState('');
@@ -71,6 +74,37 @@ function NotesTab({ member }: NotesTabProps) {
     setPrayerRequests(updatedRequests);
     updatePrayerRequestsMutation.mutate();
   };
+
+  if (mode !== 'view') {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="p-6 space-y-4">
+            <Textarea
+              value={member.pastoral_notes || ''}
+              onChange={e => onChange('pastoral_notes', e.target.value)}
+              placeholder="Enter pastoral notes here..."
+              className="min-h-[150px]"
+            />
+            <Textarea
+              value={(member.prayer_requests || []).join('\n')}
+              onChange={e =>
+                onChange(
+                  'prayer_requests',
+                  e.target.value
+                    .split('\n')
+                    .map(v => v.trim())
+                    .filter(Boolean)
+                )
+              }
+              placeholder="Prayer requests (one per line)"
+              className="min-h-[150px]"
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -154,3 +188,4 @@ function NotesTab({ member }: NotesTabProps) {
 }
 
 export default NotesTab;
+


### PR DESCRIPTION
## Summary
- allow member tabs to work in `view`, `edit` and `add` modes
- show input fields in edit/add mode for Basic, Contact, Ministry, and Notes tabs
- wire tabs in `MemberAddEdit` to use edit/add modes
- use view mode for tabs in `MemberProfile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855cc38d27083268b83aad352f4e0b0