### PR TITLE
Refactor finance page structure

### DIFF
--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -6,15 +6,15 @@ import { SubscriptionGate } from '../../components/SubscriptionGate';
 
 // Lazy load finance components
 const FinancesDashboard = React.lazy(() => import('./FinancesDashboard'));
-const TransactionList = React.lazy(() => import('./TransactionList'));
-const TransactionDetail = React.lazy(() => import('./TransactionDetail'));
-const BulkTransactionEntry = React.lazy(() => import('./BulkTransactionEntry'));
-const BudgetList = React.lazy(() => import('./BudgetList'));
-const BudgetAdd = React.lazy(() => import('./BudgetAdd'));
-const BudgetProfile = React.lazy(() => import('./BudgetProfile'));
-const FundList = React.lazy(() => import('./FundList'));
-const FundAddEdit = React.lazy(() => import('./FundAddEdit'));
-const FundProfile = React.lazy(() => import('./FundProfile'));
+const TransactionList = React.lazy(() => import('./transactions/TransactionList'));
+const TransactionDetail = React.lazy(() => import('./transactions/TransactionDetail'));
+const BulkTransactionEntry = React.lazy(() => import('./transactions/BulkTransactionEntry'));
+const BudgetList = React.lazy(() => import('./budgets/BudgetList'));
+const BudgetAdd = React.lazy(() => import('./budgets/BudgetAdd'));
+const BudgetProfile = React.lazy(() => import('./budgets/BudgetProfile'));
+const FundList = React.lazy(() => import('./funds/FundList'));
+const FundAddEdit = React.lazy(() => import('./funds/FundAddEdit'));
+const FundProfile = React.lazy(() => import('./funds/FundProfile'));
 const Reports = React.lazy(() => import('./Reports'));
 const Statements = React.lazy(() => import('./Statements'));
 const GivingList = React.lazy(() => import('./giving/GivingList'));

--- a/src/pages/finances/budgets/BudgetAdd.tsx
+++ b/src/pages/finances/budgets/BudgetAdd.tsx
@@ -1,40 +1,28 @@
-// src/pages/finances/BudgetEdit.tsx
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
-import { useMessageStore } from '../../components/MessageHandler';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Input } from '../../components/ui2/input';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Combobox } from '../../components/ui2/combobox';
-import { DatePickerInput } from '../../components/ui2/date-picker';
-import { Textarea } from '../../components/ui2/textarea';
+import { supabase } from '../../../lib/supabase';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+import { formatCurrency } from '../../../utils/currency';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Combobox } from '../../../components/ui2/combobox';
+import { DatePickerInput } from '../../../components/ui2/date-picker';
+import { Textarea } from '../../../components/ui2/textarea';
 import {
   Save,
   Loader2,
   AlertCircle,
 } from 'lucide-react';
 
-type Budget = {
-  id: string;
-  name: string;
-  amount: number;
-  start_date: string;
-  end_date: string;
-  category_id: string;
-  description: string | null;
-};
-
-function BudgetEdit() {
-  const { id } = useParams<{ id: string }>();
+function BudgetAdd() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { addMessage } = useMessageStore();
+  const { currency } = useCurrencyStore();
   const [error, setError] = useState<string | null>(null);
-  const [formData, setFormData] = useState<Budget>({
-    id: '',
+  const [formData, setFormData] = useState({
     name: '',
     amount: 0,
     category_id: '',
@@ -51,22 +39,6 @@ function BudgetEdit() {
       if (error) throw error;
       return data?.[0];
     },
-  });
-
-  // Get budget data
-  const { data: budget, isLoading: budgetLoading } = useQuery({
-    queryKey: ['budget', id],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('budgets')
-        .select('*')
-        .eq('id', id)
-        .single();
-
-      if (error) throw error;
-      return data as Budget;
-    },
-    enabled: !!id,
   });
 
   // Get budget categories
@@ -87,45 +59,27 @@ function BudgetEdit() {
     enabled: !!currentTenant?.id,
   });
 
-  useEffect(() => {
-    if (budget) {
-      setFormData(budget);
-    }
-  }, [budget]);
-
-  const updateBudgetMutation = useMutation({
-    mutationFn: async (data: Budget) => {
-      const { error } = await supabase
+  const addBudgetMutation = useMutation({
+    mutationFn: async (data: typeof formData) => {
+      const { data: newBudget, error } = await supabase
         .from('budgets')
-        .update({
-          name: data.name,
-          amount: data.amount,
-          category_id: data.category_id,
-          description: data.description,
-          start_date: data.start_date,
-          end_date: data.end_date,
-        })
-        .eq('id', id);
+        .insert([{
+          ...data,
+          tenant_id: currentTenant?.id,
+          created_by: (await supabase.auth.getUser()).data.user?.id,
+        }])
+        .select()
+        .single();
 
       if (error) throw error;
+      return newBudget;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['budgets'] });
-      queryClient.invalidateQueries({ queryKey: ['budget', id] });
-      addMessage({
-        type: 'success',
-        text: 'Budget updated successfully',
-        duration: 3000,
-      });
-      navigate(`/finances/budgets/${id}`);
+      navigate('/finances/budgets');
     },
     onError: (error: Error) => {
       setError(error.message);
-      addMessage({
-        type: 'error',
-        text: error.message,
-        duration: 5000,
-      });
     },
   });
 
@@ -143,10 +97,20 @@ function BudgetEdit() {
     }
 
     try {
-      await updateBudgetMutation.mutateAsync(formData);
+      await addBudgetMutation.mutateAsync(formData);
     } catch (error) {
-      console.error('Error updating budget:', error);
+      console.error('Error adding budget:', error);
     }
+  };
+
+  const handleInputChange = (
+    field: keyof typeof formData,
+    value: string | number
+  ) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: field === 'amount' ? Number(value) : value,
+    }));
   };
 
   const categoryOptions = React.useMemo(() => 
@@ -157,25 +121,17 @@ function BudgetEdit() {
     [categories]
   );
 
-  if (budgetLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    );
-  }
-
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <BackButton fallbackPath={`/finances/budgets/${id}`} label="Back to Budget" />
+        <BackButton fallbackPath="/finances/budgets" label="Back to Budgets" />
       </div>
 
       <Card>
         <CardHeader>
-          <h3 className="text-lg font-medium text-foreground">Edit Budget</h3>
+          <h3 className="text-lg font-medium text-foreground">Add New Budget</h3>
           <p className="text-sm text-muted-foreground">
-            Update budget details and allocation
+            Create a new budget allocation
           </p>
         </CardHeader>
 
@@ -187,7 +143,7 @@ function BudgetEdit() {
                   label="Budget Name"
                   required
                   value={formData.name}
-                  onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
                   placeholder="e.g., Youth Ministry 2025"
                 />
               </div>
@@ -196,7 +152,7 @@ function BudgetEdit() {
                 <Combobox
                   options={categoryOptions}
                   value={formData.category_id}
-                  onChange={(value) => setFormData(prev => ({ ...prev, category_id: value }))}
+                  onChange={(value) => handleInputChange('category_id', value)}
                   placeholder="Select Category"
                 />
               </div>
@@ -204,10 +160,9 @@ function BudgetEdit() {
               <div>
                 <Input
                   type="number"
-                  label="Amount"
                   required
                   value={formData.amount || ''}
-                  onChange={(e) => setFormData(prev => ({ ...prev, amount: Number(e.target.value) }))}
+                  onChange={(e) => handleInputChange('amount', e.target.value)}
                   min={0}
                   step="0.01"
                   placeholder="Enter the amount (0.00)"
@@ -218,10 +173,10 @@ function BudgetEdit() {
                 <DatePickerInput
                   label="Start Date"
                   value={formData.start_date ? new Date(formData.start_date) : undefined}
-                  onChange={(date) => setFormData(prev => ({
-                    ...prev,
-                    start_date: date?.toISOString().split('T')[0] || ''
-                  }))}
+                  onChange={(date) => handleInputChange(
+                    'start_date',
+                    date?.toISOString().split('T')[0] || ''
+                  )}
                 />
               </div>
 
@@ -229,18 +184,18 @@ function BudgetEdit() {
                 <DatePickerInput
                   label="End Date"
                   value={formData.end_date ? new Date(formData.end_date) : undefined}
-                  onChange={(date) => setFormData(prev => ({
-                    ...prev,
-                    end_date: date?.toISOString().split('T')[0] || ''
-                  }))}
+                  onChange={(date) => handleInputChange(
+                    'end_date',
+                    date?.toISOString().split('T')[0] || ''
+                  )}
                 />
               </div>
 
               <div className="sm:col-span-2">
                 <Textarea
                   label="Description"
-                  value={formData.description || ''}
-                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                  value={formData.description}
+                  onChange={(e) => handleInputChange('description', e.target.value)}
                   rows={3}
                   placeholder="Enter budget details..."
                 />
@@ -262,23 +217,23 @@ function BudgetEdit() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => navigate(`/finances/budgets/${id}`)}
+                onClick={() => navigate('/finances/budgets')}
               >
                 Cancel
               </Button>
               <Button
                 type="submit"
-                disabled={updateBudgetMutation.isPending}
+                disabled={addBudgetMutation.isPending}
               >
-                {updateBudgetMutation.isPending ? (
+                {addBudgetMutation.isPending ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
+                    Adding...
                   </>
                 ) : (
                   <>
                     <Save className="mr-2 h-4 w-4" />
-                    Save Changes
+                    Add Budget
                   </>
                 )}
               </Button>
@@ -290,4 +245,4 @@ function BudgetEdit() {
   );
 }
 
-export default BudgetEdit;
+export default BudgetAdd;

--- a/src/pages/finances/budgets/BudgetEdit.tsx
+++ b/src/pages/finances/budgets/BudgetEdit.tsx
@@ -1,28 +1,40 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+// src/pages/finances/BudgetEdit.tsx
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
-import { useCurrencyStore } from '../../stores/currencyStore';
-import { formatCurrency } from '../../utils/currency';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Input } from '../../components/ui2/input';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Combobox } from '../../components/ui2/combobox';
-import { DatePickerInput } from '../../components/ui2/date-picker';
-import { Textarea } from '../../components/ui2/textarea';
+import { supabase } from '../../../lib/supabase';
+import { useMessageStore } from '../../../components/MessageHandler';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Combobox } from '../../../components/ui2/combobox';
+import { DatePickerInput } from '../../../components/ui2/date-picker';
+import { Textarea } from '../../../components/ui2/textarea';
 import {
   Save,
   Loader2,
   AlertCircle,
 } from 'lucide-react';
 
-function BudgetAdd() {
+type Budget = {
+  id: string;
+  name: string;
+  amount: number;
+  start_date: string;
+  end_date: string;
+  category_id: string;
+  description: string | null;
+};
+
+function BudgetEdit() {
+  const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { currency } = useCurrencyStore();
+  const { addMessage } = useMessageStore();
   const [error, setError] = useState<string | null>(null);
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<Budget>({
+    id: '',
     name: '',
     amount: 0,
     category_id: '',
@@ -39,6 +51,22 @@ function BudgetAdd() {
       if (error) throw error;
       return data?.[0];
     },
+  });
+
+  // Get budget data
+  const { data: budget, isLoading: budgetLoading } = useQuery({
+    queryKey: ['budget', id],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('budgets')
+        .select('*')
+        .eq('id', id)
+        .single();
+
+      if (error) throw error;
+      return data as Budget;
+    },
+    enabled: !!id,
   });
 
   // Get budget categories
@@ -59,27 +87,45 @@ function BudgetAdd() {
     enabled: !!currentTenant?.id,
   });
 
-  const addBudgetMutation = useMutation({
-    mutationFn: async (data: typeof formData) => {
-      const { data: newBudget, error } = await supabase
+  useEffect(() => {
+    if (budget) {
+      setFormData(budget);
+    }
+  }, [budget]);
+
+  const updateBudgetMutation = useMutation({
+    mutationFn: async (data: Budget) => {
+      const { error } = await supabase
         .from('budgets')
-        .insert([{
-          ...data,
-          tenant_id: currentTenant?.id,
-          created_by: (await supabase.auth.getUser()).data.user?.id,
-        }])
-        .select()
-        .single();
+        .update({
+          name: data.name,
+          amount: data.amount,
+          category_id: data.category_id,
+          description: data.description,
+          start_date: data.start_date,
+          end_date: data.end_date,
+        })
+        .eq('id', id);
 
       if (error) throw error;
-      return newBudget;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['budgets'] });
-      navigate('/finances/budgets');
+      queryClient.invalidateQueries({ queryKey: ['budget', id] });
+      addMessage({
+        type: 'success',
+        text: 'Budget updated successfully',
+        duration: 3000,
+      });
+      navigate(`/finances/budgets/${id}`);
     },
     onError: (error: Error) => {
       setError(error.message);
+      addMessage({
+        type: 'error',
+        text: error.message,
+        duration: 5000,
+      });
     },
   });
 
@@ -97,20 +143,10 @@ function BudgetAdd() {
     }
 
     try {
-      await addBudgetMutation.mutateAsync(formData);
+      await updateBudgetMutation.mutateAsync(formData);
     } catch (error) {
-      console.error('Error adding budget:', error);
+      console.error('Error updating budget:', error);
     }
-  };
-
-  const handleInputChange = (
-    field: keyof typeof formData,
-    value: string | number
-  ) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: field === 'amount' ? Number(value) : value,
-    }));
   };
 
   const categoryOptions = React.useMemo(() => 
@@ -121,17 +157,25 @@ function BudgetAdd() {
     [categories]
   );
 
+  if (budgetLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <BackButton fallbackPath="/finances/budgets" label="Back to Budgets" />
+        <BackButton fallbackPath={`/finances/budgets/${id}`} label="Back to Budget" />
       </div>
 
       <Card>
         <CardHeader>
-          <h3 className="text-lg font-medium text-foreground">Add New Budget</h3>
+          <h3 className="text-lg font-medium text-foreground">Edit Budget</h3>
           <p className="text-sm text-muted-foreground">
-            Create a new budget allocation
+            Update budget details and allocation
           </p>
         </CardHeader>
 
@@ -143,7 +187,7 @@ function BudgetAdd() {
                   label="Budget Name"
                   required
                   value={formData.name}
-                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
                   placeholder="e.g., Youth Ministry 2025"
                 />
               </div>
@@ -152,7 +196,7 @@ function BudgetAdd() {
                 <Combobox
                   options={categoryOptions}
                   value={formData.category_id}
-                  onChange={(value) => handleInputChange('category_id', value)}
+                  onChange={(value) => setFormData(prev => ({ ...prev, category_id: value }))}
                   placeholder="Select Category"
                 />
               </div>
@@ -160,9 +204,10 @@ function BudgetAdd() {
               <div>
                 <Input
                   type="number"
+                  label="Amount"
                   required
                   value={formData.amount || ''}
-                  onChange={(e) => handleInputChange('amount', e.target.value)}
+                  onChange={(e) => setFormData(prev => ({ ...prev, amount: Number(e.target.value) }))}
                   min={0}
                   step="0.01"
                   placeholder="Enter the amount (0.00)"
@@ -173,10 +218,10 @@ function BudgetAdd() {
                 <DatePickerInput
                   label="Start Date"
                   value={formData.start_date ? new Date(formData.start_date) : undefined}
-                  onChange={(date) => handleInputChange(
-                    'start_date',
-                    date?.toISOString().split('T')[0] || ''
-                  )}
+                  onChange={(date) => setFormData(prev => ({
+                    ...prev,
+                    start_date: date?.toISOString().split('T')[0] || ''
+                  }))}
                 />
               </div>
 
@@ -184,18 +229,18 @@ function BudgetAdd() {
                 <DatePickerInput
                   label="End Date"
                   value={formData.end_date ? new Date(formData.end_date) : undefined}
-                  onChange={(date) => handleInputChange(
-                    'end_date',
-                    date?.toISOString().split('T')[0] || ''
-                  )}
+                  onChange={(date) => setFormData(prev => ({
+                    ...prev,
+                    end_date: date?.toISOString().split('T')[0] || ''
+                  }))}
                 />
               </div>
 
               <div className="sm:col-span-2">
                 <Textarea
                   label="Description"
-                  value={formData.description}
-                  onChange={(e) => handleInputChange('description', e.target.value)}
+                  value={formData.description || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                   rows={3}
                   placeholder="Enter budget details..."
                 />
@@ -217,23 +262,23 @@ function BudgetAdd() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => navigate('/finances/budgets')}
+                onClick={() => navigate(`/finances/budgets/${id}`)}
               >
                 Cancel
               </Button>
               <Button
                 type="submit"
-                disabled={addBudgetMutation.isPending}
+                disabled={updateBudgetMutation.isPending}
               >
-                {addBudgetMutation.isPending ? (
+                {updateBudgetMutation.isPending ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Adding...
+                    Saving...
                   </>
                 ) : (
                   <>
                     <Save className="mr-2 h-4 w-4" />
-                    Add Budget
+                    Save Changes
                   </>
                 )}
               </Button>
@@ -245,4 +290,4 @@ function BudgetAdd() {
   );
 }
 
-export default BudgetAdd;
+export default BudgetEdit;

--- a/src/pages/finances/budgets/BudgetList.tsx
+++ b/src/pages/finances/budgets/BudgetList.tsx
@@ -2,18 +2,18 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
+import { supabase } from '../../../lib/supabase';
 import { format } from 'date-fns';
-import { useCurrencyStore } from '../../stores/currencyStore';
-import { formatCurrency } from '../../utils/currency';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Input } from '../../components/ui2/input';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
-import { Badge } from '../../components/ui2/badge';
-import { Progress } from '../../components/ui2/progress';
-import { useMessageStore } from '../../components/MessageHandler';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+import { formatCurrency } from '../../../utils/currency';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Input } from '../../../components/ui2/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../../components/ui2/select';
+import { Badge } from '../../../components/ui2/badge';
+import { Progress } from '../../../components/ui2/progress';
+import { useMessageStore } from '../../../components/MessageHandler';
 import {
   Plus,
   Search,

--- a/src/pages/finances/budgets/BudgetProfile.tsx
+++ b/src/pages/finances/budgets/BudgetProfile.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
+import { supabase } from '../../../lib/supabase';
 import { format } from 'date-fns';
-import { useCurrencyStore } from '../../stores/currencyStore';
-import { formatCurrency } from '../../utils/currency';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Badge } from '../../components/ui2/badge';
-import { Progress } from '../../components/ui2/progress';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+import { formatCurrency } from '../../../utils/currency';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Badge } from '../../../components/ui2/badge';
+import { Progress } from '../../../components/ui2/progress';
 import {
   PiggyBank,
   Calendar,

--- a/src/pages/finances/funds/FundAddEdit.tsx
+++ b/src/pages/finances/funds/FundAddEdit.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFundRepository } from '../../hooks/useFundRepository';
-import { Fund, FundType } from '../../models/fund.model';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Input } from '../../components/ui2/input';
-import { Textarea } from '../../components/ui2/textarea';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
+import { useFundRepository } from '../../../hooks/useFundRepository';
+import { Fund, FundType } from '../../../models/fund.model';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Textarea } from '../../../components/ui2/textarea';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../../components/ui2/select';
 
 import { Save, Loader2, AlertCircle } from 'lucide-react';
 

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useFundRepository } from '../../hooks/useFundRepository';
-import { Fund } from '../../models/fund.model';
-import { Card, CardContent } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import { Input } from '../../components/ui2/input';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../components/ui2/select';
-import { Badge } from '../../components/ui2/badge';
-import { DataGrid } from '../../components/ui2/mui-datagrid';
+import { useFundRepository } from '../../../hooks/useFundRepository';
+import { Fund } from '../../../models/fund.model';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import { Input } from '../../../components/ui2/input';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../../components/ui2/select';
+import { Badge } from '../../../components/ui2/badge';
+import { DataGrid } from '../../../components/ui2/mui-datagrid';
 import { GridColDef } from '@mui/x-data-grid';
 import { Plus, Search, Loader2 } from 'lucide-react';
 

--- a/src/pages/finances/funds/FundProfile.tsx
+++ b/src/pages/finances/funds/FundProfile.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFundRepository } from '../../hooks/useFundRepository';
+import { useFundRepository } from '../../../hooks/useFundRepository';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Badge } from '../../components/ui2/badge';
-import { Tabs } from '../../components/ui2/tabs';
+import { supabase } from '../../../lib/supabase';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Badge } from '../../../components/ui2/badge';
+import { Tabs } from '../../../components/ui2/tabs';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -17,7 +17,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '../../components/ui2/alert-dialog';
+} from '../../../components/ui2/alert-dialog';
 import {
   DollarSign,
   Pencil,

--- a/src/pages/finances/transactions/BulkTransactionEntry.tsx
+++ b/src/pages/finances/transactions/BulkTransactionEntry.tsx
@@ -1,29 +1,29 @@
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useFinancialTransactionHeaderRepository } from "../../hooks/useFinancialTransactionHeaderRepository";
-import { useChartOfAccounts } from "../../hooks/useChartOfAccounts";
-import { useFinancialSourceRepository } from "../../hooks/useFinancialSourceRepository";
+import { useFinancialTransactionHeaderRepository } from "../../../hooks/useFinancialTransactionHeaderRepository";
+import { useChartOfAccounts } from "../../../hooks/useChartOfAccounts";
+import { useFinancialSourceRepository } from "../../../hooks/useFinancialSourceRepository";
 import {
   Card,
   CardHeader,
   CardContent,
   CardFooter,
-} from "../../components/ui2/card";
-import { Input } from "../../components/ui2/input";
-import { Button } from "../../components/ui2/button";
-import BackButton from "../../components/BackButton";
-import { Textarea } from "../../components/ui2/textarea";
-import { DatePickerInput } from "../../components/ui2/date-picker";
+} from "../../../components/ui2/card";
+import { Input } from "../../../components/ui2/input";
+import { Button } from "../../../components/ui2/button";
+import BackButton from "../../../components/BackButton";
+import { Textarea } from "../../../components/ui2/textarea";
+import { DatePickerInput } from "../../../components/ui2/date-picker";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../../components/ui2/select";
-import { Combobox } from "../../components/ui2/combobox";
-import { Switch } from "../../components/ui2/switch";
-import { useAccountRepository } from "../../hooks/useAccountRepository";
+} from "../../../components/ui2/select";
+import { Combobox } from "../../../components/ui2/combobox";
+import { Switch } from "../../../components/ui2/switch";
+import { useAccountRepository } from "../../../hooks/useAccountRepository";
 import {
   Save,
   Loader2,
@@ -35,11 +35,11 @@ import {
   FileText,
   AlertCircle,
 } from "lucide-react";
-import { useCurrencyStore } from "../../stores/currencyStore";
-import { formatCurrency } from "../../utils/currency";
-import { FormDialog } from "../../components/ui2/form-dialog";
-import AccountCreateForm from "../../components/forms/AccountCreateForm";
-import ChartOfAccountCreateForm from "../../components/forms/ChartOfAccountCreateForm";
+import { useCurrencyStore } from "../../../stores/currencyStore";
+import { formatCurrency } from "../../../utils/currency";
+import { FormDialog } from "../../../components/ui2/form-dialog";
+import AccountCreateForm from "../../../components/forms/AccountCreateForm";
+import ChartOfAccountCreateForm from "../../../components/forms/ChartOfAccountCreateForm";
 
 interface TransactionEntry {
   accounts_account_id: string;

--- a/src/pages/finances/transactions/TransactionDetail.tsx
+++ b/src/pages/finances/transactions/TransactionDetail.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
-import { usePermissions } from '../../hooks/usePermissions';
-import PermissionGate from '../../components/PermissionGate';
-import { Card, CardHeader, CardContent, CardFooter } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import BackButton from '../../components/BackButton';
-import { Badge } from '../../components/ui2/badge';
-import { Textarea } from '../../components/ui2/textarea';
+import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { usePermissions } from '../../../hooks/usePermissions';
+import PermissionGate from '../../../components/PermissionGate';
+import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Badge } from '../../../components/ui2/badge';
+import { Textarea } from '../../../components/ui2/textarea';
 import { 
   FileText,
   Loader2,
@@ -22,8 +22,8 @@ import {
   FileSpreadsheet
 } from 'lucide-react';
 import { format } from 'date-fns';
-import { useCurrencyStore } from '../../stores/currencyStore';
-import { formatCurrency } from '../../utils/currency';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+import { formatCurrency } from '../../../utils/currency';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,7 +33,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '../../components/ui2/alert-dialog';
+} from '../../../components/ui2/alert-dialog';
 
 function TransactionDetail() {
   const { id } = useParams<{ id: string }>();

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -1,14 +1,14 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
-import { usePermissions } from '../../hooks/usePermissions';
-import PermissionGate from '../../components/PermissionGate';
-import { Card, CardHeader, CardContent } from '../../components/ui2/card';
-import { Button } from '../../components/ui2/button';
-import { Input } from '../../components/ui2/input';
-import { DateRangePickerField } from '../../components/ui2/date-range-picker-field';
-import { Badge } from '../../components/ui2/badge';
-import { DataGrid } from '../../components/ui2/mui-datagrid';
+import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
+import { usePermissions } from '../../../hooks/usePermissions';
+import PermissionGate from '../../../components/PermissionGate';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import { Input } from '../../../components/ui2/input';
+import { DateRangePickerField } from '../../../components/ui2/date-range-picker-field';
+import { Badge } from '../../../components/ui2/badge';
+import { DataGrid } from '../../../components/ui2/mui-datagrid';
 import { 
   Plus, 
   Search, 
@@ -26,15 +26,15 @@ import {
   MoreHorizontal
 } from 'lucide-react';
 import { format } from 'date-fns';
-import { useCurrencyStore } from '../../stores/currencyStore';
-import { formatCurrency } from '../../utils/currency';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+import { formatCurrency } from '../../../utils/currency';
 import { GridColDef } from '@mui/x-data-grid';
 import { 
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger
-} from '../../components/ui2/dropdown-menu';
+} from '../../../components/ui2/dropdown-menu';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,14 +44,14 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '../../components/ui2/alert-dialog';
+} from '../../../components/ui2/alert-dialog';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue
-} from '../../components/ui2/select';
+} from '../../../components/ui2/select';
 
 function TransactionList() {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- organize finance pages into scoped folders for budgets, funds, and transactions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bca9d552883269b9d631f1464eba0