### PR TITLE
Fix not filter handling

### DIFF
--- a/src/adapters/base.adapter.ts
+++ b/src/adapters/base.adapter.ts
@@ -91,7 +91,7 @@ export class BaseAdapter<T extends BaseModel> {
         case 'contains':
           return query.ilike(key, `%${value}%`);
         case 'notContains':
-          return query.not('ilike', key, `%${value}%`);
+          return query.not(key, 'ilike', `%${value}%`);
         case 'startsWith':
           return query.ilike(key, `${value}%`);
         case 'endsWith':
@@ -99,7 +99,7 @@ export class BaseAdapter<T extends BaseModel> {
         case 'isEmpty':
           return query.is(key, null);
         case 'isNotEmpty':
-          return query.not('is', key, null);
+          return query.not(key, 'is', null);
         case 'isAnyOf':
           return query.in(key, Array.isArray(value) ? value : [value]);
         case 'between':

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -70,7 +70,7 @@ export class QueryUtils {
         case 'contains':
           return query.ilike(key, `%${value}%`);
         case 'notContains':
-          return query.not('ilike', key, `%${value}%`);
+          return query.not(key, 'ilike', `%${value}%`);
         case 'startsWith':
           return query.ilike(key, `${value}%`);
         case 'endsWith':
@@ -78,7 +78,7 @@ export class QueryUtils {
         case 'isEmpty':
           return query.is(key, null);
         case 'isNotEmpty':
-          return query.not('is', key, null);
+          return query.not(key, 'is', null);
         case 'isAnyOf':
           return query.in(key, Array.isArray(value) ? value : [value]);
         case 'between':


### PR DESCRIPTION
## Summary
- correct parameter order for `query.not` filter handling

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf1e91388326803d8c0b5e00570b