### PR TITLE
Fix repeated reload in TransactionDetail

### DIFF
--- a/src/hooks/useFinancialTransactionHeaderRepository.ts
+++ b/src/hooks/useFinancialTransactionHeaderRepository.ts
@@ -2,28 +2,47 @@ import { container } from '../lib/container';
 import { TYPES } from '../lib/types';
 import type { IFinancialTransactionHeaderRepository } from '../repositories/financialTransactionHeader.repository';
 import { useBaseRepository } from './useBaseRepository';
+import { useCallback } from 'react';
 
 export function useFinancialTransactionHeaderRepository() {
   const repository = container.get<IFinancialTransactionHeaderRepository>(TYPES.IFinancialTransactionHeaderRepository);
+  const postTransaction = useCallback(
+    async (id: string) => repository.postTransaction(id),
+    [repository]
+  );
+
+  const submitTransaction = useCallback(
+    async (id: string) => repository.submitTransaction(id),
+    [repository]
+  );
+
+  const approveTransaction = useCallback(
+    async (id: string) => repository.approveTransaction(id),
+    [repository]
+  );
+
+  const voidTransaction = useCallback(
+    async (id: string, reason: string) => repository.voidTransaction(id, reason),
+    [repository]
+  );
+
+  const getTransactionEntries = useCallback(
+    async (headerId: string) => repository.getTransactionEntries(headerId),
+    [repository]
+  );
+
+  const isTransactionBalanced = useCallback(
+    async (headerId: string) => repository.isTransactionBalanced(headerId),
+    [repository]
+  );
+
   return {
     ...useBaseRepository(repository, 'Transaction', 'financial_transaction_headers'),
-    postTransaction: async (id: string) => {
-      return repository.postTransaction(id);
-    },
-    submitTransaction: async (id: string) => {
-      return repository.submitTransaction(id);
-    },
-    approveTransaction: async (id: string) => {
-      return repository.approveTransaction(id);
-    },
-    voidTransaction: async (id: string, reason: string) => {
-      return repository.voidTransaction(id, reason);
-    },
-    getTransactionEntries: async (headerId: string) => {
-      return repository.getTransactionEntries(headerId);
-    },
-    isTransactionBalanced: async (headerId: string) => {
-      return repository.isTransactionBalanced(headerId);
-    }
+    postTransaction,
+    submitTransaction,
+    approveTransaction,
+    voidTransaction,
+    getTransactionEntries,
+    isTransactionBalanced
   };
 }


### PR DESCRIPTION
## Summary
- stabilize callbacks in financial transaction repository to prevent infinite effects
- filter entries by tenant when loading transaction details

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567ff3b8f08326aace2216cd95c9ea