### PR TITLE
Fix finance profile grids

### DIFF
--- a/src/pages/finances/expenses/ExpenseProfile.tsx
+++ b/src/pages/finances/expenses/ExpenseProfile.tsx
@@ -33,10 +33,34 @@ function ExpenseProfile() {
   }, [id, getByHeaderId]);
 
   const columns: GridColDef[] = [
-    { field: 'account', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account?.name },
-    { field: 'fund', headerName: 'Fund', flex: 1, minWidth: 120, valueGetter: p => p.row.fund?.name },
-    { field: 'category', headerName: 'Category', flex: 1, minWidth: 120, valueGetter: p => p.row.category?.name },
-    { field: 'source', headerName: 'Source', flex: 1, minWidth: 120, valueGetter: p => p.row.source?.name },
+    {
+      field: 'accounts',
+      headerName: 'Account',
+      flex: 1,
+      minWidth: 150,
+      valueGetter: (p) => p.row.accounts?.name,
+    },
+    {
+      field: 'funds',
+      headerName: 'Fund',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.funds?.name,
+    },
+    {
+      field: 'categories',
+      headerName: 'Category',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.categories?.name,
+    },
+    {
+      field: 'financial_sources',
+      headerName: 'Source',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.financial_sources?.name,
+    },
     { field: 'amount', headerName: 'Amount', flex: 1, minWidth: 100 },
   ];
 

--- a/src/pages/finances/giving/GivingProfile.tsx
+++ b/src/pages/finances/giving/GivingProfile.tsx
@@ -33,10 +33,34 @@ function GivingProfile() {
   }, [id, getByHeaderId]);
 
   const columns: GridColDef[] = [
-    { field: 'account', headerName: 'Account', flex: 1, minWidth: 150, valueGetter: p => p.row.account?.name },
-    { field: 'fund', headerName: 'Fund', flex: 1, minWidth: 120, valueGetter: p => p.row.fund?.name },
-    { field: 'category', headerName: 'Category', flex: 1, minWidth: 120, valueGetter: p => p.row.category?.name },
-    { field: 'source', headerName: 'Source', flex: 1, minWidth: 120, valueGetter: p => p.row.source?.name },
+    {
+      field: 'accounts',
+      headerName: 'Account',
+      flex: 1,
+      minWidth: 150,
+      valueGetter: (p) => p.row.accounts?.name,
+    },
+    {
+      field: 'funds',
+      headerName: 'Fund',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.funds?.name,
+    },
+    {
+      field: 'categories',
+      headerName: 'Category',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.categories?.name,
+    },
+    {
+      field: 'financial_sources',
+      headerName: 'Source',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: (p) => p.row.financial_sources?.name,
+    },
     { field: 'amount', headerName: 'Amount', flex: 1, minWidth: 100 },
   ];
 


### PR DESCRIPTION
## Summary
- fix profile grid columns to use plural properties

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baa47fb608326a270d972d38db088