### PR TITLE
Enable bulk transaction editing

### DIFF
--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -42,6 +42,11 @@ function Finances() {
             <BulkTransactionEntry />
           </SubscriptionGate>
         } />
+        <Route path="transactions/:id/bulk" element={
+          <SubscriptionGate type="transaction">
+            <BulkTransactionEntry />
+          </SubscriptionGate>
+        } />
         <Route path="transactions/bulk-income" element={
           <SubscriptionGate type="transaction">
             <BulkIncomeEntry />

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -45,6 +45,11 @@ function Finances() {
             <TransactionAdd />
           </SubscriptionGate>
         } />
+        <Route path="transactions/:id/bulk" element={
+          <SubscriptionGate type="transaction">
+            <BulkTransactionEntry />
+          </SubscriptionGate>
+        } />
         <Route path="transactions/bulk" element={
           <SubscriptionGate type="transaction">
             <BulkTransactionEntry />

--- a/src/pages/finances/TransactionList.tsx
+++ b/src/pages/finances/TransactionList.tsx
@@ -249,7 +249,7 @@ function TransactionList() {
                 variant="ghost"
                 size="sm"
                 className="h-8 w-8 p-0"
-                onClick={() => navigate(`/finances/transactions/${params.row.id}/edit`)}
+                onClick={() => navigate(`/finances/transactions/${params.row.id}/bulk`)}
               >
                 <Edit className="h-4 w-4" />
               </Button>
@@ -276,7 +276,7 @@ function TransactionList() {
                 
                 {canEdit && (
                   <DropdownMenuItem
-                    onClick={() => navigate(`/finances/transactions/${params.row.id}/edit`)}
+                    onClick={() => navigate(`/finances/transactions/${params.row.id}/bulk`)}
                     className="flex items-center"
                   >
                     <Edit className="h-4 w-4 mr-2" />
@@ -397,7 +397,13 @@ function TransactionList() {
             onPageChange={setPage}
             onPageSizeChange={setPageSize}
             getRowId={(row) => row.id}
-            onRowClick={(params) => navigate(`/finances/transactions/${params.id}`)}
+            onRowClick={(params) =>
+              navigate(
+                params.row.status === 'draft'
+                  ? `/finances/transactions/${params.id}/bulk`
+                  : `/finances/transactions/${params.id}`
+              )
+            }
             autoHeight
             disableColumnMenu={false}
             disableColumnFilter={false}


### PR DESCRIPTION
## Summary
- allow editing transactions in the BulkTransactionEntry component
- open draft transactions from the list using the bulk editor
- add new `/transactions/:id/bulk` route

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fd254f788326a6348f403da9b24e