### PR TITLE
Implement member account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # churchsolution
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/faithfulcoronel/churchsolution)
+
+## Features
+
+### Members
+
+- When a member is created an account is automatically generated.
+- Member accounts use the format `MEM-<first 8 characters of member id>` for the account number.

--- a/tests/memberAccount.test.ts
+++ b/tests/memberAccount.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { MemberRepository } from '../src/repositories/member.repository';
+import type { IMemberAdapter } from '../src/adapters/member.adapter';
+import type { IAccountRepository } from '../src/repositories/account.repository';
+import type { Member } from '../src/models/member.model';
+
+class FakeAccountRepository {
+  public created: any = null;
+  async create(data: any) {
+    this.created = data;
+    return data;
+  }
+}
+
+class TestMemberRepository extends MemberRepository {
+  public async runAfterCreate(member: Member) {
+    // access protected method
+    await this.afterCreate(member);
+  }
+}
+
+describe('member account creation', () => {
+  it('creates account with generated account number', async () => {
+    const accountRepo = new FakeAccountRepository();
+    const repo = new TestMemberRepository({} as IMemberAdapter, accountRepo as unknown as IAccountRepository);
+
+    const member = {
+      id: 'abcdef1234567890',
+      first_name: 'John',
+      last_name: 'Doe'
+    } as Member;
+
+    await repo.runAfterCreate(member);
+
+    const accountNumber = `MEM-${member.id.slice(0, 8)}`;
+    expect((accountRepo as any).created!.account_number).toBe(accountNumber);
+  });
+});


### PR DESCRIPTION
## Summary
- automatically create member accounts
- verify account numbers in unit test
- document account number format

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855debd49d48326abf4f35a0a5964e4