### PR TITLE
Add tracking columns for error logs

### DIFF
--- a/src/adapters/errorLog.adapter.ts
+++ b/src/adapters/errorLog.adapter.ts
@@ -19,6 +19,8 @@ export class ErrorLogAdapter
     context,
     created_at,
     tenant_id,
-    created_by
+    created_by,
+    updated_at,
+    updated_by
   `;
 }

--- a/supabase/migrations/20250702051000_error_logs_tracking.sql
+++ b/supabase/migrations/20250702051000_error_logs_tracking.sql
@@ -1,0 +1,32 @@
+-- Add updated_at and updated_by columns to error_logs table if they do not exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'error_logs' AND column_name = 'updated_at'
+  ) THEN
+    ALTER TABLE error_logs ADD COLUMN updated_at timestamptz DEFAULT now();
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'error_logs' AND column_name = 'updated_by'
+  ) THEN
+    ALTER TABLE error_logs ADD COLUMN updated_by uuid REFERENCES auth.users(id);
+  END IF;
+END $$;
+
+-- Create updated_at trigger for error_logs if it doesn't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'update_error_logs_updated_at'
+  ) THEN
+    CREATE TRIGGER update_error_logs_updated_at
+    BEFORE UPDATE ON error_logs
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  END IF;
+END $$;
+
+COMMENT ON TABLE error_logs IS 'Stores detailed error information for diagnostics with tenant isolation';


### PR DESCRIPTION
## Summary
- add migration to include `updated_at` and `updated_by` for `error_logs`
- expose updated fields in `ErrorLogAdapter`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd0af2bc4832692ce6142aa7583c5