### PR TITLE
Forward enabled option in query hook

### DIFF
--- a/src/hooks/useBaseRepository.ts
+++ b/src/hooks/useBaseRepository.ts
@@ -16,6 +16,7 @@ export function useBaseRepository<T extends BaseModel>(
       queryKey: [queryKey, options],
       queryFn: () => repository.find(options),
       staleTime: 5 * 60 * 1000, // 5 minutes
+      enabled: options.enabled ?? true,
     });
   };
 


### PR DESCRIPTION
## Summary
- pass the `enabled` flag from `useBaseRepository` to React Query

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a58a137d483268ea70f4b57706216