### PR TITLE
Fix fund form save and link to accounts

### DIFF
--- a/src/adapters/fund.adapter.ts
+++ b/src/adapters/fund.adapter.ts
@@ -22,13 +22,20 @@ export class FundAdapter
     id,
     name,
     type,
+    account_id,
     created_by,
     updated_by,
     created_at,
     updated_at
   `;
 
-  protected defaultRelationships: QueryOptions['relationships'] = [];
+  protected defaultRelationships: QueryOptions['relationships'] = [
+    {
+      table: 'chart_of_accounts',
+      foreignKey: 'account_id',
+      select: ['id', 'code', 'name']
+    }
+  ];
 
   protected override async onAfterCreate(data: Fund): Promise<void> {
     await this.auditService.logAuditEvent('create', 'fund', data.id, data);

--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -1,4 +1,5 @@
 import { BaseModel } from './base.model';
+import type { ChartOfAccount } from './chartOfAccount.model';
 
 export type FundType = 'restricted' | 'unrestricted';
 
@@ -6,4 +7,6 @@ export interface Fund extends BaseModel {
   id: string;
   name: string;
   type: FundType;
+  account_id: string | null;
+  account?: Pick<ChartOfAccount, 'id' | 'code' | 'name'>;
 }

--- a/src/pages/finances/FundAddEdit.tsx
+++ b/src/pages/finances/FundAddEdit.tsx
@@ -6,6 +6,9 @@ import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
+import { Combobox } from '../../components/ui2/combobox';
+import { Label } from '../../components/ui2/label';
+import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
 import { ArrowLeft, Save, Loader2, AlertCircle } from 'lucide-react';
 
 function FundAddEdit() {
@@ -14,10 +17,12 @@ function FundAddEdit() {
   const isEditMode = !!id;
 
   const { useQuery: useFundQuery, useCreate, useUpdate } = useFundRepository();
+  const { useAccountOptions } = useChartOfAccounts();
 
   const [formData, setFormData] = useState<Partial<Fund>>({
     name: '',
     type: 'unrestricted',
+    account_id: null,
   });
   const [error, setError] = useState<string | null>(null);
 
@@ -28,6 +33,7 @@ function FundAddEdit() {
 
   const createMutation = useCreate();
   const updateMutation = useUpdate();
+  const { data: accountOptions, isLoading: isAccountsLoading } = useAccountOptions();
 
   useEffect(() => {
     if (isEditMode && fundData?.data?.[0]) {
@@ -45,6 +51,11 @@ function FundAddEdit() {
 
     if (!formData.name?.trim()) {
       setError('Fund name is required');
+      return;
+    }
+
+    if (!formData.account_id) {
+      setError('Account is required');
       return;
     }
 
@@ -112,6 +123,23 @@ function FundAddEdit() {
                     <SelectItem value="restricted">Restricted</SelectItem>
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="sm:col-span-2">
+                <Label htmlFor="account_id">Chart of Account *</Label>
+                {isAccountsLoading ? (
+                  <div className="flex items-center space-x-2">
+                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                    <span className="text-sm text-muted-foreground">Loading accounts...</span>
+                  </div>
+                ) : (
+                  <Combobox
+                    options={accountOptions || []}
+                    value={formData.account_id || ''}
+                    onChange={(value) => handleInputChange('account_id', value)}
+                    placeholder="Select account"
+                  />
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- extend `Fund` model with account relation
- fetch fund account info in adapter
- add required chart of account selection in `FundAddEdit`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859291395d483269e7a0187469dd93b