### PR TITLE
Add migration to allow submitted and approved transactions

### DIFF
--- a/supabase/migrations/20250619000000_lively_meadow.sql
+++ b/supabase/migrations/20250619000000_lively_meadow.sql
@@ -1,0 +1,9 @@
+-- Add submitted and approved statuses to financial_transaction_headers.status
+-- This migration updates the status check constraint without modifying existing data
+
+ALTER TABLE financial_transaction_headers
+  DROP CONSTRAINT IF EXISTS financial_transaction_headers_status_check;
+
+ALTER TABLE financial_transaction_headers
+  ADD CONSTRAINT financial_transaction_headers_status_check
+  CHECK (status IN ('draft', 'submitted', 'approved', 'posted', 'voided'));


### PR DESCRIPTION
## Summary
- add new migration to extend financial_transaction_headers.status check constraint

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567256a0588326bd95704a03d6d488