### PR TITLE
Add Vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,13 @@
 
 - When a member is created an account is automatically generated.
 - Member accounts use the format `MEM-<first 8 characters of member id>` for the account number.
+
+## Running tests
+
+This project uses [Vitest](https://vitest.dev) for unit testing. After installing
+dependencies with `npm install`, execute:
+
+```bash
+npm run test
+```
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -83,6 +84,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Vitest as the test runner
- document how to run the tests

## Testing
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e009044083269469a02763b57b69