### PR TITLE
Add reusable BackButton component

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from './ui2/button';
+
+export interface BackButtonProps {
+  label: string;
+  fallbackPath?: string;
+}
+
+export function performGoBack(
+  navigate: (to: any) => void,
+  fallbackPath: string = '/'
+) {
+  if (typeof window !== 'undefined' && window.history.length > 1) {
+    navigate(-1);
+  } else {
+    navigate(fallbackPath);
+  }
+}
+
+export default function BackButton({ label, fallbackPath = '/' }: BackButtonProps) {
+  const navigate = useNavigate();
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => performGoBack(navigate, fallbackPath)}
+      className="flex items-center"
+    >
+      <ArrowLeft className="h-5 w-5 mr-2" />
+      {label}
+    </Button>
+  );
+}

--- a/src/pages/accounts/AccountAddEdit.tsx
+++ b/src/pages/accounts/AccountAddEdit.tsx
@@ -6,13 +6,13 @@ import { Account, AccountType } from '../../models/account.model';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Textarea } from '../../components/ui2/textarea';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
 import { Combobox } from '../../components/ui2/combobox';
 import { Switch } from '../../components/ui2/switch';
 import { Tabs } from '../../components/ui2/tabs';
 import {
-  ArrowLeft,
   Save,
   Loader2,
   Building2,
@@ -136,14 +136,7 @@ function AccountAddEdit() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Accounts
-        </Button>
+        <BackButton fallbackPath="/accounts" label="Back to Accounts" />
       </div>
       
       <Card>

--- a/src/pages/accounts/AccountProfile.tsx
+++ b/src/pages/accounts/AccountProfile.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import { Tabs } from '../../components/ui2/tabs';
 import {
@@ -18,7 +19,6 @@ import {
   AlertDialogTitle,
 } from '../../components/ui2/alert-dialog';
 import {
-  ArrowLeft,
   Building2,
   User,
   Mail,
@@ -163,9 +163,7 @@ function AccountProfile() {
           <AlertTriangle className="h-12 w-12 text-warning mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">Account Not Found</h3>
           <p className="text-muted-foreground mb-6">The account you're looking for doesn't exist or has been removed.</p>
-          <Button onClick={() => navigate('/accounts')}>
-            Go Back to Accounts
-          </Button>
+          <BackButton fallbackPath="/accounts" label="Go Back to Accounts" />
         </CardContent>
       </Card>
     );
@@ -174,14 +172,7 @@ function AccountProfile() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Accounts
-        </Button>
+        <BackButton fallbackPath="/accounts" label="Back to Accounts" />
       </div>
       
       {/* Account Header */}

--- a/src/pages/accounts/ChartOfAccountAddEdit.tsx
+++ b/src/pages/accounts/ChartOfAccountAddEdit.tsx
@@ -5,6 +5,7 @@ import { ChartOfAccount } from '../../models/chartOfAccount.model';
 import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Textarea } from '../../components/ui2/textarea';
 import { 
   Select, 
@@ -15,9 +16,8 @@ import {
 } from '../../components/ui2/select';
 import { Switch } from '../../components/ui2/switch';
 import { 
-  ArrowLeft, 
-  Save, 
-  Loader2, 
+  Save,
+  Loader2,
   BookOpen, 
   Hash, 
   FileText, 
@@ -159,14 +159,7 @@ function ChartOfAccountAddEdit() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts/chart-of-accounts')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Chart of Accounts
-        </Button>
+        <BackButton fallbackPath="/accounts/chart-of-accounts" label="Back to Chart of Accounts" />
       </div>
       
       <form onSubmit={handleSubmit}>

--- a/src/pages/accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/ChartOfAccountProfile.tsx
@@ -4,6 +4,7 @@ import { useChartOfAccountRepository } from '../../hooks/useChartOfAccountReposi
 import { useAccountingReports } from '../../hooks/useAccountingReports';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import { DateRangePickerField } from '../../components/ui2/date-range-picker-field';
 import { DataGrid } from '../../components/ui2/mui-datagrid';
@@ -18,8 +19,7 @@ import {
   AlertDialogTitle,
 } from '../../components/ui2/alert-dialog';
 import { 
-  ArrowLeft, 
-  BookOpen, 
+  BookOpen,
   Pencil, 
   Trash2, 
   Loader2, 
@@ -276,12 +276,10 @@ function ChartOfAccountProfile() {
           <p className="mt-2 text-sm text-muted-foreground">
             The account you're looking for doesn't exist or has been deleted.
           </p>
-          <Button
-            className="mt-4"
-            onClick={() => navigate('/accounts/chart-of-accounts')}
-          >
-            Back to Chart of Accounts
-          </Button>
+          <BackButton
+            fallbackPath="/accounts/chart-of-accounts"
+            label="Back to Chart of Accounts"
+          />
         </div>
       </div>
     );
@@ -290,14 +288,7 @@ function ChartOfAccountProfile() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts/chart-of-accounts')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Chart of Accounts
-        </Button>
+        <BackButton fallbackPath="/accounts/chart-of-accounts" label="Back to Chart of Accounts" />
       </div>
       
       {/* Account Header */}

--- a/src/pages/accounts/FinancialSourceAddEdit.tsx
+++ b/src/pages/accounts/FinancialSourceAddEdit.tsx
@@ -6,12 +6,13 @@ import { FinancialSource, SourceType } from '../../models/financialSource.model'
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Textarea } from '../../components/ui2/textarea';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
 import { Combobox } from '../../components/ui2/combobox';
 import { Label } from '../../components/ui2/label';
 import { Switch } from '../../components/ui2/switch';
-import { ArrowLeft, Save, Loader2, Briefcase as Bank, Wallet, Globe, CreditCard, AlertCircle, Hash, FileText } from 'lucide-react';
+import { Save, Loader2, Briefcase as Bank, Wallet, Globe, CreditCard, AlertCircle, Hash, FileText } from 'lucide-react';
 
 function FinancialSourceAddEdit() {
   const { id } = useParams<{ id: string }>();
@@ -129,14 +130,7 @@ function FinancialSourceAddEdit() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts/sources')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Financial Sources
-        </Button>
+        <BackButton fallbackPath="/accounts/sources" label="Back to Financial Sources" />
       </div>
       
       <Card>

--- a/src/pages/accounts/FinancialSourceProfile.tsx
+++ b/src/pages/accounts/FinancialSourceProfile.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import {
   AlertDialog,
@@ -16,7 +17,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../../components/ui2/alert-dialog';
-import { ArrowLeft, Ban as Bank, Wallet, Globe, CreditCard, FileText, Pencil, Trash2, Loader2, CheckCircle2, XCircle, Hash, DollarSign, AlertTriangle } from 'lucide-react';
+import { Ban as Bank, Wallet, Globe, CreditCard, FileText, Pencil, Trash2, Loader2, CheckCircle2, XCircle, Hash, DollarSign, AlertTriangle } from 'lucide-react';
 
 // Maximum number of retries for delete operation
 const MAX_RETRIES = 3;
@@ -149,9 +150,7 @@ function FinancialSourceProfile() {
           <AlertTriangle className="h-12 w-12 text-warning mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">Financial Source Not Found</h3>
           <p className="text-muted-foreground mb-6">The financial source you're looking for doesn't exist or has been removed.</p>
-          <Button onClick={() => navigate('/accounts/sources')}>
-            Go Back to Financial Sources
-          </Button>
+          <BackButton fallbackPath="/accounts/sources" label="Go Back to Financial Sources" />
         </CardContent>
       </Card>
     );
@@ -160,14 +159,7 @@ function FinancialSourceProfile() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/accounts/sources')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Financial Sources
-        </Button>
+        <BackButton fallbackPath="/accounts/sources" label="Back to Financial Sources" />
       </div>
       
       {/* Source Header */}

--- a/src/pages/admin/RoleForm.tsx
+++ b/src/pages/admin/RoleForm.tsx
@@ -3,12 +3,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { useMessageStore } from '../../components/MessageHandler';
-import {
-  Save,
-  Loader2,
-  ArrowLeft,
-  Shield,
-} from 'lucide-react';
+import { Save, Loader2, Shield } from 'lucide-react';
+import BackButton from '../../components/BackButton';
 
 type Permission = {
   id: string;
@@ -269,13 +265,7 @@ function RoleForm() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <button
-          onClick={() => navigate('/admin/roles')}
-          className="flex items-center text-gray-600 hover:text-gray-900"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Roles
-        </button>
+        <BackButton fallbackPath="/admin/roles" label="Back to Roles" />
       </div>
 
       <div className="bg-white shadow overflow-hidden sm:rounded-lg">

--- a/src/pages/admin/UserForm.tsx
+++ b/src/pages/admin/UserForm.tsx
@@ -3,13 +3,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { useMessageStore } from '../../components/MessageHandler';
-import {
-  ArrowLeft,
-  Save,
-  Loader2,
-  AlertCircle,
-  UserPlus,
-} from 'lucide-react';
+import { Save, Loader2, AlertCircle, UserPlus } from 'lucide-react';
+import BackButton from '../../components/BackButton';
 
 type UserFormData = {
   email: string;
@@ -221,13 +216,7 @@ const UserForm = () => {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <button
-          onClick={() => navigate('/admin/users')}
-          className="flex items-center text-gray-600 hover:text-gray-900"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Users
-        </button>
+        <BackButton fallbackPath="/admin/users" label="Back to Users" />
       </div>
 
       <div className="bg-white shadow overflow-hidden sm:rounded-lg">

--- a/src/pages/finances/AccountDetail.tsx
+++ b/src/pages/finances/AccountDetail.tsx
@@ -4,11 +4,11 @@ import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
 import { useAccountingReports } from '../../hooks/useAccountingReports';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { DateRangePickerField } from '../../components/ui2/date-range-picker-field';
 import { Badge } from '../../components/ui2/badge';
 import { 
-  ArrowLeft, 
-  FileText, 
+  FileText,
   Calendar, 
   Loader2, 
   DollarSign,
@@ -101,12 +101,10 @@ function AccountDetail() {
           <p className="mt-2 text-sm text-muted-foreground">
             The account you're looking for doesn't exist or has been deleted.
           </p>
-          <Button
-            className="mt-4"
-            onClick={() => navigate('/finances/chart-of-accounts')}
-          >
-            Back to Chart of Accounts
-          </Button>
+          <BackButton
+            fallbackPath="/finances/chart-of-accounts"
+            label="Back to Chart of Accounts"
+          />
         </div>
       </div>
     );
@@ -115,14 +113,7 @@ function AccountDetail() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/chart-of-accounts')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Chart of Accounts
-        </Button>
+        <BackButton fallbackPath="/finances/chart-of-accounts" label="Back to Chart of Accounts" />
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">

--- a/src/pages/finances/BudgetAdd.tsx
+++ b/src/pages/finances/BudgetAdd.tsx
@@ -7,11 +7,11 @@ import { formatCurrency } from '../../utils/currency';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Combobox } from '../../components/ui2/combobox';
 import { DatePickerInput } from '../../components/ui2/date-picker';
 import { Textarea } from '../../components/ui2/textarea';
 import {
-  ArrowLeft,
   Save,
   Loader2,
   AlertCircle,
@@ -124,14 +124,7 @@ function BudgetAdd() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/budgets')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Budgets
-        </Button>
+        <BackButton fallbackPath="/finances/budgets" label="Back to Budgets" />
       </div>
 
       <Card>

--- a/src/pages/finances/BudgetEdit.tsx
+++ b/src/pages/finances/BudgetEdit.tsx
@@ -7,11 +7,11 @@ import { useMessageStore } from '../../components/MessageHandler';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Combobox } from '../../components/ui2/combobox';
 import { DatePickerInput } from '../../components/ui2/date-picker';
 import { Textarea } from '../../components/ui2/textarea';
 import {
-  ArrowLeft,
   Save,
   Loader2,
   AlertCircle,
@@ -168,14 +168,7 @@ function BudgetEdit() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate(`/finances/budgets/${id}`)}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Budget
-        </Button>
+        <BackButton fallbackPath={`/finances/budgets/${id}`} label="Back to Budget" />
       </div>
 
       <Card>

--- a/src/pages/finances/BudgetList.tsx
+++ b/src/pages/finances/BudgetList.tsx
@@ -8,13 +8,13 @@ import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Input } from '../../components/ui2/input';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
 import { Badge } from '../../components/ui2/badge';
 import { Progress } from '../../components/ui2/progress';
 import { useMessageStore } from '../../components/MessageHandler';
 import {
-  ArrowLeft,
   Plus,
   Search,
   Filter,
@@ -185,14 +185,7 @@ function BudgetList() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Finances
-        </Button>
+        <BackButton fallbackPath="/finances" label="Back to Finances" />
       </div>
 
       <div className="sm:flex sm:items-center">

--- a/src/pages/finances/BudgetProfile.tsx
+++ b/src/pages/finances/BudgetProfile.tsx
@@ -7,10 +7,10 @@ import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import { Progress } from '../../components/ui2/progress';
 import {
-  ArrowLeft,
   PiggyBank,
   Calendar,
   DollarSign,
@@ -165,14 +165,7 @@ function BudgetProfile() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/budgets')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Budgets
-        </Button>
+        <BackButton fallbackPath="/finances/budgets" label="Back to Budgets" />
       </div>
 
       {/* Budget Overview */}

--- a/src/pages/finances/BulkTransactionEntry.tsx
+++ b/src/pages/finances/BulkTransactionEntry.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../components/ui2/card";
 import { Input } from "../../components/ui2/input";
 import { Button } from "../../components/ui2/button";
+import BackButton from "../../components/BackButton";
 import { Textarea } from "../../components/ui2/textarea";
 import { DatePickerInput } from "../../components/ui2/date-picker";
 import {
@@ -24,7 +25,6 @@ import { Combobox } from "../../components/ui2/combobox";
 import { Switch } from "../../components/ui2/switch";
 import { useAccountRepository } from "../../hooks/useAccountRepository";
 import {
-  ArrowLeft,
   Save,
   Loader2,
   Plus,
@@ -443,14 +443,7 @@ function BulkTransactionEntry() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate("/finances/transactions")}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Transactions
-        </Button>
+        <BackButton fallbackPath="/finances/transactions" label="Back to Transactions" />
       </div>
 
       <form onSubmit={handleSubmit}>

--- a/src/pages/finances/FundAddEdit.tsx
+++ b/src/pages/finances/FundAddEdit.tsx
@@ -5,11 +5,12 @@ import { Fund, FundType } from '../../models/fund.model';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
 import { Combobox } from '../../components/ui2/combobox';
 import { Label } from '../../components/ui2/label';
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
-import { ArrowLeft, Save, Loader2, AlertCircle } from 'lucide-react';
+import { Save, Loader2, AlertCircle } from 'lucide-react';
 
 function FundAddEdit() {
   const { id } = useParams<{ id: string }>();
@@ -84,10 +85,7 @@ function FundAddEdit() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button variant="ghost" onClick={() => navigate('/finances/funds')} className="flex items-center">
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Funds
-        </Button>
+        <BackButton fallbackPath="/finances/funds" label="Back to Funds" />
       </div>
 
       <Card>

--- a/src/pages/finances/FundProfile.tsx
+++ b/src/pages/finances/FundProfile.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import { Tabs } from '../../components/ui2/tabs';
 import {
@@ -18,7 +19,6 @@ import {
   AlertDialogTitle,
 } from '../../components/ui2/alert-dialog';
 import {
-  ArrowLeft,
   DollarSign,
   Pencil,
   Trash2,
@@ -123,7 +123,7 @@ function FundProfile() {
         <CardContent className="flex flex-col items-center justify-center py-12">
           <AlertTriangle className="h-12 w-12 text-warning mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">Fund Not Found</h3>
-          <Button onClick={() => navigate('/finances/funds')}>Go Back to Funds</Button>
+          <BackButton fallbackPath="/finances/funds" label="Go Back to Funds" />
         </CardContent>
       </Card>
     );
@@ -132,10 +132,7 @@ function FundProfile() {
   return (
     <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button variant="ghost" onClick={() => navigate('/finances/funds')} className="flex items-center">
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Funds
-        </Button>
+        <BackButton fallbackPath="/finances/funds" label="Back to Funds" />
       </div>
 
       <Card className="mb-6">

--- a/src/pages/finances/JournalEntryForm.tsx
+++ b/src/pages/finances/JournalEntryForm.tsx
@@ -4,17 +4,17 @@ import { useJournalEntry, JournalEntryLine } from '../../hooks/useJournalEntry';
 import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
 import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Input } from '../../components/ui2/input';
 import { DatePickerInput } from '../../components/ui2/date-picker';
 import { Textarea } from '../../components/ui2/textarea';
 import { Select } from '../../components/ui2/select';
 import { Badge } from '../../components/ui2/badge';
 import { 
-  Plus, 
-  Trash2, 
-  Save, 
-  ArrowLeft, 
-  Calendar, 
+  Plus,
+  Trash2,
+  Save,
+  Calendar,
   FileText, 
   DollarSign,
   Loader2,
@@ -158,14 +158,7 @@ function JournalEntryForm() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/transactions')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Transactions
-        </Button>
+        <BackButton fallbackPath="/finances/transactions" label="Back to Transactions" />
       </div>
       
       <form onSubmit={handleSubmit}>

--- a/src/pages/finances/TransactionAdd.tsx
+++ b/src/pages/finances/TransactionAdd.tsx
@@ -7,13 +7,13 @@ import { useFundRepository } from '../../hooks/useFundRepository';
 import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Textarea } from '../../components/ui2/textarea';
 import { DatePickerInput } from '../../components/ui2/date-picker';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui2/select';
 import { 
-  ArrowLeft, 
-  Save, 
-  Loader2, 
+  Save,
+  Loader2,
   Plus, 
   Trash2, 
   DollarSign,
@@ -315,14 +315,7 @@ function TransactionAdd() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/transactions')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Transactions
-        </Button>
+        <BackButton fallbackPath="/finances/transactions" label="Back to Transactions" />
       </div>
       
       <form onSubmit={handleSubmit}>

--- a/src/pages/finances/TransactionDetail.tsx
+++ b/src/pages/finances/TransactionDetail.tsx
@@ -5,12 +5,12 @@ import { usePermissions } from '../../hooks/usePermissions';
 import PermissionGate from '../../components/PermissionGate';
 import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
 import { Badge } from '../../components/ui2/badge';
 import { Textarea } from '../../components/ui2/textarea';
 import { 
-  ArrowLeft, 
-  FileText, 
-  Loader2, 
+  FileText,
+  Loader2,
   Edit, 
   Trash2,
   Check,
@@ -290,12 +290,7 @@ function TransactionDetail() {
           <p className="mt-2 text-sm text-muted-foreground">
             The transaction you're looking for doesn't exist or has been deleted.
           </p>
-          <Button
-            className="mt-4"
-            onClick={() => navigate('/finances/transactions')}
-          >
-            Back to Transactions
-          </Button>
+          <BackButton fallbackPath="/finances/transactions" label="Back to Transactions" />
         </div>
       </div>
     );
@@ -304,14 +299,7 @@ function TransactionDetail() {
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/finances/transactions')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Transactions
-        </Button>
+        <BackButton fallbackPath="/finances/transactions" label="Back to Transactions" />
       </div>
       
       {/* Transaction Header */}

--- a/src/pages/members/MemberAddEdit.tsx
+++ b/src/pages/members/MemberAddEdit.tsx
@@ -4,6 +4,7 @@ import { useMemberRepository } from '../../hooks/useMemberRepository';
 import { Member } from '../../models/member.model';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
+import BackButton, { performGoBack } from '../../components/BackButton';
 import { ImageInput } from '../../components/ui2/image-input';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../components/ui2/tabs';
 import { Separator } from '../../components/ui2/separator';
@@ -17,7 +18,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '../../components/ui2/alert-dialog';
-import { Save, ArrowLeft, Loader2 } from 'lucide-react';
+import { Save, Loader2 } from 'lucide-react';
 
 // Import tabs
 import BasicInfoTab from './tabs/BasicInfoTab';
@@ -120,7 +121,7 @@ function MemberAddEdit() {
     if (hasUnsavedChanges) {
       setShowCancelConfirm(true);
     } else {
-      navigate(id ? `/members/${id}` : '/members/list');
+      performGoBack(navigate, id ? `/members/${id}` : '/members/list');
     }
   };
 
@@ -192,14 +193,7 @@ function MemberAddEdit() {
   return (
     <div className="space-y-6">
         {/* Back Button */}
-        <Button
-          variant="ghost"
-          onClick={handleCancel}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Members
-        </Button>
+        <BackButton fallbackPath="/members" label="Back to Members" />
 
         <form onSubmit={handleSubmit}>
           <Card>
@@ -312,7 +306,7 @@ function MemberAddEdit() {
                 variant="destructive"
                 onClick={() => {
                   setShowCancelConfirm(false);
-                  navigate(id ? `/members/${id}` : '/members/list');
+                  performGoBack(navigate, id ? `/members/${id}` : '/members/list');
                 }}
               >
                 Discard Changes

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -2,22 +2,22 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
-import { 
-  User, 
-  Users, 
-  Phone, 
-  Mail, 
-  MapPin, 
-  Calendar, 
-  Edit, 
-  Trash2, 
-  ArrowLeft,
+import {
+  User,
+  Users,
+  Phone,
+  Mail,
+  MapPin,
+  Calendar,
+  Edit,
+  Trash2,
   Cake,
   Heart,
   Loader2,
   AlertTriangle,
   FileText
 } from 'lucide-react';
+import BackButton from '../../components/BackButton';
 
 // UI Components
 import { Card, CardHeader, CardContent, CardTitle, CardDescription, CardFooter } from '../../components/ui2/card';
@@ -121,9 +121,7 @@ function MemberProfile() {
           <AlertTriangle className="h-12 w-12 text-warning mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">Member Not Found</h3>
           <p className="text-muted-foreground mb-6">The member you're looking for doesn't exist or has been removed.</p>
-          <Button onClick={() => navigate('/members')}>
-            Go Back to Members
-          </Button>
+          <BackButton fallbackPath="/members" label="Go Back to Members" />
         </CardContent>
       </Card>
     );
@@ -132,14 +130,7 @@ function MemberProfile() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <Button
-          variant="ghost"
-          onClick={() => navigate('/members')}
-          className="flex items-center"
-        >
-          <ArrowLeft className="h-5 w-5 mr-2" />
-          Back to Members
-        </Button>
+        <BackButton fallbackPath="/members" label="Back to Members" />
         
         <div className="flex space-x-3">
           <Button

--- a/src/pages/members/family/FamilyRelationshipAddEdit.tsx
+++ b/src/pages/members/family/FamilyRelationshipAddEdit.tsx
@@ -6,6 +6,7 @@ import { useMessageStore } from '../../../components/MessageHandler';
 import { Container } from '../../../components/ui2/container';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
+import BackButton, { performGoBack } from '../../../components/BackButton';
 import { Input } from '../../../components/ui2/input';
 import { Label } from '../../../components/ui2/label';
 import { Textarea } from '../../../components/ui2/textarea';
@@ -21,7 +22,6 @@ import {
   AlertDialogCancel,
 } from '../../../components/ui2/alert-dialog';
 import {
-  ArrowLeft,
   Save,
   Loader2,
   Users,
@@ -267,7 +267,7 @@ function FamilyRelationshipAddEdit() {
     if (hasUnsavedChanges) {
       setShowCancelConfirm(true);
     } else {
-      navigate(id ? `/members/family/${id}` : '/members/family');
+      performGoBack(navigate, id ? `/members/family/${id}` : '/members/family');
     }
   };
 
@@ -300,14 +300,7 @@ function FamilyRelationshipAddEdit() {
       <div className="space-y-6">
         {/* Back Button */}
         <div className="flex items-center justify-between">
-          <Button
-            variant="ghost"
-            onClick={handleCancel}
-            className="flex items-center"
-          >
-            <ArrowLeft className="h-5 w-5 mr-2" />
-            Back to Family Relationships
-          </Button>
+          <BackButton fallbackPath="/members/family" label="Back to Family Relationships" />
         </div>
 
         <Card>
@@ -414,7 +407,7 @@ function FamilyRelationshipAddEdit() {
               <AlertDialogAction
                 onClick={() => {
                   setShowCancelConfirm(false);
-                  navigate(id ? `/members/family/${id}` : '/members/family');
+                  performGoBack(navigate, id ? `/members/family/${id}` : '/members/family');
                 }}
               >
                 Discard Changes

--- a/src/pages/members/family/FamilyRelationshipProfile.tsx
+++ b/src/pages/members/family/FamilyRelationshipProfile.tsx
@@ -6,6 +6,7 @@ import { format } from 'date-fns';
 import { Container } from '../../../components/ui2/container';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
 import { Badge } from '../../../components/ui2/badge';
 import { Separator } from '../../../components/ui2/separator';
 import {
@@ -19,7 +20,6 @@ import {
   AlertDialogCancel,
 } from '../../../components/ui2/alert-dialog';
 import {
-  ArrowLeft,
   Edit2,
   Trash2,
   Users,
@@ -147,14 +147,7 @@ function FamilyRelationshipProfile() {
       <div className="space-y-6">
         {/* Back Button */}
         <div className="flex items-center justify-between">
-          <Button
-            variant="ghost"
-            onClick={() => navigate('/members/family')}
-            className="flex items-center"
-          >
-            <ArrowLeft className="h-5 w-5 mr-2" />
-            Back to Family Relationships
-          </Button>
+          <BackButton fallbackPath="/members/family" label="Back to Family Relationships" />
 
           <div className="flex space-x-2">
             <Button

--- a/src/pages/members/family/FamilyRelationships.tsx
+++ b/src/pages/members/family/FamilyRelationships.tsx
@@ -5,11 +5,11 @@ import { supabase } from '../../../lib/supabase';
 import { format } from 'date-fns';
 import { DataGrid } from '../../../components/ui2/data-grid';
 import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
 import { Badge } from '../../../components/ui2/badge';
 import { Container } from '../../../components/ui2/container';
 import {
   Plus,
-  ChevronLeft,
   Users,
   Heart,
   Edit2,
@@ -181,14 +181,7 @@ function FamilyRelationships() {
       <div className="space-y-6">
         {/* Back Button */}
         <div className="flex items-center justify-between">
-          <Button
-            variant="ghost"
-            onClick={() => navigate('/members')}
-            className="flex items-center"
-          >
-            <ChevronLeft className="h-5 w-5 mr-2" />
-            Back to Members
-          </Button>
+          <BackButton fallbackPath="/members" label="Back to Members" />
 
           <Button
             variant="default"

--- a/tests/backButton.test.ts
+++ b/tests/backButton.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { performGoBack } from '../src/components/BackButton';
+
+declare let global: any;
+
+describe('performGoBack', () => {
+  const originalWindow = global.window;
+
+  beforeEach(() => {
+    global.window = { history: { length: 0 } };
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+  });
+
+  it('navigates back when history length > 1', () => {
+    global.window.history.length = 2;
+    const navigate = vi.fn();
+    performGoBack(navigate, '/fallback');
+    expect(navigate).toHaveBeenCalledWith(-1);
+  });
+
+  it('navigates to fallback when history length <= 1', () => {
+    global.window.history.length = 1;
+    const navigate = vi.fn();
+    performGoBack(navigate, '/fallback');
+    expect(navigate).toHaveBeenCalledWith('/fallback');
+  });
+});


### PR DESCRIPTION
## Summary
- add `BackButton` component with `performGoBack` helper
- update many pages to use `BackButton`
- adjust Member and Family relationship pages to use the new go-back logic
- test `performGoBack` behaviour

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685931be01548326a4e9c31eed3f4627