### PR TITLE
Fix hook mismatch in finance forms

### DIFF
--- a/src/pages/finances/expenses/ExpenseAddEdit.tsx
+++ b/src/pages/finances/expenses/ExpenseAddEdit.tsx
@@ -99,18 +99,6 @@ function ExpenseAddEdit() {
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
 
-  if (
-    isLoading &&
-    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
-      (isEditMode && !header))
-  ) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    );
-  }
-
   useEffect(() => {
     if (isEditMode && header) {
       setHeaderData({
@@ -145,6 +133,18 @@ function ExpenseAddEdit() {
       })),
     );
   }, [sources, categories]);
+
+  if (
+    isLoading &&
+    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
+      (isEditMode && !header))
+  ) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
 
   const handleEntryChange = (index: number, field: keyof ExpenseEntry, value: any) => {
     const newEntries = [...entries];

--- a/src/pages/finances/giving/GivingAddEdit.tsx
+++ b/src/pages/finances/giving/GivingAddEdit.tsx
@@ -99,18 +99,6 @@ function GivingAddEdit() {
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
 
-  if (
-    isLoading &&
-    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
-      (isEditMode && !header))
-  ) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    );
-  }
-
   useEffect(() => {
     if (isEditMode && header) {
       setHeaderData({
@@ -145,6 +133,18 @@ function GivingAddEdit() {
       })),
     );
   }, [sources, categories]);
+
+  if (
+    isLoading &&
+    (!accountsData || !fundsData || !categoriesData || !sourcesData ||
+      (isEditMode && !header))
+  ) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
 
   const handleEntryChange = (index: number, field: keyof ContributionEntry, value: any) => {
     const newEntries = [...entries];


### PR DESCRIPTION
## Summary
- maintain consistent hook order in giving and expenses forms

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baf27951c8326a6c09d9091ea0959