### PR TITLE
Fix invalid regex in subdomain input

### DIFF
--- a/src/pages/auth/Register.tsx
+++ b/src/pages/auth/Register.tsx
@@ -297,7 +297,7 @@ function Register() {
                         subdomain: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') 
                       }))}
                       required
-                      pattern="[a-z0-9-]+"
+                      pattern="(?:[a-z0-9]|-)+"
                       icon={<Globe />}
                       rightElement={
                         <div className="px-3 py-2 bg-muted text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary
- update subdomain pattern to avoid `v` flag regex error

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc6fff9d48326b884d68a5e5623b6