### PR TITLE
Remove fund account link

### DIFF
--- a/src/adapters/fund.adapter.ts
+++ b/src/adapters/fund.adapter.ts
@@ -22,20 +22,11 @@ export class FundAdapter
     id,
     name,
     type,
-    account_id,
     created_by,
     updated_by,
     created_at,
     updated_at
   `;
-
-  protected defaultRelationships: QueryOptions['relationships'] = [
-    {
-      table: 'chart_of_accounts',
-      foreignKey: 'account_id',
-      select: ['id', 'code', 'name']
-    }
-  ];
 
   protected override async onAfterCreate(data: Fund): Promise<void> {
     await this.auditService.logAuditEvent('create', 'fund', data.id, data);

--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -1,5 +1,4 @@
 import { BaseModel } from './base.model';
-import type { ChartOfAccount } from './chartOfAccount.model';
 
 export type FundType = 'restricted' | 'unrestricted';
 
@@ -7,6 +6,4 @@ export interface Fund extends BaseModel {
   id: string;
   name: string;
   type: FundType;
-  account_id: string | null;
-  account?: Pick<ChartOfAccount, 'id' | 'code' | 'name'>;
 }

--- a/src/pages/finances/FundAddEdit.tsx
+++ b/src/pages/finances/FundAddEdit.tsx
@@ -7,9 +7,7 @@ import { Input } from '../../components/ui2/input';
 import { Button } from '../../components/ui2/button';
 import BackButton from '../../components/BackButton';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
-import { Combobox } from '../../components/ui2/combobox';
-import { Label } from '../../components/ui2/label';
-import { useChartOfAccounts } from '../../hooks/useChartOfAccounts';
+
 import { Save, Loader2, AlertCircle } from 'lucide-react';
 
 function FundAddEdit() {
@@ -18,12 +16,10 @@ function FundAddEdit() {
   const isEditMode = !!id;
 
   const { useQuery: useFundQuery, useCreate, useUpdate } = useFundRepository();
-  const { useAccountOptions } = useChartOfAccounts();
 
   const [formData, setFormData] = useState<Partial<Fund>>({
     name: '',
     type: 'unrestricted',
-    account_id: null,
   });
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +30,6 @@ function FundAddEdit() {
 
   const createMutation = useCreate();
   const updateMutation = useUpdate();
-  const { data: accountOptions, isLoading: isAccountsLoading } = useAccountOptions();
 
   useEffect(() => {
     if (isEditMode && fundData?.data?.[0]) {
@@ -55,10 +50,6 @@ function FundAddEdit() {
       return;
     }
 
-    if (!formData.account_id) {
-      setError('Account is required');
-      return;
-    }
 
     try {
       if (isEditMode && id) {
@@ -123,22 +114,6 @@ function FundAddEdit() {
                 </Select>
               </div>
 
-              <div className="sm:col-span-2">
-                <Label htmlFor="account_id">Chart of Account *</Label>
-                {isAccountsLoading ? (
-                  <div className="flex items-center space-x-2">
-                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
-                    <span className="text-sm text-muted-foreground">Loading accounts...</span>
-                  </div>
-                ) : (
-                  <Combobox
-                    options={accountOptions || []}
-                    value={formData.account_id || ''}
-                    onChange={(value) => handleInputChange('account_id', value)}
-                    placeholder="Select account"
-                  />
-                )}
-              </div>
             </div>
 
             {error && (

--- a/src/validators/fund.validator.ts
+++ b/src/validators/fund.validator.ts
@@ -6,10 +6,6 @@ export class FundValidator {
       throw new Error('Fund name is required');
     }
 
-    if (!data.account_id?.toString().trim()) {
-      throw new Error('Account ID is required');
-    }
-
     if (data.type !== undefined) {
       const validTypes: Fund['type'][] = ['restricted', 'unrestricted'];
       if (!validTypes.includes(data.type)) {

--- a/supabase/migrations/20250628110000_drop_fund_account.sql
+++ b/supabase/migrations/20250628110000_drop_fund_account.sql
@@ -1,0 +1,13 @@
+-- Remove account_id column from funds
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'funds'
+      AND column_name = 'account_id'
+  ) THEN
+    ALTER TABLE funds DROP COLUMN account_id;
+  END IF;
+END $$;
+
+-- Drop index if it exists
+DROP INDEX IF EXISTS funds_account_id_idx;

--- a/tests/fundRepositoryValidation.test.ts
+++ b/tests/fundRepositoryValidation.test.ts
@@ -15,26 +15,26 @@ class TestFundRepository extends FundRepository {
 describe('FundRepository validation', () => {
   it('throws error for invalid data on create', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
-    await expect(repo.runBeforeCreate({ name: '', account_id: '' })).rejects.toThrow('Fund name is required');
+    await expect(repo.runBeforeCreate({ name: '' })).rejects.toThrow('Fund name is required');
   });
 
   it('throws error for invalid fund type', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
     await expect(
-      repo.runBeforeCreate({ name: 'Test', account_id: 'a', type: 'bad' as any })
+      repo.runBeforeCreate({ name: 'Test', type: 'bad' as any })
     ).rejects.toThrow('Invalid fund type');
   });
 
   it('formats data on create', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
-    const data = await repo.runBeforeCreate({ name: '  My Fund ', account_id: 'a', type: 'restricted' });
+    const data = await repo.runBeforeCreate({ name: '  My Fund ', type: 'restricted' });
     expect(data.name).toBe('My Fund');
   });
 
   it('validates on update', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
     await expect(
-      repo.runBeforeUpdate('1', { name: '', account_id: '' })
+      repo.runBeforeUpdate('1', { name: '' })
     ).rejects.toThrow('Fund name is required');
   });
 });


### PR DESCRIPTION
## Summary
- drop `account_id` from `funds` table
- remove chart-of-account relationship from Fund model and adapter
- simplify fund add/edit form
- loosen fund validator and tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685997014cec83268c701f7cbc8072d4