### PR TITLE
Introduce ErrorLogs entity for critical error tracking

### DIFF
--- a/src/adapters/errorLog.adapter.ts
+++ b/src/adapters/errorLog.adapter.ts
@@ -1,0 +1,24 @@
+import 'reflect-metadata';
+import { injectable } from 'inversify';
+import { BaseAdapter } from './base.adapter';
+import { ErrorLog } from '../models/errorLog.model';
+
+export interface IErrorLogAdapter extends BaseAdapter<ErrorLog> {}
+
+@injectable()
+export class ErrorLogAdapter
+  extends BaseAdapter<ErrorLog>
+  implements IErrorLogAdapter
+{
+  protected tableName = 'error_logs';
+
+  protected defaultSelect = `
+    id,
+    message,
+    stack,
+    context,
+    created_at,
+    tenant_id,
+    created_by
+  `;
+}

--- a/src/hooks/useErrorLogRepository.ts
+++ b/src/hooks/useErrorLogRepository.ts
@@ -1,0 +1,9 @@
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { IErrorLogRepository } from '../repositories/errorLog.repository';
+import { useBaseRepository } from './useBaseRepository';
+
+export function useErrorLogRepository() {
+  const repository = container.get<IErrorLogRepository>(TYPES.IErrorLogRepository);
+  return useBaseRepository(repository, 'Error Log', 'error_logs');
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -33,6 +33,7 @@ import {
 } from '../adapters/offeringBatch.adapter';
 import { CategoryAdapter, type ICategoryAdapter } from '../adapters/category.adapter';
 import { AuthUserAdapter, type IAuthUserAdapter } from '../adapters/authUser.adapter';
+import { ErrorLogAdapter, type IErrorLogAdapter } from '../adapters/errorLog.adapter';
 import { MemberRepository, type IMemberRepository } from '../repositories/member.repository';
 import {
   NotificationRepository,
@@ -66,10 +67,12 @@ import {
 } from '../repositories/offeringBatch.repository';
 import { CategoryRepository, type ICategoryRepository } from '../repositories/category.repository';
 import { UserRepository, type IUserRepository } from '../repositories/user.repository';
+import { ErrorLogRepository, type IErrorLogRepository } from '../repositories/errorLog.repository';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { GivingService } from '../services/GivingService';
 import { ExpenseService } from '../services/ExpenseService';
 import { IncomeExpenseTransactionService } from '../services/IncomeExpenseTransactionService';
+import { SupabaseErrorLogService, type ErrorLogService } from '../services/ErrorLogService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -123,6 +126,10 @@ container
   .bind<IAuthUserAdapter>(TYPES.IAuthUserAdapter)
   .to(AuthUserAdapter)
   .inSingletonScope();
+container
+  .bind<IErrorLogAdapter>(TYPES.IErrorLogAdapter)
+  .to(ErrorLogAdapter)
+  .inSingletonScope();
 
 // Register services
 container
@@ -140,6 +147,10 @@ container
 container
   .bind<IncomeExpenseTransactionService>(TYPES.IncomeExpenseTransactionService)
   .to(IncomeExpenseTransactionService)
+  .inSingletonScope();
+container
+  .bind<ErrorLogService>(TYPES.ErrorLogService)
+  .to(SupabaseErrorLogService)
   .inSingletonScope();
 
 // Register repositories
@@ -192,6 +203,10 @@ container
 container
   .bind<IUserRepository>(TYPES.IUserRepository)
   .to(UserRepository)
+  .inSingletonScope();
+container
+  .bind<IErrorLogRepository>(TYPES.IErrorLogRepository)
+  .to(ErrorLogRepository)
   .inSingletonScope();
 
 export { container };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export const TYPES = {
   IFundAdapter: 'IFundAdapter',
   IOfferingBatchAdapter: 'IOfferingBatchAdapter',
   IAuthUserAdapter: 'IAuthUserAdapter',
+  IErrorLogAdapter: 'IErrorLogAdapter',
   IMemberRepository: 'IMemberRepository',
   INotificationRepository: 'INotificationRepository',
   IAccountRepository: 'IAccountRepository',
@@ -23,7 +24,9 @@ export const TYPES = {
   ICategoryAdapter: 'ICategoryAdapter',
   ICategoryRepository: 'ICategoryRepository',
   IUserRepository: 'IUserRepository',
+  IErrorLogRepository: 'IErrorLogRepository',
   AuditService: 'AuditService',
+  ErrorLogService: 'ErrorLogService',
   GivingService: 'GivingService',
   ExpenseService: 'ExpenseService',
   IncomeExpenseTransactionService: 'IncomeExpenseTransactionService'

--- a/src/models/errorLog.model.ts
+++ b/src/models/errorLog.model.ts
@@ -1,0 +1,8 @@
+import { BaseModel } from './base.model';
+
+export interface ErrorLog extends BaseModel {
+  id: string;
+  message: string;
+  stack?: string | null;
+  context?: Record<string, any> | null;
+}

--- a/src/repositories/errorLog.repository.ts
+++ b/src/repositories/errorLog.repository.ts
@@ -1,0 +1,17 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { ErrorLog } from '../models/errorLog.model';
+import { TYPES } from '../lib/types';
+import type { IErrorLogAdapter } from '../adapters/errorLog.adapter';
+
+export interface IErrorLogRepository extends BaseRepository<ErrorLog> {}
+
+@injectable()
+export class ErrorLogRepository
+  extends BaseRepository<ErrorLog>
+  implements IErrorLogRepository
+{
+  constructor(@inject(TYPES.IErrorLogAdapter) adapter: IErrorLogAdapter) {
+    super(adapter);
+  }
+}

--- a/src/services/ErrorLogService.ts
+++ b/src/services/ErrorLogService.ts
@@ -1,0 +1,23 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { IErrorLogRepository } from '../repositories/errorLog.repository';
+
+export interface ErrorLogService {
+  logError(message: string, stack?: string | null, context?: Record<string, any>): Promise<void>;
+}
+
+@injectable()
+export class SupabaseErrorLogService implements ErrorLogService {
+  constructor(
+    @inject(TYPES.IErrorLogRepository)
+    private repo: IErrorLogRepository,
+  ) {}
+
+  async logError(message: string, stack?: string | null, context?: Record<string, any>): Promise<void> {
+    try {
+      await this.repo.create({ message, stack: stack ?? null, context: context ?? null });
+    } catch (err) {
+      console.error('Failed to record error log:', err);
+    }
+  }
+}

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,4 +1,7 @@
 import { type NotifyErrorOptions } from '../hooks/useNotifications';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { ErrorLogService } from '../services/ErrorLogService';
 
 // Error types
 type ErrorType = 'auth' | 'database' | 'network' | 'validation' | 'unknown';
@@ -56,6 +59,9 @@ function logError(error: any, context?: Record<string, any>) {
   if (import.meta.env.DEV) {
     console.error('Error Details:', errorDetails);
   }
+
+  const service = container.get<ErrorLogService>(TYPES.ErrorLogService);
+  service.logError(errorDetails.message, errorDetails.stack, errorDetails);
 }
 
 // Main error handler function - now returns error info instead of showing notification

--- a/supabase/migrations/20250702050000_error_logs.sql
+++ b/supabase/migrations/20250702050000_error_logs.sql
@@ -1,0 +1,71 @@
+-- Create error_logs table for capturing application errors
+CREATE TABLE IF NOT EXISTS error_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid REFERENCES tenants(id) ON DELETE CASCADE,
+  message text NOT NULL,
+  stack text,
+  context jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz DEFAULT now(),
+  created_by uuid REFERENCES auth.users(id)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_error_logs_tenant_id ON error_logs(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_error_logs_created_at ON error_logs(created_at);
+
+-- Enable RLS
+ALTER TABLE error_logs ENABLE ROW LEVEL SECURITY;
+
+-- Allow authenticated users to view and insert error logs
+DROP POLICY IF EXISTS "Error logs policy" ON error_logs;
+CREATE POLICY "Error logs policy"
+  ON error_logs FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- RPC function for convenience
+CREATE OR REPLACE FUNCTION record_error_log(
+  p_message text,
+  p_stack text DEFAULT NULL,
+  p_context jsonb DEFAULT '{}'::jsonb
+) RETURNS uuid
+SECURITY DEFINER
+SET search_path = public, auth
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_tenant_id uuid;
+  v_log_id uuid;
+BEGIN
+  SELECT tenant_id INTO v_tenant_id
+  FROM tenant_users
+  WHERE user_id = auth.uid()
+  LIMIT 1;
+
+  IF v_tenant_id IS NULL THEN
+    RAISE EXCEPTION 'No tenant context found';
+  END IF;
+
+  INSERT INTO error_logs (
+    tenant_id,
+    message,
+    stack,
+    context,
+    created_by
+  ) VALUES (
+    v_tenant_id,
+    p_message,
+    p_stack,
+    p_context,
+    auth.uid()
+  ) RETURNING id INTO v_log_id;
+
+  RETURN v_log_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION record_error_log(text, text, jsonb) TO authenticated;
+
+COMMENT ON TABLE error_logs IS 'Stores detailed error information for diagnostics';
+COMMENT ON FUNCTION record_error_log IS 'Records an application error with tenant isolation';

--- a/tests/errorLogService.test.ts
+++ b/tests/errorLogService.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SupabaseErrorLogService } from '../src/services/ErrorLogService';
+import type { IErrorLogRepository } from '../src/repositories/errorLog.repository';
+
+const repo: IErrorLogRepository = {
+  create: vi.fn().mockResolvedValue({}),
+} as unknown as IErrorLogRepository;
+
+const service = new SupabaseErrorLogService(repo);
+
+describe('ErrorLogService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs errors via repository', async () => {
+    await service.logError('oops', 'stack', { a: 1 });
+    expect(repo.create).toHaveBeenCalledWith({ message: 'oops', stack: 'stack', context: { a: 1 } });
+  });
+});


### PR DESCRIPTION
## Summary
- add ErrorLog model, adapter, repository, and service
- register new components with DI container
- log errors to database via `ErrorLogService`
- add Supabase migration creating `error_logs` table and RPC
- include minimal test for `ErrorLogService`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3dcf7bc83269cb36f5e8639cfd9