### PR TITLE
Fix BulkTransactionEntry not saving lines

### DIFF
--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -15,6 +15,15 @@ export interface IFinancialTransactionHeaderAdapter
   voidTransaction(id: string, reason: string): Promise<void>;
   getTransactionEntries(headerId: string): Promise<any[]>;
   isTransactionBalanced(headerId: string): Promise<boolean>;
+  createWithTransactions(
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader>;
+  updateWithTransactions(
+    id: string,
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader>;
 }
 
 @injectable()
@@ -258,8 +267,74 @@ export class FinancialTransactionHeaderAdapter
     const { data, error } = await supabase.rpc('is_transaction_balanced', {
       p_header_id: headerId
     });
-    
+
     if (error) throw error;
     return data;
+  }
+
+  public async createWithTransactions(
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader> {
+    const header = await super.create(data);
+    if (transactions && transactions.length) {
+      await this.insertTransactions(header.id, transactions);
+    }
+    return header;
+  }
+
+  public async updateWithTransactions(
+    id: string,
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader> {
+    const header = await super.update(id, data);
+    await this.replaceTransactions(id, transactions);
+    return header;
+  }
+
+  private async insertTransactions(headerId: string, entries: any[]): Promise<void> {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) throw new Error('No tenant context found');
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    const rows = entries.map((e) => ({
+      ...e,
+      header_id: headerId,
+      tenant_id: tenantId,
+      created_by: userId,
+      updated_by: userId,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }));
+    const { error } = await supabase
+      .from('financial_transactions')
+      .insert(rows);
+    if (error) throw error;
+  }
+
+  private async replaceTransactions(headerId: string, entries: any[]): Promise<void> {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) throw new Error('No tenant context found');
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    await supabase
+      .from('financial_transactions')
+      .delete()
+      .eq('header_id', headerId)
+      .eq('tenant_id', tenantId);
+    if (entries && entries.length) {
+      const rows = entries.map((e) => ({
+        ...e,
+        header_id: headerId,
+        tenant_id: tenantId,
+        created_by: userId,
+        updated_by: userId,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }));
+      const { error } = await supabase
+        .from('financial_transactions')
+        .insert(rows);
+      if (error) throw error;
+    }
   }
 }

--- a/src/pages/finances/BulkTransactionEntry.tsx
+++ b/src/pages/finances/BulkTransactionEntry.tsx
@@ -51,8 +51,12 @@ function BulkTransactionEntry() {
   const { currency } = useCurrencyStore();
 
   // Repositories
-  const { useCreate, useUpdate, useQuery, getTransactionEntries } =
-    useFinancialTransactionHeaderRepository();
+  const {
+    useCreateWithTransactions,
+    useUpdateWithTransactions,
+    useQuery,
+    getTransactionEntries,
+  } = useFinancialTransactionHeaderRepository();
   const { useAccountOptions } = useChartOfAccounts();
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
   const { useQuery: useMembersQuery } = useMemberRepository();
@@ -76,8 +80,8 @@ function BulkTransactionEntry() {
   });
 
   // Create/update mutations
-  const createMutation = useCreate();
-  const updateMutation = useUpdate();
+  const createMutation = useCreateWithTransactions();
+  const updateMutation = useUpdateWithTransactions();
 
   // Get account options
   const { data: accountOptions, isLoading: isAccountsLoading } =
@@ -407,9 +411,7 @@ function BulkTransactionEntry() {
             source_id:
               headerData.source_id === "none" ? null : headerData.source_id,
           },
-          relations: {
-            transactions: formattedEntries,
-          },
+          transactions: formattedEntries,
         });
       } else {
         // Create transaction header and entries
@@ -422,9 +424,7 @@ function BulkTransactionEntry() {
               headerData.source_id === "none" ? null : headerData.source_id,
             status: "draft",
           },
-          relations: {
-            transactions: formattedEntries,
-          },
+          transactions: formattedEntries,
         });
       }
 

--- a/src/pages/finances/TransactionAdd.tsx
+++ b/src/pages/finances/TransactionAdd.tsx
@@ -37,13 +37,18 @@ function TransactionAdd() {
   const isEditMode = !!id;
   
   // Repositories
-  const { useQuery, useCreate, useUpdate, getTransactionEntries } = useFinancialTransactionHeaderRepository();
+  const {
+    useQuery,
+    useCreateWithTransactions,
+    useUpdateWithTransactions,
+    getTransactionEntries,
+  } = useFinancialTransactionHeaderRepository();
   const { useAccountOptions } = useChartOfAccounts();
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
   
   // Create/update mutation
-  const createMutation = useCreate();
-  const updateMutation = useUpdate();
+  const createMutation = useCreateWithTransactions();
+  const updateMutation = useUpdateWithTransactions();
   
   // Get account options
   const { data: accountOptions, isLoading: isAccountsLoading } = useAccountOptions();
@@ -267,9 +272,7 @@ function TransactionAdd() {
             reference: headerData.reference || null,
             source_id: headerData.source_id === 'none' ? null : headerData.source_id
           },
-          relations: {
-            transactions: formattedEntries
-          }
+          transactions: formattedEntries
         });
       } else {
         // Create transaction
@@ -281,9 +284,7 @@ function TransactionAdd() {
             source_id: headerData.source_id === 'none' ? null : headerData.source_id,
             status: 'draft'
           },
-          relations: {
-            transactions: formattedEntries
-          }
+          transactions: formattedEntries
         });
       }
       

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -9,6 +9,15 @@ export interface IFinancialTransactionHeaderRepository
   extends BaseRepository<FinancialTransactionHeader> {
   submitTransaction(id: string): Promise<void>;
   approveTransaction(id: string): Promise<void>;
+  createWithTransactions(
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader>;
+  updateWithTransactions(
+    id: string,
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader>;
 }
 
 @injectable()
@@ -64,6 +73,31 @@ export class FinancialTransactionHeaderRepository
   protected override async afterDelete(id: string): Promise<void> {
     // Additional repository-level cleanup after delete
     NotificationService.showSuccess('Transaction deleted successfully');
+  }
+
+  public async createWithTransactions(
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader> {
+    const processed = await this.beforeCreate(data);
+    const created = await (
+      this.adapter as unknown as IFinancialTransactionHeaderAdapter
+    ).createWithTransactions(processed, transactions);
+    await this.afterCreate(created);
+    return created;
+  }
+
+  public async updateWithTransactions(
+    id: string,
+    data: Partial<FinancialTransactionHeader>,
+    transactions: any[],
+  ): Promise<FinancialTransactionHeader> {
+    const processed = await this.beforeUpdate(id, data);
+    const updated = await (
+      this.adapter as unknown as IFinancialTransactionHeaderAdapter
+    ).updateWithTransactions(id, processed, transactions);
+    await this.afterUpdate(updated);
+    return updated;
   }
 
   // Private helper methods


### PR DESCRIPTION
## Summary
- enable saving transaction entry lines via adapter/repository hooks
- expose new mutations from financial transaction hooks
- use new hooks in BulkTransactionEntry and TransactionAdd to persist lines

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba7181388326810138ce0c5cae33