### PR TITLE
Add quick account modals

### DIFF
--- a/src/components/forms/AccountCreateForm.tsx
+++ b/src/components/forms/AccountCreateForm.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useAccountRepository } from '../../hooks/useAccountRepository';
+import { AccountType } from '../../models/account.model';
+import { Input } from '../ui2/input';
+import { Button } from '../ui2/button';
+import { Textarea } from '../ui2/textarea';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../ui2/select';
+import { Switch } from '../ui2/switch';
+import { AlertCircle } from 'lucide-react';
+
+interface AccountCreateFormProps {
+  onCancel: () => void;
+  onSuccess?: () => void;
+}
+
+export default function AccountCreateForm({ onCancel, onSuccess }: AccountCreateFormProps) {
+  const { useCreate } = useAccountRepository();
+  const createMutation = useCreate();
+
+  const [formData, setFormData] = useState({
+    name: '',
+    account_type: 'organization' as AccountType,
+    account_number: '',
+    description: '',
+    is_active: true,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (field: string, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!formData.name.trim()) {
+      setError('Account name is required');
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync({ data: formData });
+      onSuccess && onSuccess();
+    } catch (err) {
+      console.error('Error creating account:', err);
+      setError(err instanceof Error ? err.message : 'Failed to create account');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1.5 text-foreground">Account Type</label>
+        <Select value={formData.account_type} onValueChange={(v) => handleChange('account_type', v as AccountType)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="organization">Organization</SelectItem>
+            <SelectItem value="person">Person</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Input
+        label="Account Name"
+        value={formData.name}
+        onChange={(e) => handleChange('name', e.target.value)}
+        required
+      />
+      <Input
+        label="Account Number"
+        value={formData.account_number}
+        onChange={(e) => handleChange('account_number', e.target.value)}
+      />
+      <Textarea
+        label="Description"
+        value={formData.description}
+        onChange={(e) => handleChange('description', e.target.value)}
+        rows={3}
+      />
+      <div className="flex items-center space-x-2">
+        <Switch
+          checked={formData.is_active}
+          onCheckedChange={(v) => handleChange('is_active', v)}
+        />
+        <label className="text-sm font-medium">Account is active</label>
+      </div>
+      {error && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-2 flex items-start text-destructive">
+          <AlertCircle className="h-4 w-4 mr-2 mt-0.5" />
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+      <div className="flex justify-end space-x-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel}>Cancel</Button>
+        <Button type="submit" loading={createMutation.isPending}>Create</Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/forms/ChartOfAccountCreateForm.tsx
+++ b/src/components/forms/ChartOfAccountCreateForm.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
+import { AccountType } from '../../models/chartOfAccount.model';
+import { Input } from '../ui2/input';
+import { Button } from '../ui2/button';
+import { Textarea } from '../ui2/textarea';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../ui2/select';
+import { Switch } from '../ui2/switch';
+import { AlertCircle } from 'lucide-react';
+
+interface ChartOfAccountCreateFormProps {
+  onCancel: () => void;
+  onSuccess?: () => void;
+}
+
+export default function ChartOfAccountCreateForm({ onCancel, onSuccess }: ChartOfAccountCreateFormProps) {
+  const { useCreateAccount } = useChartOfAccounts();
+  const createMutation = useCreateAccount();
+
+  const [formData, setFormData] = useState({
+    code: '',
+    name: '',
+    account_type: 'asset' as AccountType,
+    description: '',
+    is_active: true,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (field: string, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!formData.code.trim()) {
+      setError('Account code is required');
+      return;
+    }
+    if (!formData.name.trim()) {
+      setError('Account name is required');
+      return;
+    }
+
+    try {
+      await createMutation.mutateAsync(formData);
+      onSuccess && onSuccess();
+    } catch (err) {
+      console.error('Error creating account:', err);
+      setError(err instanceof Error ? err.message : 'Failed to create account');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input
+        label="Account Code"
+        value={formData.code}
+        onChange={(e) => handleChange('code', e.target.value)}
+        required
+      />
+      <Input
+        label="Account Name"
+        value={formData.name}
+        onChange={(e) => handleChange('name', e.target.value)}
+        required
+      />
+      <div>
+        <label className="block text-sm font-medium mb-1.5 text-foreground">Account Type</label>
+        <Select value={formData.account_type} onValueChange={(v) => handleChange('account_type', v as AccountType)}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="asset">Asset</SelectItem>
+            <SelectItem value="liability">Liability</SelectItem>
+            <SelectItem value="equity">Equity</SelectItem>
+            <SelectItem value="revenue">Revenue</SelectItem>
+            <SelectItem value="expense">Expense</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Textarea
+        label="Description"
+        value={formData.description}
+        onChange={(e) => handleChange('description', e.target.value)}
+        rows={3}
+      />
+      <div className="flex items-center space-x-2">
+        <Switch checked={formData.is_active} onCheckedChange={(v) => handleChange('is_active', v)} />
+        <label className="text-sm font-medium">Account is active</label>
+      </div>
+      {error && (
+        <div className="rounded-md bg-destructive/10 border border-destructive/20 p-2 flex items-start text-destructive">
+          <AlertCircle className="h-4 w-4 mr-2 mt-0.5" />
+          <span className="text-sm">{error}</span>
+        </div>
+      )}
+      <div className="flex justify-end space-x-2 pt-2">
+        <Button type="button" variant="outline" onClick={onCancel}>Cancel</Button>
+        <Button type="submit" loading={createMutation.isPending}>Create</Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/ui2/form-dialog.tsx
+++ b/src/components/ui2/form-dialog.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './dialog';
+
+interface FormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export function FormDialog({ open, onOpenChange, title, children }: FormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {title && (
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+          </DialogHeader>
+        )}
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/finances/BulkTransactionEntry.tsx
+++ b/src/pages/finances/BulkTransactionEntry.tsx
@@ -29,12 +29,17 @@ import {
   Loader2,
   Plus,
   Trash2,
+  BookOpen,
+  Building2,
   DollarSign,
   FileText,
   AlertCircle,
 } from "lucide-react";
 import { useCurrencyStore } from "../../stores/currencyStore";
 import { formatCurrency } from "../../utils/currency";
+import { FormDialog } from "../../components/ui2/form-dialog";
+import AccountCreateForm from "../../components/forms/AccountCreateForm";
+import ChartOfAccountCreateForm from "../../components/forms/ChartOfAccountCreateForm";
 
 interface TransactionEntry {
   accounts_account_id: string;
@@ -117,6 +122,9 @@ function BulkTransactionEntry() {
   });
 
   const [isLoading, setIsLoading] = useState(isEditMode);
+
+  const [showAccountModal, setShowAccountModal] = useState(false);
+  const [showChartAccountModal, setShowChartAccountModal] = useState(false);
 
   const [autoBalance, setAutoBalance] = useState(false);
   const [offsetAccountId, setOffsetAccountId] = useState("");
@@ -541,14 +549,36 @@ function BulkTransactionEntry() {
                 <h3 className="text-lg font-medium">Transaction Entries</h3>
               </div>
 
-              <Button
-                type="button"
-                onClick={addEntry}
-                className="flex items-center"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Entry
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowAccountModal(true)}
+                  className="flex items-center"
+                >
+                  <Building2 className="h-4 w-4 mr-1" />
+                  New Account
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowChartAccountModal(true)}
+                  className="flex items-center"
+                >
+                  <BookOpen className="h-4 w-4 mr-1" />
+                  New Chart
+                </Button>
+                <Button
+                  type="button"
+                  onClick={addEntry}
+                  className="flex items-center"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Entry
+                </Button>
+              </div>
             </div>
           </CardHeader>
 
@@ -778,6 +808,26 @@ function BulkTransactionEntry() {
           </CardFooter>
         </Card>
       </form>
+      <FormDialog
+        open={showAccountModal}
+        onOpenChange={setShowAccountModal}
+        title="Add Account"
+      >
+        <AccountCreateForm
+          onCancel={() => setShowAccountModal(false)}
+          onSuccess={() => setShowAccountModal(false)}
+        />
+      </FormDialog>
+      <FormDialog
+        open={showChartAccountModal}
+        onOpenChange={setShowChartAccountModal}
+        title="Add Chart of Account"
+      >
+        <ChartOfAccountCreateForm
+          onCancel={() => setShowChartAccountModal(false)}
+          onSuccess={() => setShowChartAccountModal(false)}
+        />
+      </FormDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `FormDialog` component for showing forms in a modal
- create quick create forms for Accounts and Chart of Accounts
- expose buttons on BulkTransactionEntry to open these forms

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cf2371ec8326aec68e48dbc2c7aa