### PR TITLE
Refactor financial module for SOLID

### DIFF
--- a/src/adapters/chartOfAccount.adapter.ts
+++ b/src/adapters/chartOfAccount.adapter.ts
@@ -6,7 +6,9 @@ import { AuditService } from '../services/AuditService';
 import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
-export interface IChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {}
+export interface IChartOfAccountAdapter extends BaseAdapter<ChartOfAccount> {
+  getHierarchy(): Promise<ChartOfAccount[]>;
+}
 
 @injectable()
 export class ChartOfAccountAdapter

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -7,7 +7,12 @@ import { TYPES } from '../lib/types';
 import { supabase } from '../lib/supabase';
 
 export interface IFinancialTransactionHeaderAdapter
-  extends BaseAdapter<FinancialTransactionHeader> {}
+  extends BaseAdapter<FinancialTransactionHeader> {
+  postTransaction(id: string): Promise<void>;
+  voidTransaction(id: string, reason: string): Promise<void>;
+  getTransactionEntries(headerId: string): Promise<any[]>;
+  isTransactionBalanced(headerId: string): Promise<boolean>;
+}
 
 @injectable()
 export class FinancialTransactionHeaderAdapter

--- a/src/repositories/chartOfAccount.repository.ts
+++ b/src/repositories/chartOfAccount.repository.ts
@@ -74,6 +74,6 @@ export class ChartOfAccountRepository
   }
 
   public async getHierarchy(): Promise<ChartOfAccount[]> {
-    return (this.adapter as ChartOfAccountAdapter).getHierarchy();
+    return (this.adapter as unknown as IChartOfAccountAdapter).getHierarchy();
   }
 }

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -81,7 +81,7 @@ export class FinancialTransactionHeaderRepository
 
   public async postTransaction(id: string): Promise<void> {
     try {
-      await (this.adapter as FinancialTransactionHeaderAdapter).postTransaction(id);
+      await (this.adapter as unknown as IFinancialTransactionHeaderAdapter).postTransaction(id);
       
       NotificationService.showSuccess('Transaction posted successfully');
     } catch (error) {
@@ -95,7 +95,7 @@ export class FinancialTransactionHeaderRepository
 
   public async voidTransaction(id: string, reason: string): Promise<void> {
     try {
-      await (this.adapter as FinancialTransactionHeaderAdapter).voidTransaction(id, reason);
+      await (this.adapter as unknown as IFinancialTransactionHeaderAdapter).voidTransaction(id, reason);
       
       NotificationService.showSuccess('Transaction voided successfully');
     } catch (error) {
@@ -108,10 +108,10 @@ export class FinancialTransactionHeaderRepository
   }
 
   public async getTransactionEntries(headerId: string): Promise<any[]> {
-    return (this.adapter as FinancialTransactionHeaderAdapter).getTransactionEntries(headerId);
+    return (this.adapter as unknown as IFinancialTransactionHeaderAdapter).getTransactionEntries(headerId);
   }
 
   public async isTransactionBalanced(headerId: string): Promise<boolean> {
-    return (this.adapter as FinancialTransactionHeaderAdapter).isTransactionBalanced(headerId);
+    return (this.adapter as unknown as IFinancialTransactionHeaderAdapter).isTransactionBalanced(headerId);
   }
 }


### PR DESCRIPTION
## Summary
- extend adapter interfaces for chart of account and financial transaction headers
- refactor repositories to depend on adapter interfaces

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: registry access blocked)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f81a3d0883269dc52dc93f0b1bbc