### PR TITLE
Fix sidebar update loop

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -143,6 +143,14 @@ function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps) {
   };
 
   // Auto-expand submenus when searching
+  const areSetsEqual = (a: Set<string>, b: Set<string>) => {
+    if (a.size !== b.size) return false;
+    for (const item of a) {
+      if (!b.has(item)) return false;
+    }
+    return true;
+  };
+
   React.useEffect(() => {
     if (searchTerm) {
       const names = new Set<string>();
@@ -157,7 +165,10 @@ function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps) {
       };
 
       collect(filteredNavigation);
-      setOpenSubmenus(names);
+      setOpenSubmenus((prev) => {
+        if (areSetsEqual(prev, names)) return prev;
+        return names;
+      });
     }
   }, [searchTerm, filteredNavigation]);
 
@@ -201,6 +212,7 @@ function Sidebar({ sidebarOpen, setSidebarOpen }: SidebarProps) {
     setOpenSubmenus((prev) => {
       const newSet = new Set(prev);
       activeNames.forEach((name) => newSet.add(name));
+      if (areSetsEqual(prev, newSet)) return prev;
       return newSet;
     });
   }, [location.pathname, navigation]);


### PR DESCRIPTION
## Summary
- prevent setState loops in sidebar when searching or when active route changes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bbbd596e48326b80c22e929d8c24a