### PR TITLE
Show loader while lookup queries load

### DIFF
--- a/src/pages/finances/expenses/ExpenseAddEdit.tsx
+++ b/src/pages/finances/expenses/ExpenseAddEdit.tsx
@@ -29,24 +29,32 @@ function ExpenseAddEdit() {
   const { useQuery: useCategoriesQuery } = useCategoryRepository();
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
 
-  const { data: accountsData } = useAccountsQuery();
-  const { data: fundsData } = useFundsQuery();
-  const { data: categoriesData } = useCategoriesQuery({
+  const { data: accountsData, isLoading: accountsLoading } = useAccountsQuery();
+  const { data: fundsData, isLoading: fundsLoading } = useFundsQuery();
+  const { data: categoriesData, isLoading: categoriesLoading } = useCategoriesQuery({
     filters: { type: { operator: 'eq', value: 'expense_transaction' } },
   });
-  const { data: sourcesData } = useSourcesQuery({
+  const { data: sourcesData, isLoading: sourcesLoading } = useSourcesQuery({
     filters: { is_active: { operator: 'eq', value: true } },
   });
 
-  const { data: headerResponse } = useHeaderQuery({
+  const { data: headerResponse, isLoading: headerLoading } = useHeaderQuery({
     filters: { id: { operator: 'eq', value: id } },
     enabled: isEditMode,
   });
 
-  const { data: entryResponse } = useIeQuery({
+  const { data: entryResponse, isLoading: entryLoading } = useIeQuery({
     filters: { header_id: { operator: 'eq', value: id } },
     enabled: isEditMode,
   });
+
+  const isLoading =
+    accountsLoading ||
+    fundsLoading ||
+    categoriesLoading ||
+    sourcesLoading ||
+    headerLoading ||
+    entryLoading;
 
   const accounts = accountsData?.data || [];
   const funds = fundsData?.data || [];
@@ -90,6 +98,18 @@ function ExpenseAddEdit() {
   const header = headerResponse?.data?.[0];
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
+
+  if (
+    isLoading &&
+    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
+      (isEditMode && !header))
+  ) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
 
   useEffect(() => {
     if (isEditMode && header) {

--- a/src/pages/finances/giving/GivingAddEdit.tsx
+++ b/src/pages/finances/giving/GivingAddEdit.tsx
@@ -29,24 +29,32 @@ function GivingAddEdit() {
   const { useQuery: useCategoriesQuery } = useCategoryRepository();
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
 
-  const { data: accountsData } = useAccountsQuery();
-  const { data: fundsData } = useFundsQuery();
-  const { data: categoriesData } = useCategoriesQuery({
+  const { data: accountsData, isLoading: accountsLoading } = useAccountsQuery();
+  const { data: fundsData, isLoading: fundsLoading } = useFundsQuery();
+  const { data: categoriesData, isLoading: categoriesLoading } = useCategoriesQuery({
     filters: { type: { operator: 'eq', value: 'income_transaction' } },
   });
-  const { data: sourcesData } = useSourcesQuery({
+  const { data: sourcesData, isLoading: sourcesLoading } = useSourcesQuery({
     filters: { is_active: { operator: 'eq', value: true } },
   });
 
-  const { data: headerResponse } = useHeaderQuery({
+  const { data: headerResponse, isLoading: headerLoading } = useHeaderQuery({
     filters: { id: { operator: 'eq', value: id } },
     enabled: isEditMode,
   });
 
-  const { data: entryResponse } = useIeQuery({
+  const { data: entryResponse, isLoading: entryLoading } = useIeQuery({
     filters: { header_id: { operator: 'eq', value: id } },
     enabled: isEditMode,
   });
+
+  const isLoading =
+    accountsLoading ||
+    fundsLoading ||
+    categoriesLoading ||
+    sourcesLoading ||
+    headerLoading ||
+    entryLoading;
 
   const accounts = accountsData?.data || [];
   const funds = fundsData?.data || [];
@@ -90,6 +98,18 @@ function GivingAddEdit() {
   const header = headerResponse?.data?.[0];
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
+
+  if (
+    isLoading &&
+    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
+      (isEditMode && !header))
+  ) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
 
   useEffect(() => {
     if (isEditMode && header) {


### PR DESCRIPTION
## Summary
- surface `isLoading` from account, fund, category, source and edit queries
- show a centered Loader while lookups are loading for Giving and Expense forms

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9faae7208326996a1bfc0db92219