### PR TITLE
Fix useCreate to pass fieldsToRemove

### DIFF
--- a/src/hooks/useBaseRepository.ts
+++ b/src/hooks/useBaseRepository.ts
@@ -27,7 +27,7 @@ export function useBaseRepository<T extends BaseModel>(
                      relations?: Record<string, any[]>,
                      fieldsToRemove?: string[]
                    }) => {
-        return repository.create(data, relations);
+        return repository.create(data, relations, fieldsToRemove);
       },
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: [queryKey] });


### PR DESCRIPTION
## Summary
- forward `fieldsToRemove` in `useCreate`
- confirm update behavior already forwards `fieldsToRemove`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68585229dfcc8326b4f30ec82e82d0d3