### PR TITLE
Fix monthly trend card safety

### DIFF
--- a/src/pages/dashboard/PersonalDashboard.tsx
+++ b/src/pages/dashboard/PersonalDashboard.tsx
@@ -228,13 +228,17 @@ function PersonalDashboard() {
     );
   }
 
+  const lastTrend = monthlyTrends && monthlyTrends.length
+    ? monthlyTrends[monthlyTrends.length - 1]
+    : undefined;
+
   const cards = [
     {
       name: 'Monthly Contributions',
       value: formatCurrency(contributionStats?.monthlyTotal || 0, currency),
       icon: <TrendingUp className="text-emerald-500" />,
       color: 'bg-emerald-100 dark:bg-emerald-900/50',
-      trend: monthlyTrends?.[monthlyTrends.length - 1]?.percentageChange
+      trend: lastTrend?.percentageChange
     },
     {
       name: 'Yearly Contributions',

--- a/src/pages/finances/FinancesDashboard.tsx
+++ b/src/pages/finances/FinancesDashboard.tsx
@@ -243,13 +243,17 @@ function FinancesDashboard() {
     );
   }
 
+  const lastTrend = monthlyTrends && monthlyTrends.length
+    ? monthlyTrends[monthlyTrends.length - 1]
+    : undefined;
+
   const cards = [
     {
       name: 'Monthly Income',
       value: formatCurrency(stats?.monthlyIncome || 0, currency),
       icon: <TrendingUp className="text-emerald-500" />,
       color: 'bg-emerald-100 dark:bg-emerald-900/50',
-      trend: monthlyTrends?.[monthlyTrends.length - 1]?.percentageChange
+      trend: lastTrend?.percentageChange
     },
     {
       name: 'Monthly Expenses',


### PR DESCRIPTION
## Summary
- avoid runtime errors when monthlyTrends is empty in FinancesDashboard
- safely read latest trend in PersonalDashboard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_685bdcd0a6bc8326a0d7165326c526d2