### PR TITLE
Add Giving section to finances

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -83,6 +83,11 @@ export const navigation: NavItem[] = [
         icon: Wallet,
       },
       {
+        name: 'Giving',
+        href: '/finances/giving',
+        icon: Heart,
+      },
+      {
         name: 'Reports',
         href: '/finances/reports',
         icon: FileText,

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -18,6 +18,9 @@ const FundProfile = React.lazy(() => import('./FundProfile'));
 const Reports = React.lazy(() => import('./Reports'));
 const JournalEntryForm = React.lazy(() => import('./JournalEntryForm'));
 const Statements = React.lazy(() => import('./Statements'));
+const GivingList = React.lazy(() => import('./giving/GivingList'));
+const GivingAddEdit = React.lazy(() => import('./giving/GivingAddEdit'));
+const GivingProfile = React.lazy(() => import('./giving/GivingProfile'));
 
 function LoadingSpinner() {
   return (
@@ -60,6 +63,10 @@ function Finances() {
         <Route path="funds/add" element={<FundAddEdit />} />
         <Route path="funds/:id/edit" element={<FundAddEdit />} />
         <Route path="funds/:id" element={<FundProfile />} />
+        <Route path="giving" element={<GivingList />} />
+        <Route path="giving/add" element={<GivingAddEdit />} />
+        <Route path="giving/:id/edit" element={<GivingAddEdit />} />
+        <Route path="giving/:id" element={<GivingProfile />} />
         <Route path="reports" element={<Reports />} />
         <Route path="statements" element={<Statements />} />
         <Route path="journal-entry" element={<JournalEntryForm />} />


### PR DESCRIPTION
## Summary
- import new giving pages lazily in finances page
- set up routes for giving list, create/edit, and profile
- link to giving section in navigation menu

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b08dd29948326b1300c94cb4716ed