### PR TITLE
Fix account id mapping in entry edit

### DIFF
--- a/src/pages/finances/expenses/ExpenseAddEdit.tsx
+++ b/src/pages/finances/expenses/ExpenseAddEdit.tsx
@@ -124,7 +124,7 @@ function ExpenseAddEdit() {
     if (isEditMode && entryRecords.length > 0) {
       setEntries(
         entryRecords.map((e: any) => ({
-          accounts_account_id: e.accounts_account_id || '',
+          accounts_account_id: e.account_id || '',
           fund_id: e.fund_id || '',
           category_id: e.category_id || '',
           source_id: e.source_id || '',

--- a/src/pages/finances/giving/GivingAddEdit.tsx
+++ b/src/pages/finances/giving/GivingAddEdit.tsx
@@ -124,7 +124,7 @@ function GivingAddEdit() {
     if (isEditMode && entryRecords.length > 0) {
       setEntries(
         entryRecords.map((e: any) => ({
-          accounts_account_id: e.accounts_account_id || '',
+          accounts_account_id: e.account_id || '',
           fund_id: e.fund_id || '',
           category_id: e.category_id || '',
           source_id: e.source_id || '',


### PR DESCRIPTION
## Summary
- fix mapping of account id when editing giving batches
- fix mapping of account id when editing expense batches

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba8cc92388326a4a7d8c5740b00eb