### PR TITLE
Allow nullable transaction type

### DIFF
--- a/src/models/financialTransaction.model.ts
+++ b/src/models/financialTransaction.model.ts
@@ -7,7 +7,7 @@ export type TransactionType = 'income' | 'expense';
 
 export interface FinancialTransaction extends BaseModel {
   id: string;
-  type: TransactionType;
+  type: TransactionType | null;
   amount: number;
   description: string;
   date: string;

--- a/supabase/migrations/20250620123000_allow_null_transaction_type.sql
+++ b/supabase/migrations/20250620123000_allow_null_transaction_type.sql
@@ -1,0 +1,4 @@
+-- Allow null values for financial_transactions.type
+
+ALTER TABLE financial_transactions
+  ALTER COLUMN type DROP NOT NULL;


### PR DESCRIPTION
## Summary
- allow `financial_transactions.type` to be nullable via migration
- update FinancialTransaction model to allow `type` to be `null`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0b2735083268c225f7f2583ddb9