### PR TITLE
Add migration for funds account_id

### DIFF
--- a/supabase/migrations/20250628101000_funds_account.sql
+++ b/supabase/migrations/20250628101000_funds_account.sql
@@ -1,0 +1,27 @@
+-- Add account_id column to funds
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'funds'
+      AND column_name = 'account_id'
+  ) THEN
+    ALTER TABLE funds
+      ADD COLUMN account_id uuid REFERENCES chart_of_accounts(id);
+  END IF;
+END $$;
+
+-- Create index for the column
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE tablename = 'funds'
+      AND indexname = 'funds_account_id_idx'
+  ) THEN
+    CREATE INDEX funds_account_id_idx
+      ON funds(account_id);
+  END IF;
+END $$;
+
+-- Add comment
+COMMENT ON COLUMN funds.account_id IS
+  'Chart of account linked to this fund';


### PR DESCRIPTION
## Summary
- add missing `account_id` column to `funds` table via migration

## Testing
- `npm run -s test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592ead24c08326849bcc21c8bd2c57