### PR TITLE
Ensure headers refetch when entry IDs load

### DIFF
--- a/src/pages/finances/expenses/ExpenseList.tsx
+++ b/src/pages/finances/expenses/ExpenseList.tsx
@@ -31,11 +31,20 @@ function ExpenseList() {
     [entryResult]
   );
 
-  const { data: headerResult, isLoading: headerLoading } = useHeaderQuery({
+  const {
+    data: headerResult,
+    isLoading: headerLoading,
+    refetch,
+  } = useHeaderQuery({
     filters: { id: { operator: 'isAnyOf', value: headerIds } },
     order: { column: 'transaction_date', ascending: false },
-    enabled: headerIds.length > 0,
   });
+
+  React.useEffect(() => {
+    if (headerIds.length > 0) {
+      refetch();
+    }
+  }, [headerIds, refetch]);
   const headers = headerResult?.data || [];
   const isLoading = entriesLoading || headerLoading;
 


### PR DESCRIPTION
## Summary
- make ExpenseList refetch header list when entry IDs update

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba377cb40832690e0676e91f6b919