### PR TITLE
Fix chart of accounts update

### DIFF
--- a/src/pages/accounts/ChartOfAccountAddEdit.tsx
+++ b/src/pages/accounts/ChartOfAccountAddEdit.tsx
@@ -122,15 +122,18 @@ function ChartOfAccountAddEdit() {
     }
     
     try {
+      const common = { fieldsToRemove: ['chart_of_accounts'] };
       if (isEditMode) {
         await updateMutation.mutateAsync({
           id: id!,
-          data: formData
+          data: formData,
+          ...common
         });
         navigate(`/accounts/chart-of-accounts/${id}`);
       } else {
         const result = await createMutation.mutateAsync({
-          data: formData
+          data: formData,
+          ...common
         });
         navigate(`/accounts/chart-of-accounts/${result.id}`);
       }


### PR DESCRIPTION
## Summary
- fix update on ChartOfAccountAddEdit by removing relationship field

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba2bf244083269cf129a724568538