### PR TITLE
Add Expense entry pages

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -83,6 +83,11 @@ export const navigation: NavItem[] = [
         icon: Wallet,
       },
       {
+        name: 'Expenses',
+        href: '/finances/expenses',
+        icon: CreditCard,
+      },
+      {
         name: 'Giving',
         href: '/finances/giving',
         icon: Heart,

--- a/src/hooks/useExpenseService.ts
+++ b/src/hooks/useExpenseService.ts
@@ -1,0 +1,50 @@
+import type { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
+import { ExpenseService, ExpenseLine } from '../services/ExpenseService';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { NotificationService } from '../services/NotificationService';
+
+export interface ExpenseEntry extends ExpenseLine {}
+
+export function useExpenseService() {
+  const service = container.get<ExpenseService>(TYPES.ExpenseService);
+  const queryClient = useQueryClient();
+
+  const createMutation = useMutation({
+    mutationFn: ({ header, expenses }: { header: Partial<FinancialTransactionHeader>; expenses: ExpenseEntry[] }) =>
+      service.createExpenseBatch(header, expenses),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['financial_transaction_headers'] });
+      NotificationService.showSuccess('Transaction created successfully');
+    },
+    onError: (error: Error) => {
+      NotificationService.showError(error.message, 5000);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, header, expenses }: { id: string; header: Partial<FinancialTransactionHeader>; expenses: ExpenseEntry[] }) =>
+      service.updateExpenseBatch(id, header, expenses),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['financial_transaction_headers'] });
+      NotificationService.showSuccess('Transaction updated successfully');
+    },
+    onError: (error: Error) => {
+      NotificationService.showError(error.message, 5000);
+    },
+  });
+
+  const createExpenseBatch = async (
+    header: Partial<FinancialTransactionHeader>,
+    expenses: ExpenseEntry[],
+  ) => createMutation.mutateAsync({ header, expenses });
+
+  const updateExpenseBatch = async (
+    id: string,
+    header: Partial<FinancialTransactionHeader>,
+    expenses: ExpenseEntry[],
+  ) => updateMutation.mutateAsync({ id, header, expenses });
+
+  return { createExpenseBatch, updateExpenseBatch, createMutation, updateMutation };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -68,6 +68,7 @@ import { CategoryRepository, type ICategoryRepository } from '../repositories/ca
 import { UserRepository, type IUserRepository } from '../repositories/user.repository';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { GivingService } from '../services/GivingService';
+import { ExpenseService } from '../services/ExpenseService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -130,6 +131,10 @@ container
 container
   .bind<GivingService>(TYPES.GivingService)
   .to(GivingService)
+  .inSingletonScope();
+container
+  .bind<ExpenseService>(TYPES.ExpenseService)
+  .to(ExpenseService)
   .inSingletonScope();
 
 // Register repositories

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,5 +24,6 @@ export const TYPES = {
   ICategoryRepository: 'ICategoryRepository',
   IUserRepository: 'IUserRepository',
   AuditService: 'AuditService',
-  GivingService: 'GivingService'
+  GivingService: 'GivingService',
+  ExpenseService: 'ExpenseService'
 };

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -21,6 +21,9 @@ const Statements = React.lazy(() => import('./Statements'));
 const GivingList = React.lazy(() => import('./giving/GivingList'));
 const GivingAddEdit = React.lazy(() => import('./giving/GivingAddEdit'));
 const GivingProfile = React.lazy(() => import('./giving/GivingProfile'));
+const ExpenseList = React.lazy(() => import('./expenses/ExpenseList'));
+const ExpenseAddEdit = React.lazy(() => import('./expenses/ExpenseAddEdit'));
+const ExpenseProfile = React.lazy(() => import('./expenses/ExpenseProfile'));
 
 function LoadingSpinner() {
   return (
@@ -63,6 +66,10 @@ function Finances() {
         <Route path="funds/add" element={<FundAddEdit />} />
         <Route path="funds/:id/edit" element={<FundAddEdit />} />
         <Route path="funds/:id" element={<FundProfile />} />
+        <Route path="expenses" element={<ExpenseList />} />
+        <Route path="expenses/add" element={<ExpenseAddEdit />} />
+        <Route path="expenses/:id/edit" element={<ExpenseAddEdit />} />
+        <Route path="expenses/:id" element={<ExpenseProfile />} />
         <Route path="giving" element={<GivingList />} />
         <Route path="giving/add" element={<GivingAddEdit />} />
         <Route path="giving/:id/edit" element={<GivingAddEdit />} />

--- a/src/pages/finances/expenses/ExpenseAddEdit.tsx
+++ b/src/pages/finances/expenses/ExpenseAddEdit.tsx
@@ -1,0 +1,244 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Card, CardContent, CardFooter, CardHeader } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import { Input } from '../../../components/ui2/input';
+import { Combobox } from '../../../components/ui2/combobox';
+import { DatePickerInput } from '../../../components/ui2/date-picker';
+import { useAccountRepository } from '../../../hooks/useAccountRepository';
+import { useFundRepository } from '../../../hooks/useFundRepository';
+import { useCategoryRepository } from '../../../hooks/useCategoryRepository';
+import { useFinancialSourceRepository } from '../../../hooks/useFinancialSourceRepository';
+import { useExpenseService, ExpenseEntry } from '../../../hooks/useExpenseService';
+import BackButton from '../../../components/BackButton';
+import { Plus, Trash2, Loader2 } from 'lucide-react';
+
+function ExpenseAddEdit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const { createExpenseBatch, updateExpenseBatch, createMutation, updateMutation } = useExpenseService();
+
+  const { useQuery: useAccountsQuery } = useAccountRepository();
+  const { useQuery: useFundsQuery } = useFundRepository();
+  const { useQuery: useCategoriesQuery } = useCategoryRepository();
+  const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
+
+  const { data: accountsData } = useAccountsQuery();
+  const { data: fundsData } = useFundsQuery();
+  const { data: categoriesData } = useCategoriesQuery({
+    filters: { type: { operator: 'eq', value: 'expense_transaction' } },
+  });
+  const { data: sourcesData } = useSourcesQuery({
+    filters: { is_active: { operator: 'eq', value: true } },
+  });
+
+  const accounts = accountsData?.data || [];
+  const funds = fundsData?.data || [];
+  const categories = categoriesData?.data || [];
+  const sources = sourcesData?.data || [];
+
+  const accountOptions = React.useMemo(
+    () => accounts.map(a => ({ value: a.id, label: a.name })),
+    [accounts],
+  );
+  const fundOptions = React.useMemo(
+    () => funds.map(f => ({ value: f.id, label: f.name })),
+    [funds],
+  );
+  const categoryOptions = React.useMemo(
+    () => categories.map(c => ({ value: c.id, label: c.name })),
+    [categories],
+  );
+  const sourceOptions = React.useMemo(
+    () => sources.map(s => ({ value: s.id, label: s.name })),
+    [sources],
+  );
+
+  const [headerData, setHeaderData] = useState({
+    transaction_date: new Date().toISOString().split('T')[0],
+    description: '',
+  });
+
+  const [entries, setEntries] = useState<ExpenseEntry[]>([
+    {
+      accounts_account_id: '',
+      fund_id: '',
+      category_id: '',
+      source_id: '',
+      amount: 0,
+      source_account_id: null,
+      category_account_id: null,
+    },
+  ]);
+
+  useEffect(() => {
+    setEntries((prev) =>
+      prev.map((e) => ({
+        ...e,
+        source_account_id: sources.find((s) => s.id === e.source_id)?.account_id || null,
+        category_account_id: categories.find((c) => c.id === e.category_id)?.chart_of_account_id || null,
+      })),
+    );
+  }, [sources, categories]);
+
+  const handleEntryChange = (index: number, field: keyof ExpenseEntry, value: any) => {
+    const newEntries = [...entries];
+    newEntries[index] = { ...newEntries[index], [field]: value };
+    if (field === 'source_id') {
+      newEntries[index].source_account_id = sources.find((s) => s.id === value)?.account_id || null;
+    }
+    if (field === 'category_id') {
+      newEntries[index].category_account_id = categories.find((c) => c.id === value)?.chart_of_account_id || null;
+    }
+    setEntries(newEntries);
+  };
+
+  const addEntry = () => {
+    setEntries([
+      ...entries,
+      {
+        accounts_account_id: '',
+        fund_id: '',
+        category_id: '',
+        source_id: '',
+        amount: 0,
+        source_account_id: null,
+        category_account_id: null,
+      },
+    ]);
+  };
+
+  const removeEntry = (index: number) => {
+    const newEntries = [...entries];
+    newEntries.splice(index, 1);
+    setEntries(newEntries);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isEditMode && id) {
+      await updateExpenseBatch(id, headerData, entries);
+    } else {
+      await createExpenseBatch(headerData, entries);
+    }
+    navigate('/finances/expenses');
+  };
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath="/finances/expenses" label="Back to Expenses" />
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card className="dark:bg-slate-800">
+          <CardHeader>
+            <h3 className="text-lg font-medium">{isEditMode ? 'Edit Expense' : 'New Expense'}</h3>
+          </CardHeader>
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <DatePickerInput
+              label="Date"
+              value={headerData.transaction_date ? new Date(headerData.transaction_date) : undefined}
+              onChange={(d) => setHeaderData({ ...headerData, transaction_date: d ? d.toISOString().split('T')[0] : '' })}
+              required
+            />
+            <Input
+              label="Description"
+              value={headerData.description}
+              onChange={(e) => setHeaderData({ ...headerData, description: e.target.value })}
+              required
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="dark:bg-slate-800">
+          <CardHeader className="flex items-center justify-between">
+            <h3 className="text-lg font-medium">Entries</h3>
+            <Button type="button" onClick={addEntry} className="flex items-center">
+              <Plus className="h-4 w-4 mr-2" /> Add Row
+            </Button>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="bg-muted text-xs text-muted-foreground dark:bg-slate-700">
+                  <th className="px-4 py-2 text-left">Account</th>
+                  <th className="px-4 py-2 text-left">Fund</th>
+                  <th className="px-4 py-2 text-left">Category</th>
+                  <th className="px-4 py-2 text-left">Source</th>
+                  <th className="px-4 py-2 text-right">Amount</th>
+                  <th className="px-4 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry, idx) => (
+                  <tr key={idx} className="border-b border-border dark:border-slate-700">
+                    <td className="px-4 py-2">
+                      <Combobox
+                        options={accountOptions}
+                        value={entry.accounts_account_id || ''}
+                        onChange={(v) => handleEntryChange(idx, 'accounts_account_id', v)}
+                        placeholder="Select account"
+                      />
+                    </td>
+                    <td className="px-4 py-2">
+                      <Combobox
+                        options={fundOptions}
+                        value={entry.fund_id || ''}
+                        onChange={(v) => handleEntryChange(idx, 'fund_id', v)}
+                        placeholder="Select fund"
+                      />
+                    </td>
+                    <td className="px-4 py-2">
+                      <Combobox
+                        options={categoryOptions}
+                        value={entry.category_id || ''}
+                        onChange={(v) => handleEntryChange(idx, 'category_id', v)}
+                        placeholder="Select category"
+                      />
+                    </td>
+                    <td className="px-4 py-2">
+                      <Combobox
+                        options={sourceOptions}
+                        value={entry.source_id || ''}
+                        onChange={(v) => handleEntryChange(idx, 'source_id', v)}
+                        placeholder="Select source"
+                      />
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <Input
+                        type="number"
+                        value={entry.amount}
+                        onChange={(e) => handleEntryChange(idx, 'amount', parseFloat(e.target.value) || 0)}
+                        className="text-right"
+                      />
+                    </td>
+                    <td className="px-4 py-2 text-center">
+                      <Button type="button" variant="ghost" size="sm" onClick={() => removeEntry(idx)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+          <CardFooter className="flex justify-end">
+            <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              {createMutation.isPending || updateMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
+                </>
+              ) : (
+                'Save'
+              )}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}
+
+export default ExpenseAddEdit;

--- a/src/pages/finances/expenses/ExpenseList.tsx
+++ b/src/pages/finances/expenses/ExpenseList.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { GridColDef } from '@mui/x-data-grid';
+import { Plus } from 'lucide-react';
+
+function ExpenseList() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const { useQuery } = useFinancialTransactionHeaderRepository();
+  const { data: result, isLoading } = useQuery({
+    order: { column: 'transaction_date', ascending: false },
+  });
+  const headers = result?.data || [];
+
+  const columns: GridColDef[] = [
+    { field: 'transaction_date', headerName: 'Date', flex: 1, minWidth: 120 },
+    { field: 'transaction_number', headerName: 'Number', flex: 1, minWidth: 150 },
+    { field: 'description', headerName: 'Description', flex: 2, minWidth: 200 },
+  ];
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-foreground">Expenses</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Manage expense entries.</p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <Link to="/finances/expenses/add">
+            <Button className="flex items-center">
+              <Plus className="h-4 w-4 mr-2" /> Add Expense
+            </Button>
+          </Link>
+        </div>
+      </div>
+      <div className="mt-6">
+        <Card className="dark:bg-slate-800">
+          <CardContent className="p-0">
+            <DataGrid
+              columns={columns}
+              data={headers}
+              totalRows={headers.length}
+              loading={isLoading}
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+              getRowId={(row) => row.id}
+              onRowClick={(params) => navigate(`/finances/expenses/${params.id}`)}
+              autoHeight
+              page={page}
+              pageSize={pageSize}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default ExpenseList;

--- a/src/pages/finances/expenses/ExpenseProfile.tsx
+++ b/src/pages/finances/expenses/ExpenseProfile.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { Card, CardContent, CardHeader } from '../../../components/ui2/card';
+import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { GridColDef } from '@mui/x-data-grid';
+import { Loader2 } from 'lucide-react';
+import BackButton from '../../../components/BackButton';
+
+function ExpenseProfile() {
+  const { id } = useParams<{ id: string }>();
+  const { useQuery, getTransactionEntries } = useFinancialTransactionHeaderRepository();
+  const { data: headerData, isLoading: headerLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: !!id,
+  });
+  const header = headerData?.data?.[0];
+
+  const [entries, setEntries] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadEntries = async () => {
+      if (id) {
+        const data = await getTransactionEntries(id);
+        setEntries(data || []);
+        setLoading(false);
+      }
+    };
+    loadEntries();
+  }, [id, getTransactionEntries]);
+
+  const columns: GridColDef[] = [
+    { field: 'account_holder', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account_holder?.name },
+    { field: 'fund', headerName: 'Fund', flex: 1, minWidth: 120, valueGetter: p => p.row.fund?.name },
+    { field: 'category', headerName: 'Category', flex: 1, minWidth: 120, valueGetter: p => p.row.category?.name },
+    { field: 'source', headerName: 'Source', flex: 1, minWidth: 120, valueGetter: p => p.row.source?.name },
+    { field: 'debit', headerName: 'Debit', flex: 1, minWidth: 100 },
+    { field: 'credit', headerName: 'Credit', flex: 1, minWidth: 100 },
+  ];
+
+  if (headerLoading || loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!header) {
+    return (
+      <div className="w-full px-4 sm:px-6 lg:px-8">
+        <BackButton fallbackPath="/finances/expenses" label="Back" />
+        <p className="mt-4">Entry not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath="/finances/expenses" label="Back to Expenses" />
+      </div>
+      <Card className="dark:bg-slate-800 mb-6">
+        <CardHeader>
+          <h3 className="text-lg font-medium">{header.transaction_number}</h3>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{header.description}</p>
+        </CardContent>
+      </Card>
+      <Card className="dark:bg-slate-800">
+        <CardHeader>
+          <h3 className="text-lg font-medium">Entries</h3>
+        </CardHeader>
+        <CardContent className="p-0">
+          <DataGrid
+            columns={columns}
+            data={entries}
+            totalRows={entries.length}
+            loading={loading}
+            autoHeight
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default ExpenseProfile;

--- a/src/services/ExpenseService.ts
+++ b/src/services/ExpenseService.ts
@@ -1,0 +1,69 @@
+import { injectable, inject } from 'inversify';
+import type { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
+import type { IFinancialTransactionHeaderRepository } from '../repositories/financialTransactionHeader.repository';
+import { TYPES } from '../lib/types';
+
+export interface ExpenseLine {
+  accounts_account_id: string | null;
+  fund_id: string | null;
+  category_id: string | null;
+  source_id: string | null;
+  amount: number;
+  source_account_id: string | null;
+  category_account_id: string | null;
+}
+
+@injectable()
+export class ExpenseService {
+  constructor(
+    @inject(TYPES.IFinancialTransactionHeaderRepository)
+    private headerRepo: IFinancialTransactionHeaderRepository,
+  ) {}
+
+  private buildTransactions(
+    header: Partial<FinancialTransactionHeader>,
+    lines: ExpenseLine[],
+  ) {
+    return lines.flatMap((line) => {
+      const base = {
+        accounts_account_id: line.accounts_account_id,
+        fund_id: line.fund_id,
+        source_id: line.source_id,
+        category_id: line.category_id,
+        date: header.transaction_date!,
+        description: header.description || '',
+      };
+      return [
+        {
+          ...base,
+          account_id: line.category_account_id,
+          debit: line.amount,
+          credit: 0,
+        },
+        {
+          ...base,
+          account_id: line.source_account_id,
+          debit: 0,
+          credit: line.amount,
+        },
+      ];
+    });
+  }
+
+  public async createExpenseBatch(
+    header: Partial<FinancialTransactionHeader>,
+    lines: ExpenseLine[],
+  ) {
+    const transactions = this.buildTransactions(header, lines);
+    return this.headerRepo.createWithTransactions(header, transactions);
+  }
+
+  public async updateExpenseBatch(
+    id: string,
+    header: Partial<FinancialTransactionHeader>,
+    lines: ExpenseLine[],
+  ) {
+    const transactions = this.buildTransactions(header, lines);
+    return this.headerRepo.updateWithTransactions(id, header, transactions);
+  }
+}

--- a/tests/expenseService.test.ts
+++ b/tests/expenseService.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExpenseService, ExpenseLine } from '../src/services/ExpenseService';
+import type { IFinancialTransactionHeaderRepository } from '../src/repositories/financialTransactionHeader.repository';
+
+const headerRepo = {
+  createWithTransactions: vi.fn().mockResolvedValue({ id: 'h1' })
+} as unknown as IFinancialTransactionHeaderRepository;
+
+const service = new ExpenseService(headerRepo);
+
+const header = { transaction_date: '2025-06-02', description: 'Supplies' };
+const lines: ExpenseLine[] = [
+  {
+    accounts_account_id: 'acc1',
+    fund_id: 'f1',
+    category_id: 'c1',
+    source_id: 's1',
+    amount: 50,
+    source_account_id: 'a1',
+    category_account_id: 'a2'
+  }
+];
+
+describe('ExpenseService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates balanced transactions', async () => {
+    await service.createExpenseBatch(header, lines);
+
+    expect(headerRepo.createWithTransactions).toHaveBeenCalledTimes(1);
+    const [passedHeader, tx] = (headerRepo.createWithTransactions as any).mock.calls[0];
+    expect(passedHeader).toBe(header);
+    expect(tx).toEqual([
+      {
+        accounts_account_id: 'acc1',
+        fund_id: 'f1',
+        source_id: 's1',
+        category_id: 'c1',
+        date: '2025-06-02',
+        description: 'Supplies',
+        account_id: 'a2',
+        debit: 50,
+        credit: 0,
+      },
+      {
+        accounts_account_id: 'acc1',
+        fund_id: 'f1',
+        source_id: 's1',
+        category_id: 'c1',
+        date: '2025-06-02',
+        description: 'Supplies',
+        account_id: 'a1',
+        debit: 0,
+        credit: 50,
+      }
+    ]);
+    const totalDebit = tx.reduce((s: number, t: any) => s + t.debit, 0);
+    const totalCredit = tx.reduce((s: number, t: any) => s + t.credit, 0);
+    expect(totalDebit).toBe(totalCredit);
+  });
+});


### PR DESCRIPTION
## Summary
- implement ExpenseService for double-entry expense batches
- add useExpenseService hook
- add expense list/profile/add-edit pages
- register new service and routes
- expose Expenses in navigation
- test ExpenseService

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1b0932c48326bd09efbe2f43af74