### PR TITLE
Refactor settings UI components

### DIFF
--- a/src/pages/settings/Administration.tsx
+++ b/src/pages/settings/Administration.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
 import { UserCog, Shield, Building2 } from 'lucide-react';
 import { usePermissions } from '../../hooks/usePermissions';
-import { Card } from '../../components/ui/Card';
+import { Card } from '../../components/ui2/card';
 
 // Import admin pages
 import Users from '../admin/Users';

--- a/src/pages/settings/AuditLog.tsx
+++ b/src/pages/settings/AuditLog.tsx
@@ -2,12 +2,24 @@ import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { format, startOfDay, endOfDay, startOfWeek, endOfWeek, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns';
-import { Card } from '../../components/ui/Card';
-import { Input } from '../../components/ui/Input';
-import { Select } from '../../components/ui/Select';
-import { Button } from '../../components/ui/Button';
-import { Table, TableHeader, TableBody, TableRow, TableCell } from '../../components/ui/Table';
-import { Badge } from '../../components/ui/Badge';
+import { Card } from '../../components/ui2/card';
+import { Input } from '../../components/ui2/input';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem
+} from '../../components/ui2/select';
+import { Button } from '../../components/ui2/button';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableCell
+} from '../../components/ui2/table';
+import { Badge } from '../../components/ui2/badge';
 import {
   Calendar,
   Filter,
@@ -17,8 +29,6 @@ import {
   Loader2,
   History,
   Users,
-  ChevronDown,
-  ChevronUp,
   AlertTriangle,
   CheckCircle2,
   Pencil,
@@ -194,18 +204,20 @@ function AuditLog() {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
               <Select
-                label="Date Range"
                 value={dateRange}
-                onChange={(e) => handleDateRangeChange(e.target.value as DateRange)}
-                icon={<Calendar />}
-                options={[
-                  { value: 'daily', label: 'Today' },
-                  { value: 'weekly', label: 'This Week' },
-                  { value: 'monthly', label: 'This Month' },
-                  { value: 'yearly', label: 'This Year' },
-                  { value: 'custom', label: 'Custom Range' },
-                ]}
-              />
+                onValueChange={(value) => handleDateRangeChange(value as DateRange)}
+              >
+                <SelectTrigger label="Date Range" icon={<Calendar />}> 
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="daily">Today</SelectItem>
+                  <SelectItem value="weekly">This Week</SelectItem>
+                  <SelectItem value="monthly">This Month</SelectItem>
+                  <SelectItem value="yearly">This Year</SelectItem>
+                  <SelectItem value="custom">Custom Range</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             {dateRange === 'custom' && (
@@ -230,33 +242,31 @@ function AuditLog() {
             )}
 
             <div>
-              <Select
-                label="Action"
-                value={actionFilter}
-                onChange={(e) => setActionFilter(e.target.value)}
-                icon={<Filter />}
-                options={[
-                  { value: 'all', label: 'All Actions' },
-                  { value: 'create', label: 'Create' },
-                  { value: 'update', label: 'Update' },
-                  { value: 'delete', label: 'Delete' },
-                ]}
-              />
+              <Select value={actionFilter} onValueChange={setActionFilter}>
+                <SelectTrigger label="Action" icon={<Filter />}> 
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Actions</SelectItem>
+                  <SelectItem value="create">Create</SelectItem>
+                  <SelectItem value="update">Update</SelectItem>
+                  <SelectItem value="delete">Delete</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div>
-              <Select
-                label="Entity Type"
-                value={entityFilter}
-                onChange={(e) => setEntityFilter(e.target.value)}
-                icon={<Filter />}
-                options={[
-                  { value: 'all', label: 'All Entities' },
-                  { value: 'member', label: 'Members' },
-                  { value: 'transaction', label: 'Transactions' },
-                  { value: 'budget', label: 'Budgets' },
-                ]}
-              />
+              <Select value={entityFilter} onValueChange={setEntityFilter}>
+                <SelectTrigger label="Entity Type" icon={<Filter />}> 
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Entities</SelectItem>
+                  <SelectItem value="member">Members</SelectItem>
+                  <SelectItem value="transaction">Transactions</SelectItem>
+                  <SelectItem value="budget">Budgets</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <div>

--- a/src/pages/settings/Privacy.tsx
+++ b/src/pages/settings/Privacy.tsx
@@ -1,77 +1,85 @@
 import React from 'react';
-import { Card } from '../../components/ui/Card';
+import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Shield } from 'lucide-react';
 
 function Privacy() {
   return (
     <div className="space-y-8">
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
-          <Shield className="h-5 w-5 mr-2 text-primary-600" />
-          Information We Collect
-        </h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold flex items-center">
+            <Shield className="h-5 w-5 mr-2 text-primary-600" />
+            Information We Collect
+          </h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2">
           <p>
             We collect information that you provide directly to us, including personal information such as:
           </p>
-          <ul className="list-disc ml-6 mt-2 space-y-1">
+          <ul className="list-disc ml-6 space-y-1">
             <li>Names and contact information</li>
             <li>Email addresses and phone numbers</li>
             <li>Membership and attendance records</li>
             <li>Financial contribution data</li>
             <li>Ministry participation information</li>
           </ul>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">How We Use Your Information</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">How We Use Your Information</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2">
           <p>We use the information we collect to:</p>
-          <ul className="list-disc ml-6 mt-2 space-y-1">
+          <ul className="list-disc ml-6 space-y-1">
             <li>Provide and maintain our church administration services</li>
             <li>Communicate with you about church activities and events</li>
             <li>Process donations and maintain accurate financial records</li>
             <li>Manage membership and attendance records</li>
             <li>Facilitate ministry and volunteer coordination</li>
           </ul>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">Information Sharing and Security</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
-          <p className="mb-4">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">Information Sharing and Security</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2">
+          <p className="mb-2">
             We do not sell or share your personal information with third parties except as necessary to provide our services or as required by law.
           </p>
           <p>
             We implement appropriate technical and organizational security measures to protect your personal information, including:
           </p>
-          <ul className="list-disc ml-6 mt-2 space-y-1">
+          <ul className="list-disc ml-6 space-y-1">
             <li>Encryption of sensitive data</li>
             <li>Secure access controls</li>
             <li>Regular security assessments</li>
             <li>Staff training on data protection</li>
           </ul>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">Your Rights and Choices</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">Your Rights and Choices</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2">
           <p>You have the right to:</p>
-          <ul className="list-disc ml-6 mt-2 space-y-1">
+          <ul className="list-disc ml-6 space-y-1">
             <li>Access your personal information</li>
             <li>Correct inaccurate or incomplete information</li>
             <li>Request deletion of your information</li>
             <li>Opt-out of certain communications</li>
             <li>File a complaint with relevant authorities</li>
           </ul>
-          <p className="mt-4">
+          <p>
             Contact your church administrator to exercise these rights or for any privacy-related concerns.
           </p>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/pages/settings/Terms.tsx
+++ b/src/pages/settings/Terms.tsx
@@ -1,39 +1,46 @@
 import React from 'react';
 import { FileText } from 'lucide-react';
+import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 
 function Terms() {
   return (
     <div className="space-y-8">
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
-          <FileText className="h-5 w-5 mr-2 text-primary-600" />
-          Acceptance of Terms
-        </h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold flex items-center">
+            <FileText className="h-5 w-5 mr-2 text-primary-600" />
+            Acceptance of Terms
+          </h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground">
           <p>
             By accessing and using this church administration system, you agree to be bound by these Terms of Service and all applicable laws and regulations. If you do not agree with any of these terms, you are prohibited from using the service.
           </p>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">User Responsibilities</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
-          <p className="mb-4">Users must:</p>
-          <ul className="list-disc ml-6 space-y-2">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">User Responsibilities</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-2">
+          <p className="mb-2">Users must:</p>
+          <ul className="list-disc ml-6 space-y-1">
             <li>Maintain the confidentiality of their account credentials</li>
             <li>Use the system only for authorized church administration purposes</li>
             <li>Respect the privacy and rights of other users</li>
             <li>Comply with all applicable laws and regulations</li>
             <li>Report any security concerns or unauthorized access</li>
           </ul>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">System Usage and Data Privacy</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
-          <div className="mb-4">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">System Usage and Data Privacy</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-4">
+          <div>
             <h5 className="font-medium mb-2">Acceptable Use</h5>
             <p>
               The church administration system is provided "as is" and is to be used solely for legitimate church administration purposes. Any unauthorized use or abuse of the system may result in immediate termination of access.
@@ -45,13 +52,15 @@ function Terms() {
               Users agree to handle all personal and sensitive information in accordance with applicable privacy laws and church policies. This includes maintaining confidentiality and using data only for authorized purposes.
             </p>
           </div>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">Termination and Changes</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
-          <div className="mb-4">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">Termination and Changes</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground space-y-4">
+          <div>
             <h5 className="font-medium mb-2">Account Termination</h5>
             <p>
               Access to the system may be terminated for violations of these terms or at the discretion of church administration. Users will be notified of any such action.
@@ -63,17 +72,19 @@ function Terms() {
               We reserve the right to modify these terms at any time. Users will be notified of significant changes, and continued use of the system constitutes acceptance of updated terms.
             </p>
           </div>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
 
-      <section>
-        <h4 className="text-lg font-semibold text-gray-900 mb-4">Contact Information</h4>
-        <div className="bg-gray-50 rounded-lg p-4 text-gray-600 leading-relaxed">
+      <Card>
+        <CardHeader>
+          <h4 className="text-lg font-semibold">Contact Information</h4>
+        </CardHeader>
+        <CardContent className="text-muted-foreground">
           <p>
             For questions about these Terms of Service or to report violations, please contact your church administrator or system support team.
           </p>
-        </div>
-      </section>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/pages/settings/Usage.tsx
+++ b/src/pages/settings/Usage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { Users, DollarSign, AlertCircle, CheckCircle2 } from 'lucide-react';
-import { Progress } from '../../components/ui/Progress';
+import { Progress } from '../../components/ui2/progress';
 
 type UsageStats = {
   members: {
@@ -95,9 +95,9 @@ function Usage() {
   }
 
   const getMeterColor = (used: number, limit: number) => {
-    if (limit === -1) return 'primary';
+    if (limit === -1) return 'default';
     const percentage = (used / limit) * 100;
-    if (percentage >= 90) return 'danger';
+    if (percentage >= 90) return 'destructive';
     if (percentage >= 75) return 'warning';
     return 'success';
   };


### PR DESCRIPTION
## Summary
- switch Settings pages to `ui2` components for consistent styling
- modernize AuditLog filters with new Select components
- restyle Privacy and Terms content using `Card` layout
- adjust usage meter styling

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68584cf31d688326bc8d0e23a15f32c1