### PR TITLE
Fix query builder usage

### DIFF
--- a/src/adapters/base.adapter.ts
+++ b/src/adapters/base.adapter.ts
@@ -142,7 +142,9 @@ export class BaseAdapter<T extends BaseModel> {
     return relationships.map(buildNestedSelect).join(',');
   }
 
-  protected async buildSecureQuery(options: QueryOptions = {}): Promise<PostgrestFilterBuilder<any, any, T[]>> {
+  protected async buildSecureQuery(
+    options: QueryOptions = {}
+  ): Promise<{ query: PostgrestFilterBuilder<any, any, T[]> }> {
     try {
       const tenantId = await tenantUtils.getTenantId();
       if (!tenantId) {
@@ -183,7 +185,7 @@ export class BaseAdapter<T extends BaseModel> {
         query = query.range(start, start + pageSize - 1);
       }
 
-      return query;
+      return { query };
     } catch (error) {
       throw handleError(error, {
         context: 'buildSecureQuery',
@@ -199,7 +201,7 @@ export class BaseAdapter<T extends BaseModel> {
         return { data: [], count: null };
       }
 
-      const query = await this.buildSecureQuery(options);
+      const { query } = await this.buildSecureQuery(options);
       const { data, error, count } = await query;
 
       if (error) {
@@ -219,7 +221,7 @@ export class BaseAdapter<T extends BaseModel> {
 
   public async fetchById(id: string, options: Omit<QueryOptions, 'pagination'> = {}): Promise<T | null> {
     try {
-      const query = await this.buildSecureQuery(options);
+      const { query } = await this.buildSecureQuery(options);
       const { data, error } = await query
         .eq('id', id)
         .single();

--- a/src/adapters/notification.adapter.ts
+++ b/src/adapters/notification.adapter.ts
@@ -59,7 +59,7 @@ export class NotificationAdapter
   }
 
   protected override async buildSecureQuery(options: QueryOptions = {}): Promise<any> {
-    const query = await super.buildSecureQuery(options);
+    const { query } = await super.buildSecureQuery(options);
     
     // Add user_id filter if not already present
     if (!options.filters?.user_id) {
@@ -69,6 +69,6 @@ export class NotificationAdapter
       }
     }
 
-    return query;
+    return { query };
   }
 }

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -128,7 +128,7 @@ export class QueryUtils {
   private async buildSecureQuery<T>(
     table: string,
     options: QueryOptions = {}
-  ): Promise<PostgrestFilterBuilder<any, any, T[]>> {
+  ): Promise<{ query: PostgrestFilterBuilder<any, any, T[]> }> {
     // Get current tenant
     const tenantId = await tenantUtils.getTenantId();
     if (!tenantId) {
@@ -173,7 +173,7 @@ export class QueryUtils {
       query = query.range(start, start + pageSize - 1);
     }
 
-    return query;
+    return { query };
   }
 
   /**
@@ -188,7 +188,7 @@ export class QueryUtils {
         return { data: [], count: null };
       }
 
-      const query = await this.buildSecureQuery<T>(table, options);
+      const { query } = await this.buildSecureQuery<T>(table, options);
       const { data, error, count } = await query;
 
       if (error) {
@@ -212,7 +212,7 @@ export class QueryUtils {
     options: Omit<QueryOptions, 'pagination'> = {}
   ): Promise<T | null> {
     try {
-      const query = await this.buildSecureQuery<T>(table, options);
+      const { query } = await this.buildSecureQuery<T>(table, options);
       const { data, error } = await query
         .eq('id', id)
         .is('deleted_at', null)
@@ -422,7 +422,7 @@ export class QueryUtils {
     filters: Record<string, any>
   ): Promise<boolean> {
     try {
-      const query = await this.buildSecureQuery(table, { filters });
+      const { query } = await this.buildSecureQuery(table, { filters });
       const { count, error } = await query.select('*', { count: 'exact', head: true });
 
       if (error) {


### PR DESCRIPTION
## Summary
- prevent accidental query execution in BaseAdapter
- update NotificationAdapter and queryUtils to use returned query object

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bd7531e7c8326a2f62e80c590a58c