### PR TITLE
Link income/expense entries to headers

### DIFF
--- a/src/adapters/incomeExpenseTransaction.adapter.ts
+++ b/src/adapters/incomeExpenseTransaction.adapter.ts
@@ -29,6 +29,7 @@ export class IncomeExpenseTransactionAdapter
     fund_id,
     source_id,
     account_id,
+    header_id,
     created_by,
     updated_by,
     created_at,
@@ -42,6 +43,13 @@ export class IncomeExpenseTransactionAdapter
     { table: 'financial_sources', foreignKey: 'source_id', select: ['id','name','source_type'] },
     { table: 'accounts', foreignKey: 'account_id', select: ['id','name'] }
   ];
+
+  public async getByHeaderId(headerId: string): Promise<IncomeExpenseTransaction[]> {
+    const query = await this.buildSecureQuery({});
+    const { data, error } = await query.eq('header_id', headerId);
+    if (error) throw error;
+    return data || [];
+  }
 
   protected override async onAfterCreate(data: IncomeExpenseTransaction): Promise<void> {
     await this.auditService.logAuditEvent('create', 'income_expense_transaction', data.id, data);

--- a/src/hooks/useIncomeExpenseTransactionRepository.ts
+++ b/src/hooks/useIncomeExpenseTransactionRepository.ts
@@ -2,8 +2,16 @@ import { container } from '../lib/container';
 import { TYPES } from '../lib/types';
 import type { IIncomeExpenseTransactionRepository } from '../repositories/incomeExpenseTransaction.repository';
 import { useBaseRepository } from './useBaseRepository';
+import { useCallback } from 'react';
 
 export function useIncomeExpenseTransactionRepository() {
   const repository = container.get<IIncomeExpenseTransactionRepository>(TYPES.IIncomeExpenseTransactionRepository);
-  return useBaseRepository(repository, 'Transaction', 'income_expense_transactions');
+  const base = useBaseRepository(repository, 'Transaction', 'income_expense_transactions');
+
+  const getByHeaderId = useCallback(
+    async (headerId: string) => repository.getByHeaderId(headerId),
+    [repository]
+  );
+
+  return { ...base, getByHeaderId };
 }

--- a/src/models/incomeExpenseTransaction.model.ts
+++ b/src/models/incomeExpenseTransaction.model.ts
@@ -26,4 +26,5 @@ export interface IncomeExpenseTransaction extends BaseModel {
   source?: FinancialSource;
   account_id: string | null;
   account?: Account;
+  header_id: string | null;
 }

--- a/src/pages/finances/expenses/ExpenseProfile.tsx
+++ b/src/pages/finances/expenses/ExpenseProfile.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
 import { Card, CardContent, CardHeader } from '../../../components/ui2/card';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
 import { GridColDef } from '@mui/x-data-grid';
@@ -9,7 +10,8 @@ import BackButton from '../../../components/BackButton';
 
 function ExpenseProfile() {
   const { id } = useParams<{ id: string }>();
-  const { useQuery, getTransactionEntries } = useFinancialTransactionHeaderRepository();
+  const { useQuery } = useFinancialTransactionHeaderRepository();
+  const { getByHeaderId } = useIncomeExpenseTransactionRepository();
   const { data: headerData, isLoading: headerLoading } = useQuery({
     filters: { id: { operator: 'eq', value: id } },
     enabled: !!id,
@@ -22,21 +24,20 @@ function ExpenseProfile() {
   useEffect(() => {
     const loadEntries = async () => {
       if (id) {
-        const data = await getTransactionEntries(id);
+        const data = await getByHeaderId(id);
         setEntries(data || []);
         setLoading(false);
       }
     };
     loadEntries();
-  }, [id, getTransactionEntries]);
+  }, [id, getByHeaderId]);
 
   const columns: GridColDef[] = [
-    { field: 'account_holder', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account_holder?.name },
+    { field: 'account', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account?.name },
     { field: 'fund', headerName: 'Fund', flex: 1, minWidth: 120, valueGetter: p => p.row.fund?.name },
     { field: 'category', headerName: 'Category', flex: 1, minWidth: 120, valueGetter: p => p.row.category?.name },
     { field: 'source', headerName: 'Source', flex: 1, minWidth: 120, valueGetter: p => p.row.source?.name },
-    { field: 'debit', headerName: 'Debit', flex: 1, minWidth: 100 },
-    { field: 'credit', headerName: 'Credit', flex: 1, minWidth: 100 },
+    { field: 'amount', headerName: 'Amount', flex: 1, minWidth: 100 },
   ];
 
   if (headerLoading || loading) {

--- a/src/pages/finances/giving/GivingProfile.tsx
+++ b/src/pages/finances/giving/GivingProfile.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
 import { Card, CardContent, CardHeader } from '../../../components/ui2/card';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
 import { GridColDef } from '@mui/x-data-grid';
@@ -9,7 +10,8 @@ import BackButton from '../../../components/BackButton';
 
 function GivingProfile() {
   const { id } = useParams<{ id: string }>();
-  const { useQuery, getTransactionEntries } = useFinancialTransactionHeaderRepository();
+  const { useQuery } = useFinancialTransactionHeaderRepository();
+  const { getByHeaderId } = useIncomeExpenseTransactionRepository();
   const { data: headerData, isLoading: headerLoading } = useQuery({
     filters: { id: { operator: 'eq', value: id } },
     enabled: !!id,
@@ -22,21 +24,20 @@ function GivingProfile() {
   useEffect(() => {
     const loadEntries = async () => {
       if (id) {
-        const data = await getTransactionEntries(id);
+        const data = await getByHeaderId(id);
         setEntries(data || []);
         setLoading(false);
       }
     };
     loadEntries();
-  }, [id, getTransactionEntries]);
+  }, [id, getByHeaderId]);
 
   const columns: GridColDef[] = [
-    { field: 'account_holder', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account_holder?.name },
+    { field: 'account', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account?.name },
     { field: 'fund', headerName: 'Fund', flex: 1, minWidth: 120, valueGetter: p => p.row.fund?.name },
     { field: 'category', headerName: 'Category', flex: 1, minWidth: 120, valueGetter: p => p.row.category?.name },
     { field: 'source', headerName: 'Source', flex: 1, minWidth: 120, valueGetter: p => p.row.source?.name },
-    { field: 'debit', headerName: 'Debit', flex: 1, minWidth: 100 },
-    { field: 'credit', headerName: 'Credit', flex: 1, minWidth: 100 },
+    { field: 'amount', headerName: 'Amount', flex: 1, minWidth: 100 },
   ];
 
   if (headerLoading || loading) {

--- a/src/repositories/incomeExpenseTransaction.repository.ts
+++ b/src/repositories/incomeExpenseTransaction.repository.ts
@@ -5,7 +5,9 @@ import type { IIncomeExpenseTransactionAdapter } from '../adapters/incomeExpense
 import { NotificationService } from '../services/NotificationService';
 import { IncomeExpenseTransactionValidator } from '../validators/incomeExpenseTransaction.validator';
 
-export interface IIncomeExpenseTransactionRepository extends BaseRepository<IncomeExpenseTransaction> {}
+export interface IIncomeExpenseTransactionRepository extends BaseRepository<IncomeExpenseTransaction> {
+  getByHeaderId(headerId: string): Promise<IncomeExpenseTransaction[]>;
+}
 
 @injectable()
 export class IncomeExpenseTransactionRepository
@@ -56,5 +58,11 @@ export class IncomeExpenseTransactionRepository
       formatted.reference = formatted.reference.trim();
     }
     return formatted;
+  }
+
+  public async getByHeaderId(headerId: string): Promise<IncomeExpenseTransaction[]> {
+    return (
+      this.adapter as unknown as IIncomeExpenseTransactionAdapter
+    ).getByHeaderId(headerId);
   }
 }

--- a/src/services/IncomeExpenseTransactionService.ts
+++ b/src/services/IncomeExpenseTransactionService.ts
@@ -79,6 +79,7 @@ export class IncomeExpenseTransactionService {
   private buildEntry(
     header: Partial<FinancialTransactionHeader>,
     line: IncomeExpenseEntry,
+    headerId: string,
   ) {
     return {
       transaction_type: line.transaction_type,
@@ -91,6 +92,7 @@ export class IncomeExpenseTransactionService {
       fund_id: line.fund_id,
       source_id: line.source_id,
       account_id: line.accounts_account_id,
+      header_id: headerId,
     };
   }
 
@@ -102,7 +104,7 @@ export class IncomeExpenseTransactionService {
     const result = await this.headerRepo.createWithTransactions(header, transactions);
 
     for (const line of lines) {
-      await this.ieRepo.create(this.buildEntry(header, line));
+      await this.ieRepo.create(this.buildEntry(header, line, result.id));
     }
 
     return result;
@@ -117,7 +119,7 @@ export class IncomeExpenseTransactionService {
     const result = await this.headerRepo.updateWithTransactions(id, header, transactions);
 
     for (const line of lines) {
-      await this.ieRepo.create(this.buildEntry(header, line));
+      await this.ieRepo.create(this.buildEntry(header, line, id));
     }
 
     return result;

--- a/supabase/migrations/20250702040000_income_expense_header.sql
+++ b/supabase/migrations/20250702040000_income_expense_header.sql
@@ -1,0 +1,15 @@
+-- Link income_expense_transactions to financial_transaction_headers
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'income_expense_transactions'
+      AND column_name = 'header_id'
+  ) THEN
+    ALTER TABLE income_expense_transactions
+      ADD COLUMN header_id uuid REFERENCES financial_transaction_headers(id);
+    CREATE INDEX IF NOT EXISTS income_expense_transactions_header_id_idx
+      ON income_expense_transactions(header_id);
+    COMMENT ON COLUMN income_expense_transactions.header_id IS 'Header reference for corresponding debit/credit transactions';
+  END IF;
+END $$;

--- a/tests/incomeExpenseTransactionService.test.ts
+++ b/tests/incomeExpenseTransactionService.test.ts
@@ -73,6 +73,7 @@ describe('IncomeExpenseTransactionService', () => {
       fund_id: 'f1',
       source_id: 's1',
       account_id: 'acc1',
+      header_id: 'h1',
     });
   });
 
@@ -84,7 +85,9 @@ describe('IncomeExpenseTransactionService', () => {
     const [, , tx] = (headerRepo.updateWithTransactions as any).mock.calls[0];
     expect(tx[0].debit).toBe(10);
     expect(tx[1].credit).toBe(10);
-    expect(ieRepo.create).toHaveBeenCalled();
+    expect(ieRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ header_id: 'h1' })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- link `income_expense_transactions` to `financial_transaction_headers` via new `header_id`
- expose repository helper for querying by header_id
- show single-entry transactions on GivingProfile and ExpenseProfile
- update service and tests for new header_id field
- add migration for new column

## Testing
- `vitest run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b90e33bc483268e8fc8064e82b7ee