### PR TITLE
Add account link to FinancialSource model

### DIFF
--- a/src/adapters/financialSource.adapter.ts
+++ b/src/adapters/financialSource.adapter.ts
@@ -24,12 +24,21 @@ export class FinancialSourceAdapter
     description,
     source_type,
     account_number,
+    account_id,
     is_active,
     created_by,
     updated_by,
     created_at,
     updated_at
   `;
+
+  protected defaultRelationships: QueryOptions['relationships'] = [
+    {
+      table: 'chart_of_accounts',
+      foreignKey: 'account_id',
+      select: ['id', 'code', 'name']
+    }
+  ];
 
   protected override async onBeforeCreate(data: Partial<FinancialSource>): Promise<Partial<FinancialSource>> {
     // Set default values

--- a/src/models/financialSource.model.ts
+++ b/src/models/financialSource.model.ts
@@ -1,4 +1,5 @@
 import { BaseModel } from './base.model';
+import type { ChartOfAccount } from './chartOfAccount.model';
 
 export type SourceType = 'bank' | 'fund' | 'wallet' | 'cash' | 'online' | 'other';
 
@@ -8,5 +9,7 @@ export interface FinancialSource extends BaseModel {
   description: string | null;
   source_type: SourceType;
   account_number: string | null;
+  account_id: string | null;
+  account?: ChartOfAccount;
   is_active: boolean;
 }

--- a/src/validators/financialSource.validator.ts
+++ b/src/validators/financialSource.validator.ts
@@ -6,6 +6,10 @@ export class FinancialSourceValidator {
       throw new Error('Source name is required');
     }
 
+    if (!data.account_id?.trim()) {
+      throw new Error('Account ID is required');
+    }
+
     if (data.source_type !== undefined) {
       const validTypes = ['bank', 'fund', 'wallet', 'cash', 'online', 'other'];
       if (!validTypes.includes(data.source_type)) {


### PR DESCRIPTION
## Summary
- add `account_id` and related chart account in FinancialSource model
- expose account info in FinancialSource adapter
- require `account_id` in financial source validator

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858486bd0708326a099928588023b1c