### PR TITLE
Use account records for People/Org field in bulk transactions

### DIFF
--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -253,7 +253,9 @@ export class FinancialTransactionHeaderAdapter
         debit,
         credit,
         account_id,
-        account:chart_of_accounts(id, code, name, account_type)
+        accounts_account_id,
+        account:chart_of_accounts(id, code, name, account_type),
+        account_holder:accounts(id, name)
       `
       )
       .eq('tenant_id', tenantId)


### PR DESCRIPTION
## Summary
- populate People/Org column in BulkTransactionEntry from Accounts table
- store selected account id in `accounts_account_id`
- include account holder info when loading transaction entries

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c6bab0008326ad13b5117df2fac2