### PR TITLE
Fix account balance sign

### DIFF
--- a/src/utils/accounting.ts
+++ b/src/utils/accounting.ts
@@ -1,0 +1,27 @@
+export interface Transaction {
+  debit?: number | null;
+  credit?: number | null;
+}
+
+/**
+ * Calculate balance for an account based on its type.
+ * Assets and expenses increase with debits while liabilities and equity
+ * increase with credits.
+ */
+export function calculateAccountBalance(
+  accountType: string,
+  transactions: Transaction[]
+): number {
+  return transactions.reduce((sum, tx) => {
+    const debit = tx.debit ?? 0;
+    const credit = tx.credit ?? 0;
+    if (accountType === 'asset' || accountType === 'expense') {
+      return sum + debit - credit;
+    }
+    if (accountType === 'liability' || accountType === 'equity') {
+      return sum + credit - debit;
+    }
+    // default behaviour mirrors assets
+    return sum + debit - credit;
+  }, 0);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from './errorHandler';
 export * from './queryErrorHandler';
 export * from './storage';
 export * from './supabaseErrorHandler';
+export * from './accounting';

--- a/supabase/migrations/20250620130000_accounting_reports.sql
+++ b/supabase/migrations/20250620130000_accounting_reports.sql
@@ -130,7 +130,13 @@ AS $$
 DECLARE
   v_balance numeric;
 BEGIN
-  SELECT COALESCE(SUM(ft.debit - ft.credit), 0)
+  SELECT COALESCE(SUM(
+      CASE
+        WHEN a.account_type = 'asset' THEN COALESCE(ft.debit,0) - COALESCE(ft.credit,0)
+        WHEN a.account_type IN ('liability','equity') THEN COALESCE(ft.credit,0) - COALESCE(ft.debit,0)
+        ELSE COALESCE(ft.debit,0) - COALESCE(ft.credit,0)
+      END
+    ), 0)
   INTO v_balance
   FROM financial_transactions ft
   JOIN chart_of_accounts a ON ft.account_id = a.id

--- a/tests/accountingUtils.test.ts
+++ b/tests/accountingUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { calculateAccountBalance, Transaction } from '../src/utils/accounting';
+
+describe('calculateAccountBalance', () => {
+  it('returns positive balance for liability when credits exceed debits', () => {
+    const txs: Transaction[] = [
+      { credit: 200 },
+      { debit: 50 }
+    ];
+    const result = calculateAccountBalance('liability', txs);
+    expect(result).toBe(150);
+  });
+
+  it('returns negative balance for asset when credits exceed debits', () => {
+    const txs: Transaction[] = [
+      { debit: 100 },
+      { credit: 150 }
+    ];
+    const result = calculateAccountBalance('asset', txs);
+    expect(result).toBe(-50);
+  });
+});


### PR DESCRIPTION
## Summary
- adjust `get_account_balance` so credit balances for liability/equity are positive
- expose new accounting helper
- test account balance helper logic

## Testing
- `supabase db reset` *(fails: command not found)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685840eb9108832685d89166e20325c2