### PR TITLE
Implement fund management pages

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -8,6 +8,7 @@ import {
   FileText,
   CreditCard,
   History,
+  Wallet,
   LucideIcon,
 } from 'lucide-react';
 
@@ -75,6 +76,11 @@ export const navigation: NavItem[] = [
         name: 'Budgets',
         href: '/finances/budgets',
         icon: CreditCard,
+      },
+      {
+        name: 'Funds',
+        href: '/finances/funds',
+        icon: Wallet,
       },
       {
         name: 'Reports',

--- a/src/pages/Finances.tsx
+++ b/src/pages/Finances.tsx
@@ -14,6 +14,9 @@ const BulkExpenseEntry = React.lazy(() => import('./finances/BulkExpenseEntry'))
 const BudgetList = React.lazy(() => import('./finances/BudgetList'));
 const BudgetAdd = React.lazy(() => import('./finances/BudgetAdd'));
 const BudgetProfile = React.lazy(() => import('./finances/BudgetProfile'));
+const FundList = React.lazy(() => import('./finances/FundList'));
+const FundAddEdit = React.lazy(() => import('./finances/FundAddEdit'));
+const FundProfile = React.lazy(() => import('./finances/FundProfile'));
 const Reports = React.lazy(() => import('./finances/Reports'));
 
 function LoadingSpinner() {
@@ -60,6 +63,10 @@ function Finances() {
         <Route path="budgets" element={<BudgetList />} />
         <Route path="budgets/add" element={<BudgetAdd />} />
         <Route path="budgets/:id" element={<BudgetProfile />} />
+        <Route path="funds" element={<FundList />} />
+        <Route path="funds/add" element={<FundAddEdit />} />
+        <Route path="funds/:id/edit" element={<FundAddEdit />} />
+        <Route path="funds/:id" element={<FundProfile />} />
         <Route path="reports" element={<Reports />} />
       </Routes>
     </Suspense>

--- a/src/pages/finances/FundAddEdit.tsx
+++ b/src/pages/finances/FundAddEdit.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useFundRepository } from '../../hooks/useFundRepository';
+import { Fund, FundType } from '../../models/fund.model';
+import { Card, CardHeader, CardContent } from '../../components/ui2/card';
+import { Input } from '../../components/ui2/input';
+import { Button } from '../../components/ui2/button';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
+import { ArrowLeft, Save, Loader2, AlertCircle } from 'lucide-react';
+
+function FundAddEdit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const { useQuery: useFundQuery, useCreate, useUpdate } = useFundRepository();
+
+  const [formData, setFormData] = useState<Partial<Fund>>({
+    name: '',
+    type: 'unrestricted',
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: fundData, isLoading: isFundLoading } = useFundQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: isEditMode,
+  });
+
+  const createMutation = useCreate();
+  const updateMutation = useUpdate();
+
+  useEffect(() => {
+    if (isEditMode && fundData?.data?.[0]) {
+      setFormData(fundData.data[0]);
+    }
+  }, [isEditMode, fundData]);
+
+  const handleInputChange = (field: keyof Fund, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!formData.name?.trim()) {
+      setError('Fund name is required');
+      return;
+    }
+
+    try {
+      if (isEditMode && id) {
+        await updateMutation.mutateAsync({ id, data: formData });
+        navigate(`/finances/funds/${id}`);
+      } else {
+        const result = await createMutation.mutateAsync({ data: formData });
+        navigate(`/finances/funds/${result.id}`);
+      }
+    } catch (err) {
+      console.error('Error saving fund:', err);
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  if (isEditMode && isFundLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <Button variant="ghost" onClick={() => navigate('/finances/funds')} className="flex items-center">
+          <ArrowLeft className="h-5 w-5 mr-2" />
+          Back to Funds
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium text-foreground">
+            {isEditMode ? 'Edit Fund' : 'Add New Fund'}
+          </h3>
+        </CardHeader>
+
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <Input
+                  label="Fund Name"
+                  required
+                  value={formData.name || ''}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  placeholder="Enter fund name"
+                />
+              </div>
+
+              <div className="sm:col-span-2">
+                <Select
+                  value={formData.type || 'unrestricted'}
+                  onValueChange={(value) => handleInputChange('type', value as FundType)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select Fund Type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="unrestricted">Unrestricted</SelectItem>
+                    <SelectItem value="restricted">Restricted</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {error && (
+              <div className="rounded-lg bg-destructive/15 p-4">
+                <div className="flex">
+                  <AlertCircle className="h-5 w-5 text-destructive" />
+                  <div className="ml-3">
+                    <h3 className="text-sm font-medium text-destructive">{error}</h3>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-end space-x-3">
+              <Button type="button" variant="outline" onClick={() => navigate('/finances/funds')}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+                {createMutation.isPending || updateMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="mr-2 h-4 w-4" />
+                    {isEditMode ? 'Update Fund' : 'Create Fund'}
+                  </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default FundAddEdit;

--- a/src/pages/finances/FundList.tsx
+++ b/src/pages/finances/FundList.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useFundRepository } from '../../hooks/useFundRepository';
+import { Fund } from '../../models/fund.model';
+import { Card, CardContent } from '../../components/ui2/card';
+import { Button } from '../../components/ui2/button';
+import { Input } from '../../components/ui2/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
+import { Badge } from '../../components/ui2/badge';
+import { DataGrid } from '../../components/ui2/mui-datagrid';
+import { GridColDef } from '@mui/x-data-grid';
+import { Plus, Search, Loader2 } from 'lucide-react';
+
+function FundList() {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const { useQuery: useFundsQuery } = useFundRepository();
+
+  const { data: result, isLoading } = useFundsQuery();
+  const funds = result?.data || [];
+
+  const filteredFunds = funds.filter((fund: Fund) => {
+    const matchesSearch = fund.name.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesType = typeFilter === 'all' || fund.type === typeFilter;
+    return matchesSearch && matchesType;
+  });
+
+  const columns: GridColDef[] = [
+    {
+      field: 'name',
+      headerName: 'Fund Name',
+      flex: 2,
+      minWidth: 200,
+    },
+    {
+      field: 'type',
+      headerName: 'Type',
+      flex: 1,
+      minWidth: 150,
+      renderCell: (params) => (
+        <Badge variant={params.value === 'restricted' ? 'destructive' : 'secondary'} className="capitalize">
+          {params.value}
+        </Badge>
+      ),
+    },
+  ];
+
+  const handleRowClick = (params: any) => {
+    navigate(`/finances/funds/${params.id}`);
+  };
+
+  const handlePageChange = (newPage: number) => setPage(newPage);
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPage(0);
+  };
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-foreground">Funds</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Manage designated and unrestricted funds.</p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <Link to="/finances/funds/add">
+            <Button variant="default" className="flex items-center">
+              <Plus className="h-4 w-4 mr-2" />
+              Add Fund
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-6 sm:flex sm:items-center sm:justify-between">
+        <div className="relative max-w-xs">
+          <Input
+            placeholder="Search funds..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            icon={<Search />}
+          />
+        </div>
+
+        <div className="mt-4 sm:mt-0">
+          <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="Filter by Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="restricted">Restricted</SelectItem>
+              <SelectItem value="unrestricted">Unrestricted</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <Card>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              </div>
+            ) : (
+              <DataGrid
+                columns={columns}
+                data={filteredFunds}
+                totalRows={filteredFunds.length}
+                loading={isLoading}
+                onPageChange={handlePageChange}
+                onPageSizeChange={handlePageSizeChange}
+                onRowClick={handleRowClick}
+                getRowId={(row) => row.id}
+                page={page}
+                pageSize={pageSize}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default FundList;

--- a/src/pages/finances/FundProfile.tsx
+++ b/src/pages/finances/FundProfile.tsx
@@ -1,0 +1,325 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useFundRepository } from '../../hooks/useFundRepository';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../../lib/supabase';
+import { Card, CardHeader, CardContent } from '../../components/ui2/card';
+import { Button } from '../../components/ui2/button';
+import { Badge } from '../../components/ui2/badge';
+import { Tabs } from '../../components/ui2/tabs';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../../components/ui2/alert-dialog';
+import {
+  ArrowLeft,
+  DollarSign,
+  Pencil,
+  Trash2,
+  Loader2,
+  AlertTriangle,
+} from 'lucide-react';
+
+const MAX_RETRIES = 3;
+const INITIAL_DELAY = 1000;
+
+function FundProfile() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [activeTab, setActiveTab] = useState('details');
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleteInProgress, setDeleteInProgress] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const { useQuery: useFundQuery, useDelete } = useFundRepository();
+
+  const { data: fundData, isLoading } = useFundQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: !!id,
+  });
+
+  const fund = fundData?.data?.[0];
+
+  const { data: transactionsData, isLoading: transactionsLoading } = useQuery({
+    queryKey: ['fund-transactions', id],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('financial_transactions')
+        .select(`
+          id,
+          type,
+          amount,
+          date,
+          description,
+          category:category_id (name)
+        `)
+        .eq('fund_id', id)
+        .order('date', { ascending: false })
+        .limit(5);
+      if (error) throw error;
+      return data;
+    },
+    enabled: !!id,
+  });
+
+  const deleteMutation = useDelete();
+
+  const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+  const handleDelete = async () => {
+    if (!id) return;
+    try {
+      setDeleteInProgress(true);
+      setDeleteError(null);
+      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          await deleteMutation.mutateAsync(id);
+          navigate('/finances/funds');
+          return;
+        } catch (error) {
+          if (attempt === MAX_RETRIES) {
+            throw error;
+          }
+          const delay = INITIAL_DELAY * Math.pow(2, attempt);
+          setRetryCount(attempt + 1);
+          setDeleteError(`Network error. Retrying in ${delay/1000} seconds... (Attempt ${attempt + 1}/${MAX_RETRIES})`);
+          await sleep(delay);
+        }
+      }
+    } catch (error) {
+      console.error('Error deleting fund:', error);
+      setDeleteError('Failed to delete fund after multiple attempts. Please check your internet connection or try again later.');
+    } finally {
+      setDeleteInProgress(false);
+      setRetryCount(0);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteDialog(false);
+    setDeleteError(null);
+    setRetryCount(0);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!fund) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center justify-center py-12">
+          <AlertTriangle className="h-12 w-12 text-warning mb-4" />
+          <h3 className="text-lg font-medium text-foreground mb-2">Fund Not Found</h3>
+          <Button onClick={() => navigate('/finances/funds')}>Go Back to Funds</Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <Button variant="ghost" onClick={() => navigate('/finances/funds')} className="flex items-center">
+          <ArrowLeft className="h-5 w-5 mr-2" />
+          Back to Funds
+        </Button>
+      </div>
+
+      <Card className="mb-6">
+        <CardContent className="p-6">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2 className="text-2xl font-bold text-foreground flex items-center">
+                {fund.name}
+                <Badge variant={fund.type === 'restricted' ? 'destructive' : 'secondary'} className="ml-3 capitalize">
+                  {fund.type}
+                </Badge>
+              </h2>
+            </div>
+            <div className="flex space-x-3">
+              <Button variant="outline" onClick={() => navigate(`/finances/funds/${id}/edit`)} className="flex items-center">
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+              <Button variant="destructive" onClick={() => setShowDeleteDialog(true)} className="flex items-center">
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="mb-6">
+        <Tabs
+          tabs={[
+            { id: 'details', label: 'Fund Details', icon: <DollarSign className="h-5 w-5" /> },
+            { id: 'transactions', label: 'Transactions', icon: <DollarSign className="h-5 w-5" /> },
+          ]}
+          activeTab={activeTab}
+          onChange={setActiveTab}
+          variant="enclosed"
+          size="sm"
+        />
+      </div>
+
+      <div className="space-y-6">
+        {activeTab === 'details' && (
+          <Card>
+            <CardHeader>
+              <h3 className="text-lg font-medium flex items-center">
+                <DollarSign className="h-5 w-5 mr-2 text-primary" />
+                Fund Details
+              </h3>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <dl className="divide-y divide-border">
+                <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Name</dt>
+                  <dd className="text-sm text-foreground col-span-2">{fund.name}</dd>
+                </div>
+                <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Type</dt>
+                  <dd className="text-sm text-foreground col-span-2 capitalize">{fund.type}</dd>
+                </div>
+                <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Created</dt>
+                  <dd className="text-sm text-foreground col-span-2">
+                    {new Date(fund.created_at).toLocaleDateString()} at {new Date(fund.created_at).toLocaleTimeString()}
+                  </dd>
+                </div>
+                <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Last Updated</dt>
+                  <dd className="text-sm text-foreground col-span-2">
+                    {new Date(fund.updated_at).toLocaleDateString()} at {new Date(fund.updated_at).toLocaleTimeString()}
+                  </dd>
+                </div>
+              </dl>
+            </CardContent>
+          </Card>
+        )}
+
+        {activeTab === 'transactions' && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-medium flex items-center">
+                  <DollarSign className="h-5 w-5 mr-2 text-primary" />
+                  Recent Transactions
+                </h3>
+                <Button variant="outline" size="sm" onClick={() => navigate('/finances/transactions')}>View All Transactions</Button>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {transactionsLoading ? (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                </div>
+              ) : transactionsData && transactionsData.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-border">
+                    <thead>
+                      <tr>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Date</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Category</th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Description</th>
+                        <th className="px-6 py-3 text-right text-xs font-medium text-muted-foreground uppercase tracking-wider">Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-background divide-y divide-border">
+                      {transactionsData.map((transaction) => (
+                        <tr key={transaction.id} className="hover:bg-muted/50">
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+                            {new Date(transaction.date).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            <Badge variant={transaction.type === 'income' ? 'success' : 'destructive'}>
+                              {transaction.type}
+                            </Badge>
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
+                            {transaction.category?.name || 'Uncategorized'}
+                          </td>
+                          <td className="px-6 py-4 text-sm text-foreground">{transaction.description}</td>
+                          <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-medium">
+                            <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
+                              {transaction.type === 'income' ? '+' : '-'}${transaction.amount.toFixed(2)}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <p className="text-muted-foreground">No transactions found for this fund.</p>
+                  <Button variant="outline" className="mt-4" onClick={() => navigate('/finances/transactions/add')}>
+                    Add Transaction
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="danger">Delete Fund</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this fund? This action cannot be undone.
+              {transactionsData && transactionsData.length > 0 && (
+                <div className="mt-2 p-2 bg-warning/10 border border-warning/20 rounded-md text-warning flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>
+                    This fund has {transactionsData.length} associated transactions.
+                    Deleting this fund may affect financial records.
+                  </span>
+                </div>
+              )}
+              {deleteError && (
+                <div className="mt-2 p-2 bg-destructive/10 border border-destructive/20 rounded-md text-destructive flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{deleteError}</span>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancelDelete} disabled={deleteInProgress}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={deleteInProgress}>
+              {deleteInProgress ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {retryCount > 0 ? `Retrying (${retryCount}/${MAX_RETRIES})...` : 'Deleting...'}
+                </>
+              ) : (
+                'Delete Fund'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export default FundProfile;


### PR DESCRIPTION
## Summary
- add FundList for viewing funds
- add FundAddEdit for managing funds
- add FundProfile for reviewing a fund
- wire fund routes in Finances section
- add Funds item to the navigation menu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858df1937248326b44c620a2f98e548