### PR TITLE
Use category utils for transaction filter

### DIFF
--- a/src/components/filters/CategoryFilter.tsx
+++ b/src/components/filters/CategoryFilter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
+import { categoryUtils } from '../../utils/categoryUtils';
 import { Select } from '../ui/Select';
 import { Tag, Loader2 } from 'lucide-react';
 
@@ -13,13 +13,22 @@ interface CategoryFilterProps {
 export function CategoryFilter({ value, onChange, transactionType }: CategoryFilterProps) {
   // Fetch categories from database
   const { data: categories, isLoading } = useQuery({
-    queryKey: ['transaction-categories'],
+    queryKey: ['transaction-categories', transactionType],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .rpc('get_enum_values', { enum_name: 'financial_transaction_category' });
+      if (transactionType === 'income') {
+        return categoryUtils.getCategories('income_transaction');
+      }
 
-      if (error) throw error;
-      return data as string[];
+      if (transactionType === 'expense') {
+        return categoryUtils.getCategories('expense_transaction');
+      }
+
+      const [income, expense] = await Promise.all([
+        categoryUtils.getCategories('income_transaction'),
+        categoryUtils.getCategories('expense_transaction'),
+      ]);
+
+      return [...income, ...expense];
     },
   });
 
@@ -27,50 +36,31 @@ export function CategoryFilter({ value, onChange, transactionType }: CategoryFil
   const categoryOptions = React.useMemo(() => {
     if (!categories) return [{ value: 'all', label: 'All Categories' }];
 
-    const formatCategory = (category: string) => ({
-      value: category,
-      label: category.split('_').map(word => 
-        word.charAt(0).toUpperCase() + word.slice(1)
-      ).join(' ')
+    const formatCategory = (category: { id: string; name: string }) => ({
+      value: category.id,
+      label: category.name,
     });
 
-    const incomeCategories = categories.filter(cat => 
-      ['tithe', 'first_fruit_offering', 'love_offering', 'mission_offering', 
-       'mission_pledge', 'building_offering', 'lot_offering'].includes(cat)
-    ).map(formatCategory);
+    const incomeCategories = categories
+      .filter((cat) => cat.type === 'income_transaction')
+      .map(formatCategory);
 
-    const expenseCategories = categories.filter(cat => 
-      ['ministry_expense', 'payroll', 'utilities', 'maintenance', 
-       'events', 'missions', 'education'].includes(cat)
-    ).map(formatCategory);
+    const expenseCategories = categories
+      .filter((cat) => cat.type === 'expense_transaction')
+      .map(formatCategory);
 
-    const otherCategories = categories.filter(cat => 
-      cat === 'other'
-    ).map(formatCategory);
-
-    // Show only relevant categories based on the transaction type
     if (transactionType === 'income') {
-      return [
-        { value: 'all', label: 'All Categories' },
-        ...incomeCategories,
-        ...otherCategories,
-      ];
+      return [{ value: 'all', label: 'All Categories' }, ...incomeCategories];
     }
 
     if (transactionType === 'expense') {
-      return [
-        { value: 'all', label: 'All Categories' },
-        ...expenseCategories,
-        ...otherCategories,
-      ];
+      return [{ value: 'all', label: 'All Categories' }, ...expenseCategories];
     }
 
-    // Return all categories if no specific transaction type is provided
     return [
       { value: 'all', label: 'All Categories' },
       ...incomeCategories,
       ...expenseCategories,
-      ...otherCategories,
     ];
   }, [categories, transactionType]);
 


### PR DESCRIPTION
## Summary
- rely on `categoryUtils.getCategories` instead of the enum RPC
- drop static category code arrays and map options dynamically

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589001be2c8326891af26649ce1888