### PR TITLE
Add offering batch infrastructure

### DIFF
--- a/src/adapters/offeringBatch.adapter.ts
+++ b/src/adapters/offeringBatch.adapter.ts
@@ -1,0 +1,66 @@
+import 'reflect-metadata';
+import { injectable, inject } from 'inversify';
+import { BaseAdapter, QueryOptions } from './base.adapter';
+import { OfferingBatch } from '../models/offeringBatch.model';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/types';
+import { supabase } from '../lib/supabase';
+
+export interface IOfferingBatchAdapter extends BaseAdapter<OfferingBatch> {}
+
+@injectable()
+export class OfferingBatchAdapter
+  extends BaseAdapter<OfferingBatch>
+  implements IOfferingBatchAdapter
+{
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
+    super();
+  }
+  protected tableName = 'offering_batches';
+
+  protected defaultSelect = `
+    id,
+    service_description,
+    batch_date,
+    total_amount,
+    created_by,
+    updated_by,
+    created_at,
+    updated_at
+  `;
+
+  protected defaultRelationships: QueryOptions['relationships'] = [];
+
+  protected override async onBeforeCreate(
+    data: Partial<OfferingBatch>
+  ): Promise<Partial<OfferingBatch>> {
+    if (data.total_amount === undefined) {
+      data.total_amount = 0;
+    }
+    return data;
+  }
+
+  protected override async onAfterCreate(data: OfferingBatch): Promise<void> {
+    await this.auditService.logAuditEvent('create', 'offering_batch', data.id, data);
+  }
+
+  protected override async onAfterUpdate(data: OfferingBatch): Promise<void> {
+    await this.auditService.logAuditEvent('update', 'offering_batch', data.id, data);
+  }
+
+  protected override async onBeforeDelete(id: string): Promise<void> {
+    const { data: tx, error } = await supabase
+      .from('financial_transactions')
+      .select('id')
+      .eq('batch_id', id)
+      .limit(1);
+    if (error) throw error;
+    if (tx?.length) {
+      throw new Error('Cannot delete batch with existing financial transactions');
+    }
+  }
+
+  protected override async onAfterDelete(id: string): Promise<void> {
+    await this.auditService.logAuditEvent('delete', 'offering_batch', id, { id });
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -13,3 +13,4 @@ export * from './usePermissions';
 export * from './useSubscriptionLimits';
 export * from './useThemeSwitcher';
 export * from './useFundRepository';
+export * from './useOfferingBatchRepository';

--- a/src/hooks/useOfferingBatchRepository.ts
+++ b/src/hooks/useOfferingBatchRepository.ts
@@ -1,0 +1,9 @@
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { IOfferingBatchRepository } from '../repositories/offeringBatch.repository';
+import { useBaseRepository } from './useBaseRepository';
+
+export function useOfferingBatchRepository() {
+  const repository = container.get<IOfferingBatchRepository>(TYPES.IOfferingBatchRepository);
+  return useBaseRepository(repository, 'Offering Batch', 'offering_batches');
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -19,6 +19,10 @@ import {
   type IFinancialTransactionHeaderAdapter
 } from '../adapters/financialTransactionHeader.adapter';
 import { FundAdapter, type IFundAdapter } from '../adapters/fund.adapter';
+import {
+  OfferingBatchAdapter,
+  type IOfferingBatchAdapter,
+} from '../adapters/offeringBatch.adapter';
 import { MemberRepository, type IMemberRepository } from '../repositories/member.repository';
 import {
   NotificationRepository,
@@ -38,6 +42,10 @@ import {
   type IFinancialTransactionHeaderRepository
 } from '../repositories/financialTransactionHeader.repository';
 import { FundRepository, type IFundRepository } from '../repositories/fund.repository';
+import {
+  OfferingBatchRepository,
+  type IOfferingBatchRepository,
+} from '../repositories/offeringBatch.repository';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { TYPES } from './types';
 
@@ -71,6 +79,10 @@ container
 container
   .bind<IFundAdapter>(TYPES.IFundAdapter)
   .to(FundAdapter)
+  .inSingletonScope();
+container
+  .bind<IOfferingBatchAdapter>(TYPES.IOfferingBatchAdapter)
+  .to(OfferingBatchAdapter)
   .inSingletonScope();
 
 // Register services
@@ -109,6 +121,10 @@ container
 container
   .bind<IFundRepository>(TYPES.IFundRepository)
   .to(FundRepository)
+  .inSingletonScope();
+container
+  .bind<IOfferingBatchRepository>(TYPES.IOfferingBatchRepository)
+  .to(OfferingBatchRepository)
   .inSingletonScope();
 
 export { container };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export const TYPES = {
   IChartOfAccountAdapter: 'IChartOfAccountAdapter',
   IFinancialTransactionHeaderAdapter: 'IFinancialTransactionHeaderAdapter',
   IFundAdapter: 'IFundAdapter',
+  IOfferingBatchAdapter: 'IOfferingBatchAdapter',
   IMemberRepository: 'IMemberRepository',
   INotificationRepository: 'INotificationRepository',
   IAccountRepository: 'IAccountRepository',
@@ -13,5 +14,6 @@ export const TYPES = {
   IChartOfAccountRepository: 'IChartOfAccountRepository',
   IFinancialTransactionHeaderRepository: 'IFinancialTransactionHeaderRepository',
   IFundRepository: 'IFundRepository',
+  IOfferingBatchRepository: 'IOfferingBatchRepository',
   AuditService: 'AuditService'
 };

--- a/src/repositories/offeringBatch.repository.ts
+++ b/src/repositories/offeringBatch.repository.ts
@@ -1,0 +1,52 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { OfferingBatch } from '../models/offeringBatch.model';
+import type { IOfferingBatchAdapter } from '../adapters/offeringBatch.adapter';
+import { NotificationService } from '../services/NotificationService';
+import { OfferingBatchValidator } from '../validators/offeringBatch.validator';
+
+export interface IOfferingBatchRepository extends BaseRepository<OfferingBatch> {}
+
+@injectable()
+export class OfferingBatchRepository
+  extends BaseRepository<OfferingBatch>
+  implements IOfferingBatchRepository
+{
+  constructor(@inject('IOfferingBatchAdapter') adapter: IOfferingBatchAdapter) {
+    super(adapter);
+  }
+
+  protected override async beforeCreate(
+    data: Partial<OfferingBatch>
+  ): Promise<Partial<OfferingBatch>> {
+    OfferingBatchValidator.validate(data);
+    return data;
+  }
+
+  protected override async afterCreate(data: OfferingBatch): Promise<void> {
+    NotificationService.showSuccess('Offering batch created successfully');
+  }
+
+  protected override async beforeUpdate(
+    id: string,
+    data: Partial<OfferingBatch>
+  ): Promise<Partial<OfferingBatch>> {
+    OfferingBatchValidator.validate(data);
+    return data;
+  }
+
+  protected override async afterUpdate(data: OfferingBatch): Promise<void> {
+    NotificationService.showSuccess('Offering batch updated successfully');
+  }
+
+  protected override async beforeDelete(id: string): Promise<void> {
+    const batch = await this.findById(id);
+    if (!batch) {
+      throw new Error('Offering batch not found');
+    }
+  }
+
+  protected override async afterDelete(id: string): Promise<void> {
+    NotificationService.showSuccess('Offering batch deleted successfully');
+  }
+}

--- a/src/validators/offeringBatch.validator.ts
+++ b/src/validators/offeringBatch.validator.ts
@@ -1,0 +1,15 @@
+import { OfferingBatch } from '../models/offeringBatch.model';
+
+export class OfferingBatchValidator {
+  static validate(data: Partial<OfferingBatch>): void {
+    if (data.batch_date !== undefined && !data.batch_date) {
+      throw new Error('Batch date is required');
+    }
+    if (
+      data.total_amount !== undefined &&
+      (isNaN(Number(data.total_amount)) || data.total_amount === null)
+    ) {
+      throw new Error('Total amount must be a valid number');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement OfferingBatchAdapter
- implement OfferingBatchRepository and validator
- expose useOfferingBatchRepository hook and export from hooks
- register OfferingBatch services in DI container
- add tokens for adapter and repository

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859310d52408326bc7249f7625b7855