### PR TITLE
Fix navigate hook

### DIFF
--- a/src/pages/finances/JournalEntryForm.tsx
+++ b/src/pages/finances/JournalEntryForm.tsx
@@ -25,7 +25,7 @@ import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 
 function JournalEntryForm() {
-  const navigate = navigate();
+  const navigate = useNavigate();
   const { currency } = useCurrencyStore();
   const { useCreateJournalEntry } = useJournalEntry();
   const { useAccountOptions } = useChartOfAccounts();


### PR DESCRIPTION
## Summary
- fix useNavigate initialization in JournalEntryForm

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585224f4e883268d78c2a1ce541066