### PR TITLE
Fix required field display in ui2 components

### DIFF
--- a/src/components/ui2/checkbox.tsx
+++ b/src/components/ui2/checkbox.tsx
@@ -20,7 +20,7 @@ const sizeClasses = {
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   CheckboxProps
->(({ className, size = 'md', label, error, helperText, ...props }, ref) => (
+>(({ className, size = 'md', label, required, error, helperText, ...props }, ref) => (
   <div className="relative flex items-start">
     <div className="flex items-center h-5">
       <CheckboxPrimitive.Root
@@ -31,6 +31,7 @@ const Checkbox = React.forwardRef<
           error && 'border-destructive',
           className
         )}
+        aria-required={required ? true : undefined}
         {...props}
       >
         <CheckboxPrimitive.Indicator
@@ -46,14 +47,15 @@ const Checkbox = React.forwardRef<
         {label && (
           <label
             htmlFor={props.id}
-            className={cn(
-              'font-medium text-foreground dark:text-gray-300',
-              props.disabled && 'opacity-50'
-            )}
-          >
+          className={cn(
+            'font-medium text-foreground dark:text-gray-300',
+            props.disabled && 'opacity-50'
+          )}
+        >
             {label}
-          </label>
-        )}
+            {required && <span className="text-destructive ml-1">*</span>}
+        </label>
+      )}
         {(helperText || error) && (
           <p className={cn(
             'text-sm',

--- a/src/components/ui2/date-picker.tsx
+++ b/src/components/ui2/date-picker.tsx
@@ -29,6 +29,7 @@ export function DatePickerInput({
   disabled = false,
   clearable = true,
   label,
+  required,
   error,
   helperText,
 }: DatePickerProps) {
@@ -63,7 +64,7 @@ export function DatePickerInput({
           )}
         >
           {label}
-          {error && <span className="text-destructive ml-1">*</span>}
+          {required && <span className="text-destructive ml-1">*</span>}
         </label>
       )}
       
@@ -81,6 +82,7 @@ export function DatePickerInput({
               clearable={clearable && !!date}
               onClear={() => handleSelect(undefined)}
               onClick={() => setIsOpen(true)}
+              required={required}
               error={error}
             />
           </div>

--- a/src/components/ui2/date-range-picker-field.tsx
+++ b/src/components/ui2/date-range-picker-field.tsx
@@ -24,6 +24,7 @@ export function DateRangePickerField({
   clearable = true,
   showCompactInput = false,
   label,
+  required,
   error,
   helperText,
 }: DateRangePickerFieldProps) {
@@ -38,6 +39,7 @@ export function DateRangePickerField({
       showCompactInput={showCompactInput}
       icon={<CalendarIcon className="h-4 w-4" />}
       label={label}
+      required={required}
       error={error}
       helperText={helperText}
     />

--- a/src/components/ui2/date-range-picker.tsx
+++ b/src/components/ui2/date-range-picker.tsx
@@ -33,6 +33,7 @@ export interface DateRangePickerProps {
   showCompactInput?: boolean;
   icon?: React.ReactNode;
   label?: string;
+  required?: boolean;
   error?: string;
   helperText?: string;
 }
@@ -50,6 +51,7 @@ export function DateRangePicker({
   showCompactInput = false,
   icon,
   label,
+  required,
   error,
   helperText,
 }: DateRangePickerProps) {
@@ -168,7 +170,7 @@ export function DateRangePicker({
           )}
         >
           {label}
-          {error && <span className="text-destructive ml-1">*</span>}
+          {required && <span className="text-destructive ml-1">*</span>}
         </label>
       )}
       
@@ -184,6 +186,7 @@ export function DateRangePicker({
                 error && "border-destructive",
                 "dark:border-gray-700 dark:bg-gray-800"
               )}
+              aria-required={required ? true : undefined}
             >
               {icon || <CalendarIcon className="h-4 w-4 mr-2" />}
               <span className="flex-1 truncate">{formattedDateRange}</span>
@@ -204,6 +207,7 @@ export function DateRangePicker({
                 clearable={clearable && !!value.from}
                 onClear={handleClear}
                 onClick={() => setOpen(true)}
+                required={required}
                 error={error}
               />
             </div>

--- a/src/components/ui2/image-input.tsx
+++ b/src/components/ui2/image-input.tsx
@@ -18,6 +18,7 @@ interface ImageInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElemen
   showOverlay?: boolean;
   loading?: boolean;
   placeholder?: React.ReactNode;
+  required?: boolean;
 }
 
 const sizeClasses = {
@@ -33,13 +34,14 @@ const shapeClasses = {
 };
 
 export const ImageInput = React.forwardRef<HTMLInputElement, ImageInputProps>(
-  ({ 
-    className = '', 
-    error, 
-    label, 
-    helperText, 
-    value, 
-    onChange, 
+  ({
+    className = '',
+    error,
+    label,
+    required,
+    helperText,
+    value,
+    onChange,
     onRemove,
     success = false,
     size = 'md',
@@ -103,6 +105,7 @@ export const ImageInput = React.forwardRef<HTMLInputElement, ImageInputProps>(
         {label && (
           <Label className="block text-sm font-medium mb-2">
             {label}
+            {required && <span className="text-destructive ml-1">*</span>}
           </Label>
         )}
 
@@ -194,6 +197,7 @@ export const ImageInput = React.forwardRef<HTMLInputElement, ImageInputProps>(
             className="sr-only"
             onChange={handleFileChange}
             accept="image/*"
+            required={required}
             {...props}
           />
         </div>

--- a/src/components/ui2/multi-select.tsx
+++ b/src/components/ui2/multi-select.tsx
@@ -42,6 +42,7 @@ export function MultiSelect({
   searchable = true,
   icon,
   label,
+  required,
   error,
   helperText,
 }: MultiSelectProps) {
@@ -98,7 +99,7 @@ export function MultiSelect({
           )}
         >
           {label}
-          {error && <span className="text-destructive ml-1">*</span>}
+          {required && <span className="text-destructive ml-1">*</span>}
         </label>
       )}
       
@@ -108,6 +109,7 @@ export function MultiSelect({
             variant="outline"
             role="combobox"
             aria-expanded={open}
+            aria-required={required ? true : undefined}
             className={cn(
               "w-full justify-between",
               value.length === 0 && "text-muted-foreground",

--- a/src/components/ui2/select.tsx
+++ b/src/components/ui2/select.tsx
@@ -52,6 +52,7 @@ const SelectTrigger = React.forwardRef<
         id={id}
         disabled={disabled}
         aria-invalid={error ? 'true' : undefined}
+        aria-required={required ? true : undefined}
         aria-describedby={
           error || helperText ? `${id}-description` : undefined
         }


### PR DESCRIPTION
## Summary
- ensure required props are passed to form components in ui2
- show `*` on labels when required
- forward required attribute/aria-required for interactive elements
- add missing `aria-required` on select triggers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859865ccab48326960793ff7ef5e18d