### PR TITLE
Update bulk transaction routes

### DIFF
--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { Card, CardContent } from "../../components/ui2/card";
 import { Loader2 } from 'lucide-react';
 import { SubscriptionGate } from '../../components/SubscriptionGate';
@@ -7,7 +7,6 @@ import { SubscriptionGate } from '../../components/SubscriptionGate';
 // Lazy load finance components
 const FinancesDashboard = React.lazy(() => import('./FinancesDashboard'));
 const TransactionList = React.lazy(() => import('./TransactionList'));
-const TransactionAdd = React.lazy(() => import('./TransactionAdd'));
 const TransactionDetail = React.lazy(() => import('./TransactionDetail'));
 const BulkTransactionEntry = React.lazy(() => import('./BulkTransactionEntry'));
 const BulkIncomeEntry = React.lazy(() => import('./BulkIncomeEntry'));
@@ -28,6 +27,11 @@ function LoadingSpinner() {
   );
 }
 
+function TransactionBulkRedirect() {
+  const { id } = useParams<{ id: string }>();
+  return <Navigate to={`/finances/transactions/${id}/edit`} replace />;
+}
+
 function Finances() {
   return (
     <Suspense fallback={<LoadingSpinner />}>
@@ -36,25 +40,17 @@ function Finances() {
         <Route path="transactions" element={<TransactionList />} />
         <Route path="transactions/add" element={
           <SubscriptionGate type="transaction">
-            <TransactionAdd />
+            <BulkTransactionEntry />
           </SubscriptionGate>
         } />
         <Route path="transactions/:id" element={<TransactionDetail />} />
         <Route path="transactions/:id/edit" element={
           <SubscriptionGate type="transaction">
-            <TransactionAdd />
-          </SubscriptionGate>
-        } />
-        <Route path="transactions/:id/bulk" element={
-          <SubscriptionGate type="transaction">
             <BulkTransactionEntry />
           </SubscriptionGate>
         } />
-        <Route path="transactions/bulk" element={
-          <SubscriptionGate type="transaction">
-            <BulkTransactionEntry />
-          </SubscriptionGate>
-        } />
+        <Route path="transactions/:id/bulk" element={<TransactionBulkRedirect />} />
+        <Route path="transactions/bulk" element={<Navigate to="/finances/transactions/add" replace />} />
         <Route path="transactions/bulk-income" element={
           <SubscriptionGate type="transaction">
             <BulkIncomeEntry />

--- a/src/pages/finances/FinancesDashboard.tsx
+++ b/src/pages/finances/FinancesDashboard.tsx
@@ -371,7 +371,7 @@ function FinancesDashboard() {
               {
                 label: 'Bulk Transaction Entry',
                 icon: <Layers className="h-4 w-4" />,
-                onClick: () => navigate('/finances/transactions/bulk')
+                onClick: () => navigate('/finances/transactions/add')
               },
               {
                 label: 'Bulk Income Entry',
@@ -618,7 +618,7 @@ function FinancesDashboard() {
                   </CardContent>
                 </Card>
               </Link>
-              <Link to="/finances/transactions/bulk">
+              <Link to="/finances/transactions/add">
                 <Card className="hover:shadow-lg transition-shadow duration-200">
                   <CardContent className="p-4 flex items-center space-x-3">
                     <div className="flex-shrink-0">
@@ -642,7 +642,7 @@ function FinancesDashboard() {
               <h3 className="text-base font-medium text-foreground">Bulk Operations</h3>
             </div>
             <div className="space-y-4 grid grid-cols-1 gap-2">
-              <Link to="/finances/transactions/bulk">
+              <Link to="/finances/transactions/add">
                 <Card className="hover:shadow-lg transition-shadow duration-200">
                   <CardContent className="p-4 flex items-center justify-between">
                     <div className="flex items-center space-x-3">

--- a/src/pages/finances/TransactionList.tsx
+++ b/src/pages/finances/TransactionList.tsx
@@ -249,7 +249,7 @@ function TransactionList() {
                 variant="ghost"
                 size="sm"
                 className="h-8 w-8 p-0"
-                onClick={() => navigate(`/finances/transactions/${params.row.id}/bulk`)}
+              onClick={() => navigate(`/finances/transactions/${params.row.id}/edit`)}
               >
                 <Edit className="h-4 w-4" />
               </Button>
@@ -276,7 +276,7 @@ function TransactionList() {
                 
                 {canEdit && (
                   <DropdownMenuItem
-                    onClick={() => navigate(`/finances/transactions/${params.row.id}/bulk`)}
+                    onClick={() => navigate(`/finances/transactions/${params.row.id}/edit`)}
                     className="flex items-center"
                   >
                     <Edit className="h-4 w-4 mr-2" />
@@ -324,7 +324,7 @@ function TransactionList() {
             </Button>
             <Button
               variant="outline"
-              onClick={() => navigate('/finances/transactions/bulk')}
+              onClick={() => navigate('/finances/transactions/add')}
               className="flex items-center"
             >
               <FileUp className="h-4 w-4 mr-2" />
@@ -400,7 +400,7 @@ function TransactionList() {
             onRowClick={(params) =>
               navigate(
                 params.row.status === 'draft'
-                  ? `/finances/transactions/${params.id}/bulk`
+                  ? `/finances/transactions/${params.id}/edit`
                   : `/finances/transactions/${params.id}`
               )
             }


### PR DESCRIPTION
## Summary
- use `BulkTransactionEntry` for adding/editing transactions
- redirect legacy `/bulk` transaction paths
- update finance dashboards and lists to link to the new routes

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685667b2e43c832690d50f259d333dfc