### PR TITLE
Add Fund validation and tests

### DIFF
--- a/src/repositories/fund.repository.ts
+++ b/src/repositories/fund.repository.ts
@@ -2,6 +2,8 @@ import { injectable, inject } from 'inversify';
 import { BaseRepository } from './base.repository';
 import { Fund } from '../models/fund.model';
 import type { IFundAdapter } from '../adapters/fund.adapter';
+import { NotificationService } from '../services/NotificationService';
+import { FundValidator } from '../validators/fund.validator';
 
 export interface IFundRepository extends BaseRepository<Fund> {}
 
@@ -12,5 +14,30 @@ export class FundRepository
 {
   constructor(@inject('IFundAdapter') adapter: IFundAdapter) {
     super(adapter);
+  }
+
+  protected override async beforeCreate(data: Partial<Fund>): Promise<Partial<Fund>> {
+    FundValidator.validate(data);
+    return this.formatFundData(data);
+  }
+
+  protected override async afterCreate(data: Fund): Promise<void> {
+    NotificationService.showSuccess(`Fund "${data.name}" created successfully`);
+  }
+
+  protected override async beforeUpdate(id: string, data: Partial<Fund>): Promise<Partial<Fund>> {
+    FundValidator.validate(data);
+    return this.formatFundData(data);
+  }
+
+  protected override async afterUpdate(data: Fund): Promise<void> {
+    NotificationService.showSuccess(`Fund "${data.name}" updated successfully`);
+  }
+
+  private formatFundData(data: Partial<Fund>): Partial<Fund> {
+    return {
+      ...data,
+      name: data.name?.trim(),
+    };
   }
 }

--- a/src/validators/fund.validator.ts
+++ b/src/validators/fund.validator.ts
@@ -1,0 +1,20 @@
+import { Fund } from '../models/fund.model';
+
+export class FundValidator {
+  static validate(data: Partial<Fund>): void {
+    if (data.name !== undefined && !data.name.trim()) {
+      throw new Error('Fund name is required');
+    }
+
+    if (!data.account_id?.toString().trim()) {
+      throw new Error('Account ID is required');
+    }
+
+    if (data.type !== undefined) {
+      const validTypes: Fund['type'][] = ['restricted', 'unrestricted'];
+      if (!validTypes.includes(data.type)) {
+        throw new Error('Invalid fund type. Must be one of: restricted, unrestricted');
+      }
+    }
+  }
+}

--- a/tests/fundRepositoryValidation.test.ts
+++ b/tests/fundRepositoryValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { FundRepository } from '../src/repositories/fund.repository';
+import type { IFundAdapter } from '../src/adapters/fund.adapter';
+import type { Fund } from '../src/models/fund.model';
+
+class TestFundRepository extends FundRepository {
+  public async runBeforeCreate(data: Partial<Fund>) {
+    return this.beforeCreate(data);
+  }
+  public async runBeforeUpdate(id: string, data: Partial<Fund>) {
+    return this.beforeUpdate(id, data);
+  }
+}
+
+describe('FundRepository validation', () => {
+  it('throws error for invalid data on create', async () => {
+    const repo = new TestFundRepository({} as IFundAdapter);
+    await expect(repo.runBeforeCreate({ name: '', account_id: '' })).rejects.toThrow('Fund name is required');
+  });
+
+  it('throws error for invalid fund type', async () => {
+    const repo = new TestFundRepository({} as IFundAdapter);
+    await expect(
+      repo.runBeforeCreate({ name: 'Test', account_id: 'a', type: 'bad' as any })
+    ).rejects.toThrow('Invalid fund type');
+  });
+
+  it('formats data on create', async () => {
+    const repo = new TestFundRepository({} as IFundAdapter);
+    const data = await repo.runBeforeCreate({ name: '  My Fund ', account_id: 'a', type: 'restricted' });
+    expect(data.name).toBe('My Fund');
+  });
+
+  it('validates on update', async () => {
+    const repo = new TestFundRepository({} as IFundAdapter);
+    await expect(
+      repo.runBeforeUpdate('1', { name: '', account_id: '' })
+    ).rejects.toThrow('Fund name is required');
+  });
+});


### PR DESCRIPTION
## Summary
- create FundValidator with basic checks
- enforce Fund validation in repository lifecycle hooks
- show success notifications for create and update
- add tests for FundRepository validation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859312146ac8326b8c36663250959ac