### PR TITLE
Fix account balance parsing

### DIFF
--- a/src/hooks/useAccountingReports.ts
+++ b/src/hooks/useAccountingReports.ts
@@ -156,9 +156,9 @@ export function useAccountingReports() {
             p_account_id: accountId,
             p_end_date: endDate
           });
-          
+
           if (error) throw error;
-          return data || 0;
+          return data?.balance ?? 0;
         } catch (error) {
           console.error(`Error fetching balance for account ${accountId}:`, error);
           addMessage({

--- a/src/hooks/useChartOfAccounts.ts
+++ b/src/hooks/useChartOfAccounts.ts
@@ -232,9 +232,9 @@ export function useChartOfAccounts() {
             p_account_id: accountId,
             p_end_date: asOfDate || new Date().toISOString().split('T')[0]
           });
-          
+
           if (error) throw error;
-          return data;
+          return data?.balance ?? 0;
         } catch (error) {
           console.error(`Error fetching balance for account ${accountId}:`, error);
           addMessage({


### PR DESCRIPTION
## Summary
- parse RPC response object when loading account balances

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857e09a429c8326ae821188961013c5