### PR TITLE
Fix menu matchPath order

### DIFF
--- a/src/components/menu/hooks/useMenuBreadcrumbs.ts
+++ b/src/components/menu/hooks/useMenuBreadcrumbs.ts
@@ -11,7 +11,7 @@ const useMenuBreadcrumbs = (pathname: string, items: TMenuConfig | null): TMenuB
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
 
-      if (item.path && matchPath(pathname, item.path)) {
+      if (item.path && matchPath(item.path, pathname)) {
         return [
           {
             title: item.title,

--- a/src/components/menu/hooks/useMenuChildren.ts
+++ b/src/components/menu/hooks/useMenuChildren.ts
@@ -10,7 +10,7 @@ const useMenuChildren = (
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
 
-      if (item.path && matchPath(pathname, item.path)) {
+      if (item.path && matchPath(item.path, pathname)) {
         return true;
       } else if (item.children) {
         if (hasActiveChild(item.children as TMenuConfig)) {
@@ -43,7 +43,7 @@ const useMenuChildren = (
         if (children) {
           return children;
         }
-      } else if (level === currentLevel && item.path && matchPath(pathname, item.path)) {
+      } else if (level === currentLevel && item.path && matchPath(item.path, pathname)) {
         // If it's a leaf node and matches the path, return the current items
         return items;
       }

--- a/src/components/menu/hooks/useMenuCurrentItem.ts
+++ b/src/components/menu/hooks/useMenuCurrentItem.ts
@@ -14,7 +14,7 @@ const useMenuCurrentItem = (
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
 
-      if (item.path && matchPath(pathname, item.path)) {
+      if (item.path && matchPath(item.path, pathname)) {
         return item ?? null;
       } else if (item.children) {
         const childItem = findCurrentItem(item.children as TMenuConfig);


### PR DESCRIPTION
## Summary
- fix ordering of arguments to `matchPath` in menu helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbb0a64f0832685bc5c2de752083e