### PR TITLE
Add fund description field

### DIFF
--- a/src/adapters/fund.adapter.ts
+++ b/src/adapters/fund.adapter.ts
@@ -21,6 +21,7 @@ export class FundAdapter
   protected defaultSelect = `
     id,
     name,
+    description,
     type,
     created_by,
     updated_by,

--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -5,5 +5,6 @@ export type FundType = 'restricted' | 'unrestricted';
 export interface Fund extends BaseModel {
   id: string;
   name: string;
+  description: string | null;
   type: FundType;
 }

--- a/src/pages/finances/FundAddEdit.tsx
+++ b/src/pages/finances/FundAddEdit.tsx
@@ -4,6 +4,7 @@ import { useFundRepository } from '../../hooks/useFundRepository';
 import { Fund, FundType } from '../../models/fund.model';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
+import { Textarea } from '../../components/ui2/textarea';
 import { Button } from '../../components/ui2/button';
 import BackButton from '../../components/BackButton';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
@@ -19,6 +20,7 @@ function FundAddEdit() {
 
   const [formData, setFormData] = useState<Partial<Fund>>({
     name: '',
+    description: '',
     type: 'unrestricted',
   });
   const [error, setError] = useState<string | null>(null);
@@ -112,6 +114,16 @@ function FundAddEdit() {
                     <SelectItem value="restricted">Restricted</SelectItem>
                   </SelectContent>
                 </Select>
+              </div>
+
+              <div className="sm:col-span-2">
+                <Textarea
+                  label="Description"
+                  value={formData.description || ''}
+                  onChange={(e) => handleInputChange('description', e.target.value)}
+                  rows={3}
+                  placeholder="Enter fund description (optional)"
+                />
               </div>
 
             </div>

--- a/src/pages/finances/FundList.tsx
+++ b/src/pages/finances/FundList.tsx
@@ -26,7 +26,10 @@ function FundList() {
   const funds = result?.data || [];
 
   const filteredFunds = funds.filter((fund: Fund) => {
-    const matchesSearch = fund.name.toLowerCase().includes(searchTerm.toLowerCase());
+    const search = searchTerm.toLowerCase();
+    const matchesSearch =
+      fund.name.toLowerCase().includes(search) ||
+      (fund.description ? fund.description.toLowerCase().includes(search) : false);
     const matchesType = typeFilter === 'all' || fund.type === typeFilter;
     return matchesSearch && matchesType;
   });
@@ -37,6 +40,12 @@ function FundList() {
       headerName: 'Fund Name',
       flex: 2,
       minWidth: 200,
+    },
+    {
+      field: 'description',
+      headerName: 'Description',
+      flex: 3,
+      minWidth: 250,
     },
     {
       field: 'type',

--- a/src/pages/finances/FundProfile.tsx
+++ b/src/pages/finances/FundProfile.tsx
@@ -193,6 +193,10 @@ function FundProfile() {
                   <dd className="text-sm text-foreground col-span-2 capitalize">{fund.type}</dd>
                 </div>
                 <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Description</dt>
+                  <dd className="text-sm text-foreground col-span-2">{fund.description || 'No description provided'}</dd>
+                </div>
+                <div className="py-3 grid grid-cols-3 gap-4">
                   <dt className="text-sm font-medium text-muted-foreground">Created</dt>
                   <dd className="text-sm text-foreground col-span-2">
                     {new Date(fund.created_at).toLocaleDateString()} at {new Date(fund.created_at).toLocaleTimeString()}

--- a/src/repositories/fund.repository.ts
+++ b/src/repositories/fund.repository.ts
@@ -38,6 +38,7 @@ export class FundRepository
     return {
       ...data,
       name: data.name?.trim(),
+      description: data.description?.trim(),
     };
   }
 }

--- a/supabase/migrations/20250630000000_fund_description.sql
+++ b/supabase/migrations/20250630000000_fund_description.sql
@@ -1,0 +1,13 @@
+-- Add description column to funds
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'funds'
+      AND column_name = 'description'
+  ) THEN
+    ALTER TABLE funds ADD COLUMN description text;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN funds.description IS
+  'Optional description of the fund';

--- a/tests/fundRepositoryValidation.test.ts
+++ b/tests/fundRepositoryValidation.test.ts
@@ -27,8 +27,9 @@ describe('FundRepository validation', () => {
 
   it('formats data on create', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
-    const data = await repo.runBeforeCreate({ name: '  My Fund ', type: 'restricted' });
+    const data = await repo.runBeforeCreate({ name: '  My Fund ', description: '  Desc  ', type: 'restricted' });
     expect(data.name).toBe('My Fund');
+    expect(data.description).toBe('Desc');
   });
 
   it('validates on update', async () => {


### PR DESCRIPTION
## Summary
- extend fund model with `description`
- select and format fund description in adapter and repository
- support descriptions in fund list, detail and edit screens
- trim description field in tests
- create migration to add column

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adf49f5808326b97f5b8adbc66e17