### PR TITLE
Add submitted and approved transaction statuses

### DIFF
--- a/src/models/financialTransactionHeader.model.ts
+++ b/src/models/financialTransactionHeader.model.ts
@@ -2,7 +2,12 @@ import { BaseModel } from './base.model';
 import { FinancialSource } from './financialSource.model';
 import { FinancialTransaction } from './financialTransaction.model';
 
-export type TransactionStatus = 'draft' | 'posted' | 'voided';
+export type TransactionStatus =
+  | 'draft'
+  | 'submitted'
+  | 'approved'
+  | 'posted'
+  | 'voided';
 
 export interface FinancialTransactionHeader extends BaseModel {
   id: string;

--- a/src/pages/accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/ChartOfAccountProfile.tsx
@@ -198,16 +198,28 @@ function ChartOfAccountProfile() {
       renderCell: (params) => {
         const status = params.value;
         return (
-          <Badge 
+          <Badge
             variant={
-              status === 'posted' ? 'success' : 
-              status === 'voided' ? 'destructive' : 
-              'secondary'
+              status === 'posted'
+                ? 'success'
+                : status === 'voided'
+                ? 'destructive'
+                : status === 'approved'
+                ? 'warning'
+                : status === 'submitted'
+                ? 'info'
+                : 'secondary'
             }
           >
-            {status === 'posted' ? 'Posted' : 
-             status === 'voided' ? 'Voided' : 
-             'Draft'}
+            {status === 'posted'
+              ? 'Posted'
+              : status === 'voided'
+              ? 'Voided'
+              : status === 'approved'
+              ? 'Approved'
+              : status === 'submitted'
+              ? 'Submitted'
+              : 'Draft'}
           </Badge>
         );
       },

--- a/src/pages/finances/AccountDetail.tsx
+++ b/src/pages/finances/AccountDetail.tsx
@@ -346,6 +346,10 @@ function AccountDetail() {
                           <Badge variant="success">Posted</Badge>
                         ) : transaction.header?.status === 'voided' ? (
                           <Badge variant="destructive">Voided</Badge>
+                        ) : transaction.header?.status === 'approved' ? (
+                          <Badge variant="warning">Approved</Badge>
+                        ) : transaction.header?.status === 'submitted' ? (
+                          <Badge variant="info">Submitted</Badge>
                         ) : (
                           <Badge variant="secondary">Draft</Badge>
                         )}

--- a/src/pages/finances/TransactionDetail.tsx
+++ b/src/pages/finances/TransactionDetail.tsx
@@ -249,11 +249,17 @@ function TransactionDetail() {
               <div className="ml-4">
                 <div className="flex items-center">
                   <h2 className="text-2xl font-bold text-foreground">{header.transaction_number}</h2>
-                  <Badge 
+                  <Badge
                     variant={
-                      header.status === 'posted' ? 'success' : 
-                      header.status === 'voided' ? 'destructive' : 
-                      'secondary'
+                      header.status === 'posted'
+                        ? 'success'
+                        : header.status === 'voided'
+                        ? 'destructive'
+                        : header.status === 'approved'
+                        ? 'warning'
+                        : header.status === 'submitted'
+                        ? 'info'
+                        : 'secondary'
                     }
                     className="ml-3 capitalize"
                   >
@@ -266,6 +272,16 @@ function TransactionDetail() {
                       <>
                         <X className="h-3 w-3 mr-1" />
                         Voided
+                      </>
+                    ) : header.status === 'approved' ? (
+                      <>
+                        <Check className="h-3 w-3 mr-1" />
+                        Approved
+                      </>
+                    ) : header.status === 'submitted' ? (
+                      <>
+                        <FileText className="h-3 w-3 mr-1" />
+                        Submitted
                       </>
                     ) : (
                       <>
@@ -471,11 +487,17 @@ function TransactionDetail() {
                 <div className="py-3 grid grid-cols-3 gap-4">
                   <dt className="text-sm font-medium text-muted-foreground">Status</dt>
                   <dd className="text-sm text-foreground col-span-2">
-                    <Badge 
+                    <Badge
                       variant={
-                        header.status === 'posted' ? 'success' : 
-                        header.status === 'voided' ? 'destructive' : 
-                        'secondary'
+                        header.status === 'posted'
+                          ? 'success'
+                          : header.status === 'voided'
+                          ? 'destructive'
+                          : header.status === 'approved'
+                          ? 'warning'
+                          : header.status === 'submitted'
+                          ? 'info'
+                          : 'secondary'
                       }
                       className="capitalize"
                     >

--- a/src/pages/finances/TransactionList.tsx
+++ b/src/pages/finances/TransactionList.tsx
@@ -194,11 +194,17 @@ function TransactionList() {
       renderCell: (params) => {
         const status = params.value;
         return (
-          <Badge 
+          <Badge
             variant={
-              status === 'posted' ? 'success' : 
-              status === 'voided' ? 'destructive' : 
-              'secondary'
+              status === 'posted'
+                ? 'success'
+                : status === 'voided'
+                ? 'destructive'
+                : status === 'approved'
+                ? 'warning'
+                : status === 'submitted'
+                ? 'info'
+                : 'secondary'
             }
             className="flex items-center"
           >
@@ -211,6 +217,16 @@ function TransactionList() {
               <>
                 <X className="h-3 w-3 mr-1" />
                 Voided
+              </>
+            ) : status === 'approved' ? (
+              <>
+                <Check className="h-3 w-3 mr-1" />
+                Approved
+              </>
+            ) : status === 'submitted' ? (
+              <>
+                <FileText className="h-3 w-3 mr-1" />
+                Submitted
               </>
             ) : (
               <>
@@ -372,6 +388,8 @@ function TransactionList() {
             <SelectContent>
               <SelectItem value="all">All Statuses</SelectItem>
               <SelectItem value="draft">Draft</SelectItem>
+              <SelectItem value="submitted">Submitted</SelectItem>
+              <SelectItem value="approved">Approved</SelectItem>
               <SelectItem value="posted">Posted</SelectItem>
               <SelectItem value="voided">Voided</SelectItem>
             </SelectContent>

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -53,7 +53,7 @@ export class FinancialTransactionHeaderRepository
       throw new Error('Transaction not found');
     }
     
-    if (header.status !== 'draft') {
+    if (header.status === 'posted' || header.status === 'voided') {
       throw new Error(`Cannot delete a ${header.status} transaction`);
     }
   }

--- a/src/validators/financialTransactionHeader.validator.ts
+++ b/src/validators/financialTransactionHeader.validator.ts
@@ -11,9 +11,17 @@ export class FinancialTransactionHeaderValidator {
     }
 
     if (data.status !== undefined) {
-      const validStatuses = ['draft', 'posted', 'voided'];
+      const validStatuses = [
+        'draft',
+        'submitted',
+        'approved',
+        'posted',
+        'voided'
+      ];
       if (!validStatuses.includes(data.status)) {
-        throw new Error('Invalid status. Must be one of: draft, posted, voided');
+        throw new Error(
+          'Invalid status. Must be one of: draft, submitted, approved, posted, voided'
+        );
       }
     }
   }

--- a/supabase/migrations/20250410150532_black_valley.sql
+++ b/supabase/migrations/20250410150532_black_valley.sql
@@ -31,7 +31,9 @@ CREATE TABLE IF NOT EXISTS financial_transaction_headers (
   description TEXT NOT NULL,
   reference TEXT,
   source_id UUID REFERENCES financial_sources(id),
-  status TEXT NOT NULL CHECK (status IN ('draft', 'posted', 'voided')) DEFAULT 'draft',
+  status TEXT NOT NULL CHECK (
+    status IN ('draft', 'submitted', 'approved', 'posted', 'voided')
+  ) DEFAULT 'draft',
   posted_at TIMESTAMPTZ,
   posted_by UUID REFERENCES auth.users(id),
   voided_at TIMESTAMPTZ,


### PR DESCRIPTION
## Summary
- extend `TransactionStatus` type with `submitted` and `approved`
- allow validator and repository to recognize new statuses
- show new statuses in lists and details with color badges
- update migration check constraint for the additional values

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685669a3652483269c592ff14d02e8fc