### PR TITLE
Refactor getByHeaderId to reuse fetch

### DIFF
--- a/src/adapters/incomeExpenseTransaction.adapter.ts
+++ b/src/adapters/incomeExpenseTransaction.adapter.ts
@@ -45,10 +45,10 @@ export class IncomeExpenseTransactionAdapter
   ];
 
   public async getByHeaderId(headerId: string): Promise<IncomeExpenseTransaction[]> {
-    const query = await this.buildSecureQuery({});
-    const { data, error } = await query.eq('header_id', headerId);
-    if (error) throw error;
-    return data || [];
+    const result = await this.fetch({
+      filters: { header_id: { operator: 'eq', value: headerId } }
+    });
+    return result.data;
   }
 
   protected override async onAfterCreate(data: IncomeExpenseTransaction): Promise<void> {


### PR DESCRIPTION
## Summary
- refactor `getByHeaderId` in `incomeExpenseTransaction.adapter` to reuse `fetch`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba58f26988326a9195aade0df0d46