### PR TITLE
Update transaction number prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 - When a member is created an account is automatically generated.
 - Member accounts use the format `MEM-<first 8 characters of member id>` for the account number.
+- Financial transaction numbers use status-based prefixes such as `DFT` for drafts,
+  `SUB` for submitted, `APP` for approved and `TRX` once posted.
 
 ## Running tests
 

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -63,7 +63,7 @@ export class FinancialTransactionHeaderAdapter
     if (!data.transaction_number) {
       data.transaction_number = await this.generateTransactionNumber(
         data.transaction_date || new Date().toISOString().split('T')[0],
-        data.status === 'draft' ? 'DFT' : 'TRX'
+        data.status ?? 'draft'
       );
     }
     
@@ -155,7 +155,16 @@ export class FinancialTransactionHeaderAdapter
   }
 
 
-  private async generateTransactionNumber(date: string, prefix: string): Promise<string> {
+  private async generateTransactionNumber(date: string, status: string): Promise<string> {
+    const prefixMap: Record<string, string> = {
+      draft: 'DFT',
+      submitted: 'SUB',
+      approved: 'APP',
+      posted: 'TRX',
+      voided: 'TRX'
+    };
+    const prefix = prefixMap[status] || 'TRX';
+
     // Format: PREFIX-YYYYMM-SEQUENCE
     const dateObj = new Date(date);
     const year = dateObj.getFullYear();

--- a/tests/transactionNumber.test.ts
+++ b/tests/transactionNumber.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FinancialTransactionHeaderAdapter } from '../src/adapters/financialTransactionHeader.adapter';
+import type { AuditService } from '../src/services/AuditService';
+
+// Mock supabase query chain
+const chain = {
+  select: vi.fn().mockReturnThis(),
+  ilike: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockResolvedValue({ data: [], error: null })
+};
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => chain)
+  }
+}));
+
+class TestAdapter extends FinancialTransactionHeaderAdapter {
+  constructor() {
+    super({} as AuditService);
+  }
+  public async generate(date: string, status: string) {
+    return (this as any).generateTransactionNumber(date, status);
+  }
+}
+
+describe('generateTransactionNumber', () => {
+  it('uses status prefixes', async () => {
+    const adapter = new TestAdapter();
+    const numDraft = await adapter.generate('2025-06-01', 'draft');
+    expect(numDraft.startsWith('DFT-')).toBe(true);
+
+    const numSub = await adapter.generate('2025-06-01', 'submitted');
+    expect(numSub.startsWith('SUB-')).toBe(true);
+
+    const numApp = await adapter.generate('2025-06-01', 'approved');
+    expect(numApp.startsWith('APP-')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- generate transaction numbers with status-specific prefixes
- document prefixes in README
- test generateTransactionNumber for draft, submitted and approved statuses

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567835a2d083268e2409b71a944833