### PR TITLE
Update finance screens to full width

### DIFF
--- a/src/pages/finances/AccountDetail.tsx
+++ b/src/pages/finances/AccountDetail.tsx
@@ -95,7 +95,7 @@ function AccountDetail() {
   
   if (!account) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="w-full px-4 sm:px-6 lg:px-8">
         <div className="text-center py-12">
           <h3 className="text-lg font-medium">Account not found</h3>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -113,7 +113,7 @@ function AccountDetail() {
   }
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BudgetAdd.tsx
+++ b/src/pages/finances/BudgetAdd.tsx
@@ -122,7 +122,7 @@ function BudgetAdd() {
   );
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BudgetEdit.tsx
+++ b/src/pages/finances/BudgetEdit.tsx
@@ -166,7 +166,7 @@ function BudgetEdit() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BudgetList.tsx
+++ b/src/pages/finances/BudgetList.tsx
@@ -183,7 +183,7 @@ function BudgetList() {
   });
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BudgetProfile.tsx
+++ b/src/pages/finances/BudgetProfile.tsx
@@ -159,7 +159,7 @@ function BudgetProfile() {
   const isUpcoming = startDate > today;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BulkExpenseEntry.tsx
+++ b/src/pages/finances/BulkExpenseEntry.tsx
@@ -477,7 +477,7 @@ function BulkExpenseEntry() {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BulkIncomeEntry.tsx
+++ b/src/pages/finances/BulkIncomeEntry.tsx
@@ -494,7 +494,7 @@ function BulkIncomeEntry() {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/BulkTransactionEntry.tsx
+++ b/src/pages/finances/BulkTransactionEntry.tsx
@@ -217,7 +217,7 @@ function BulkTransactionEntry() {
   };
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/JournalEntryForm.tsx
+++ b/src/pages/finances/JournalEntryForm.tsx
@@ -156,7 +156,7 @@ function JournalEntryForm() {
   };
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/Reports.tsx
+++ b/src/pages/finances/Reports.tsx
@@ -71,7 +71,7 @@ function Reports() {
   };
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="sm:flex sm:items-center">
         <div className="sm:flex-auto">
           <h1 className="text-2xl font-semibold text-foreground">Financial Reports</h1>

--- a/src/pages/finances/TransactionAdd.tsx
+++ b/src/pages/finances/TransactionAdd.tsx
@@ -304,7 +304,7 @@ function TransactionAdd() {
   }
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/TransactionDetail.tsx
+++ b/src/pages/finances/TransactionDetail.tsx
@@ -208,7 +208,7 @@ function TransactionDetail() {
   
   if (!header) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="w-full px-4 sm:px-6 lg:px-8">
         <div className="text-center py-12">
           <h3 className="text-lg font-medium">Transaction not found</h3>
           <p className="mt-2 text-sm text-muted-foreground">
@@ -226,7 +226,7 @@ function TransactionDetail() {
   }
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
         <Button
           variant="ghost"

--- a/src/pages/finances/TransactionList.tsx
+++ b/src/pages/finances/TransactionList.tsx
@@ -305,7 +305,7 @@ function TransactionList() {
   ];
   
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="sm:flex sm:items-center">
         <div className="sm:flex-auto">
           <h1 className="text-2xl font-semibold text-foreground">Transactions</h1>


### PR DESCRIPTION
## Summary
- remove width restrictions from all finance page containers

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e7519450832682b79ea169c5ad9a