### PR TITLE
Refactor user pages to repository pattern

### DIFF
--- a/src/pages/admin/UserAddEdit.tsx
+++ b/src/pages/admin/UserAddEdit.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
-import { useMessageStore } from '../../components/MessageHandler';
-import { Save, Loader2, AlertCircle, UserPlus } from 'lucide-react';
+import { Save, Loader2, UserPlus } from 'lucide-react';
 import BackButton from '../../components/BackButton';
+import { useUserRepository } from '../../hooks/useUserRepository';
+import { Input } from '../../components/ui2/input';
+import { Checkbox } from '../../components/ui2/checkbox';
+import { Button } from '../../components/ui2/button';
 
 type UserFormData = {
   email: string;
@@ -17,8 +20,7 @@ type UserFormData = {
 const UserAddEdit = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { addMessage } = useMessageStore();
+  const { useQuery: useUserQuery, useCreate, useUpdate } = useUserRepository();
   const [formData, setFormData] = useState<UserFormData>({
     email: '',
     password: '',
@@ -27,45 +29,20 @@ const UserAddEdit = () => {
     last_name: '',
   });
 
-  // Get current tenant
-  const { data: currentTenant } = useQuery({
-    queryKey: ['current-tenant'],
-    queryFn: async () => {
-      const { data, error } = await supabase.rpc('get_current_tenant');
-      if (error) throw error;
-      return data?.[0];
-    },
+  const { data: userResult, isLoading: userLoading } = useUserQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    relationships: [
+      {
+        table: 'user_roles',
+        foreignKey: 'user_id',
+        nestedRelationships: [
+          { table: 'roles', foreignKey: 'role_id', select: ['name'] }
+        ]
+      }
+    ],
+    enabled: !!id
   });
-
-  // Fetch user data if editing
-  const { data: userData, isLoading: userLoading } = useQuery({
-    queryKey: ['user', id],
-    queryFn: async () => {
-      if (!id) return null;
-
-      // Get user details using the secure function
-      const { data, error: userError } = await supabase.rpc('manage_user', {
-        operation: 'get',
-        target_user_id: id
-      });
-
-      if (userError) throw userError;
-      if (!data) throw new Error('User not found');
-
-      // Get user roles
-      const { data: rolesData, error: rolesError } = await supabase.rpc('get_user_roles_with_permissions', {
-        target_user_id: id
-      });
-
-      if (rolesError) throw rolesError;
-
-      return {
-        ...data,
-        roles: rolesData?.map(r => r.role_name) || [],
-      };
-    },
-    enabled: !!id,
-  });
+  const userData = userResult?.data?.[0];
 
   // Fetch available roles
   const { data: roles } = useQuery({
@@ -86,120 +63,27 @@ const UserAddEdit = () => {
       setFormData({
         email: userData.email,
         password: '',
-        roles: userData.roles || [],
+        roles: userData.user_roles?.map((r: any) => r.roles?.name) || [],
         first_name: userData.raw_user_meta_data?.first_name || '',
         last_name: userData.raw_user_meta_data?.last_name || '',
       });
     }
   }, [userData]);
 
-  const createUserMutation = useMutation({
-    mutationFn: async (data: UserFormData) => {
-      if (!currentTenant?.id) {
-        throw new Error('No tenant found');
-      }
-
-      // Create user with proper tenant and role assignment
-      const { data: newUser, error } = await supabase.rpc('handle_user_creation', {
-        p_email: data.email,
-        p_password: data.password,
-        p_tenant_id: currentTenant.id,
-        p_roles: data.roles,
-        p_first_name: data.first_name,
-        p_last_name: data.last_name,
-        p_admin_role: data.roles.includes('admin') ? 'tenant_admin' : 'member'
-      });
-
-      if (error) throw error;
-      return newUser;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
-      addMessage({
-        type: 'success',
-        text: 'User created successfully',
-        duration: 3000,
-      });
-      navigate('/admin/users');
-    },
-    onError: (error: Error) => {
-      addMessage({
-        type: 'error',
-        text: error.message,
-        duration: 5000,
-      });
-    },
-  });
-
-  const updateUserMutation = useMutation({
-    mutationFn: async (data: UserFormData) => {
-      if (!id) return;
-
-      const { error: updateError } = await supabase.rpc('manage_user', {
-        operation: 'update',
-        target_user_id: id,
-        user_data: {
-          password: data.password || undefined,
-          roles: data.roles,
-        }
-      });
-
-      if (updateError) throw updateError;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
-      addMessage({
-        type: 'success',
-        text: 'User updated successfully',
-        duration: 3000,
-      });
-      navigate('/admin/users');
-    },
-    onError: (error: Error) => {
-      addMessage({
-        type: 'error',
-        text: error.message,
-        duration: 5000,
-      });
-    },
-  });
+  const createUserMutation = useCreate();
+  const updateUserMutation = useUpdate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!id && !formData.email) {
-      addMessage({
-        type: 'error',
-        text: 'Email is required',
-        duration: 5000,
-      });
-      return;
-    }
-
-    if (!id && !formData.password) {
-      addMessage({
-        type: 'error',
-        text: 'Password is required for new users',
-        duration: 5000,
-      });
-      return;
-    }
-
-    if (!id && formData.password.length < 6) {
-      addMessage({
-        type: 'error',
-        text: 'Password must be at least 6 characters long',
-        duration: 5000,
-      });
-      return;
-    }
 
     try {
       if (id) {
-        await updateUserMutation.mutateAsync(formData);
+        await updateUserMutation.mutateAsync({ id, data: formData });
       } else {
-        await createUserMutation.mutateAsync(formData);
+        await createUserMutation.mutateAsync({ data: formData });
       }
+      navigate('/admin/users');
     } catch (error) {
       console.error('Error saving user:', error);
     }
@@ -235,59 +119,41 @@ const UserAddEdit = () => {
           <div className="px-4 py-5 sm:px-6">
             <div className="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-2">
               <div className="sm:col-span-2">
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                  Email Address {!id && '*'}
-                </label>
-                <input
+                <Input
                   type="email"
-                  id="email"
+                  label={`Email Address ${!id ? '*' : ''}`}
                   value={formData.email}
                   onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
                   required={!id}
                   disabled={!!id}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm disabled:bg-gray-100"
                   placeholder="user@example.com"
                 />
               </div>
 
               <div>
-                <label htmlFor="first_name" className="block text-sm font-medium text-gray-700">
-                  First Name
-                </label>
-                <input
-                  type="text"
-                  id="first_name"
+                <Input
+                  label="First Name"
                   value={formData.first_name}
                   onChange={(e) => setFormData(prev => ({ ...prev, first_name: e.target.value }))}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
                 />
               </div>
 
               <div>
-                <label htmlFor="last_name" className="block text-sm font-medium text-gray-700">
-                  Last Name
-                </label>
-                <input
-                  type="text"
-                  id="last_name"
+                <Input
+                  label="Last Name"
                   value={formData.last_name}
                   onChange={(e) => setFormData(prev => ({ ...prev, last_name: e.target.value }))}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
                 />
               </div>
 
               <div className="sm:col-span-2">
-                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-                  {id ? 'New Password (optional)' : 'Password *'}
-                </label>
-                <input
+                <Input
                   type="password"
-                  id="password"
+                  label={id ? 'New Password (optional)' : 'Password *'}
                   value={formData.password}
                   onChange={(e) => setFormData(prev => ({ ...prev, password: e.target.value }))}
                   required={!id}
                   minLength={6}
-                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500 sm:text-sm"
                   placeholder={id ? 'Leave blank to keep current password' : '••••••'}
                 />
               </div>
@@ -298,34 +164,22 @@ const UserAddEdit = () => {
                 </label>
                 <div className="mt-2 space-y-2">
                   {roles?.map((role) => (
-                    <div key={role.id} className="relative flex items-start">
-                      <div className="flex items-center h-5">
-                        <input
-                          id={`role-${role.id}`}
-                          type="checkbox"
-                          checked={formData.roles.includes(role.name)}
-                          onChange={(e) => {
-                            setFormData(prev => ({
-                              ...prev,
-                              roles: e.target.checked
-                                ? [...prev.roles, role.name]
-                                : prev.roles.filter((name) => name !== role.name),
-                            }));
-                          }}
-                          className="focus:ring-primary-500 h-4 w-4 text-primary-600 border-gray-300 rounded"
-                        />
-                      </div>
-                      <div className="ml-3 text-sm">
-                        <label
-                          htmlFor={`role-${role.id}`}
-                          className="font-medium text-gray-700"
-                        >
-                          {role.name}
-                        </label>
-                        {role.description && (
-                          <p className="text-gray-500">{role.description}</p>
-                        )}
-                      </div>
+                    <div key={role.id} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={`role-${role.id}`}
+                        checked={formData.roles.includes(role.name)}
+                        onCheckedChange={(checked) => {
+                          setFormData(prev => ({
+                            ...prev,
+                            roles: checked
+                              ? [...prev.roles, role.name]
+                              : prev.roles.filter((name) => name !== role.name),
+                          }));
+                        }}
+                      />
+                      <label htmlFor={`role-${role.id}`} className="text-sm font-medium text-gray-700">
+                        {role.name}
+                      </label>
                     </div>
                   ))}
                 </div>
@@ -333,35 +187,30 @@ const UserAddEdit = () => {
             </div>
 
             <div className="mt-6 flex justify-end space-x-3">
-              <button
-                type="button"
-                onClick={() => navigate('/admin/users')}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
+              <Button variant="outline" type="button" onClick={() => navigate('/admin/users')}>
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 disabled={createUserMutation.isPending || updateUserMutation.isPending}
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50"
               >
                 {createUserMutation.isPending || updateUserMutation.isPending ? (
                   <>
-                    <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5" />
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     Saving...
                   </>
                 ) : id ? (
                   <>
-                    <Save className="-ml-1 mr-2 h-5 w-5" />
+                    <Save className="mr-2 h-4 w-4" />
                     Save Changes
                   </>
                 ) : (
                   <>
-                    <UserPlus className="-ml-1 mr-2 h-5 w-5" />
+                    <UserPlus className="mr-2 h-4 w-4" />
                     Create User
                   </>
                 )}
-              </button>
+              </Button>
             </div>
           </div>
         </form>

--- a/src/pages/admin/UserList.tsx
+++ b/src/pages/admin/UserList.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
 import PermissionGate from '../../components/PermissionGate';
 import { usePermissions } from '../../hooks/usePermissions';
-import { useMessageStore } from '../../components/MessageHandler';
 import {
   Plus,
   Edit2,
@@ -13,107 +10,70 @@ import {
   Search,
   Filter,
 } from 'lucide-react';
+import { useUserRepository } from '../../hooks/useUserRepository';
+import { Input } from '../../components/ui2/input';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '../../components/ui2/alert-dialog';
+import { Button } from '../../components/ui2/button';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '../../components/ui2/table';
 
 type User = {
   id: string;
   email: string;
   created_at: string;
   last_sign_in_at: string | null;
-  roles: any[];
+  user_roles: any[];
 };
 
 function Users() {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const { hasPermission } = usePermissions();
-  const { addMessage } = useMessageStore();
   const [searchTerm, setSearchTerm] = useState('');
   const [userToDelete, setUserToDelete] = useState<User | null>(null);
 
-  // Get current tenant ID
-  const { data: currentTenant } = useQuery({
-    queryKey: ['current-tenant'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .rpc('get_current_tenant');
+  const { useQuery: useUsersQuery, useDelete } = useUserRepository();
 
-      if (error) throw error;
-      return data?.[0];
-    },
+  const { data: result, isLoading } = useUsersQuery({
+    relationships: [
+      {
+        table: 'user_roles',
+        foreignKey: 'user_id',
+        nestedRelationships: [
+          { table: 'roles', foreignKey: 'role_id', select: ['name'] }
+        ]
+      }
+    ],
+    enabled: hasPermission('user.view')
   });
 
-  // Get users for current tenant
-  const { data: users, isLoading } = useQuery({
-    queryKey: ['tenant-users', currentTenant?.id],
-    queryFn: async () => {
-      if (!currentTenant?.id) return [];
+  const users = result?.data as any[] | undefined;
 
-      const { data: users, error } = await supabase
-        .rpc('get_tenant_users', { p_tenant_id: currentTenant.id });
+  const deleteUserMutation = useDelete();
 
-      if (error) throw error;
-
-      // Get roles for each user
-      const usersWithRoles = await Promise.all(
-        users.map(async (user) => {
-          const { data: roles, error: rolesError } = await supabase
-            .rpc('get_user_roles_with_permissions', { target_user_id: user.id });
-
-          if (rolesError) throw rolesError;
-
-          return {
-            ...user,
-            roles: roles || [],
-          };
-        })
-      );
-
-      return usersWithRoles;
-    },
-    enabled: !!currentTenant?.id && hasPermission('user.view'),
-  });
-
-  const deleteUserMutation = useMutation({
-    mutationFn: async (userId: string) => {
-      const { error } = await supabase.rpc('manage_user', {
-        operation: 'delete',
-        target_user_id: userId
-      });
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['tenant-users'] });
-      addMessage({
-        type: 'success',
-        text: 'User deleted successfully',
-        duration: 3000,
-      });
-      setUserToDelete(null);
-    },
-    onError: (error: Error) => {
-      addMessage({
-        type: 'error',
-        text: 'Failed to delete user',
-        duration: 5000,
-      });
-      console.error('Error deleting user:', error);
-      setUserToDelete(null);
-    },
-  });
-
-  const handleDelete = async (user: User) => {
+  const handleDelete = (user: User) => {
     setUserToDelete(user);
-    addMessage({
-      type: 'warning',
-      text: `Are you sure you want to delete ${user.email}?`,
-      duration: 0, // Don't auto-dismiss
-    });
   };
 
   const confirmDelete = async () => {
     if (userToDelete) {
       try {
         await deleteUserMutation.mutateAsync(userToDelete.id);
+        setUserToDelete(null);
       } catch (error) {
         console.error('Error deleting user:', error);
       }
@@ -144,12 +104,11 @@ function Users() {
         </div>
         <PermissionGate permission="user.create">
           <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-            <Link
-              to="/admin/users/add"
-              className="inline-flex items-center justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:w-auto"
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Add User
+            <Link to="/admin/users/add">
+              <Button className="flex items-center">
+                <Plus className="h-4 w-4 mr-2" />
+                Add User
+              </Button>
             </Link>
           </div>
         </PermissionGate>
@@ -157,15 +116,11 @@ function Users() {
 
       <div className="mt-6">
         <div className="relative max-w-xs">
-          <div className="pointer-events-none absolute inset-y-0 left-0 pl-3 flex items-center">
-            <Search className="h-5 w-5 text-gray-400" />
-          </div>
-          <input
-            type="text"
-            className="block w-full rounded-md border border-gray-300 pl-10 pr-3 py-2 text-sm placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
-            placeholder="Search users..."
+          <Input
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Search users..."
+            icon={<Search className="h-5 w-5" />}
           />
         </div>
       </div>
@@ -175,89 +130,71 @@ function Users() {
           <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
         </div>
       ) : filteredUsers && filteredUsers.length > 0 ? (
-        <div className="mt-8 flex flex-col">
-          <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-            <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
-              <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-                <table className="min-w-full divide-y divide-gray-300">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th scope="col" className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
-                        Email
-                      </th>
-                      <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        Roles
-                      </th>
-                      <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        Created At
-                      </th>
-                      <th scope="col" className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
-                        Last Sign In
-                      </th>
-                      <th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                        <span className="sr-only">Actions</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-200 bg-white">
-                    {filteredUsers.map((user) => (
-                      <tr key={user.id}>
-                        <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
-                          {user.email}
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                          <div className="flex flex-wrap gap-1">
-                            {user.roles.map((ur, index) => (
-                              <span
-                                key={index}
-                                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"
-                              >
-                                {ur.role_name}
-                              </span>
-                            ))}
-                          </div>
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                          {new Date(user.created_at).toLocaleDateString()}
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-                          {user.last_sign_in_at
-                            ? new Date(user.last_sign_in_at).toLocaleDateString()
-                            : 'Never'}
-                        </td>
-                        <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                          <div className="flex justify-end space-x-2">
-                            <PermissionGate permission="user.edit">
-                              <button
-                                className="text-primary-600 hover:text-primary-900"
-                                onClick={() => handleEdit(user)}
-                              >
-                                <Edit2 className="h-4 w-4" />
-                              </button>
-                            </PermissionGate>
-                            <PermissionGate permission="user.delete">
-                              <button
-                                className="text-red-600 hover:text-red-900"
-                                onClick={() => handleDelete(user)}
-                                disabled={deleteUserMutation.isPending}
-                              >
-                                {deleteUserMutation.isPending ? (
-                                  <Loader2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                  <Trash2 className="h-4 w-4" />
-                                )}
-                              </button>
-                            </PermissionGate>
-                          </div>
-                        </td>
-                      </tr>
+        <Table className="mt-8">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Roles</TableHead>
+              <TableHead>Created At</TableHead>
+              <TableHead>Last Sign In</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredUsers.map((user) => (
+              <TableRow key={user.id}>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-1">
+                    {user.user_roles?.map((ur: any, index: number) => (
+                      <span
+                        key={index}
+                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"
+                      >
+                        {ur.roles?.name}
+                      </span>
                     ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-        </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  {new Date(user.created_at).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  {user.last_sign_in_at
+                    ? new Date(user.last_sign_in_at).toLocaleDateString()
+                    : 'Never'}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex justify-end space-x-2">
+                    <PermissionGate permission="user.edit">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleEdit(user)}
+                        icon={<Edit2 className="h-4 w-4" />}
+                      />
+                    </PermissionGate>
+                    <PermissionGate permission="user.delete">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(user)}
+                        disabled={deleteUserMutation.isPending}
+                        icon={
+                          deleteUserMutation.isPending ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-4 w-4" />
+                          )
+                        }
+                      />
+                    </PermissionGate>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
       ) : (
         <div className="text-center py-8 bg-white shadow sm:rounded-lg mt-8">
           <p className="text-sm text-gray-500">
@@ -268,43 +205,31 @@ function Users() {
         </div>
       )}
 
-      {/* Confirmation Dialog */}
-      {userToDelete && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">
-              Delete User
-            </h3>
-            <p className="text-sm text-gray-500 mb-6">
-              Are you sure you want to delete {userToDelete.email}? This action cannot be undone.
-            </p>
-            <div className="flex justify-end space-x-3">
-              <button
-                type="button"
-                onClick={() => setUserToDelete(null)}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={confirmDelete}
-                disabled={deleteUserMutation.isPending}
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
-              >
-                {deleteUserMutation.isPending ? (
-                  <>
-                    <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5" />
-                    Deleting...
-                  </>
-                ) : (
-                  'Delete'
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <AlertDialog open={!!userToDelete} onOpenChange={() => setUserToDelete(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="danger">Delete User</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete {userToDelete?.email}? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setUserToDelete(null)}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={confirmDelete}>
+              {deleteUserMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor user list, profile, and add/edit pages to use `useUserRepository`
- replace HTML inputs and buttons with ui2 components
- use `UserValidator` via repository methods for validation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a52dc8c9083268f35f3f60e80abf3