### PR TITLE
Remove unused icon imports

### DIFF
--- a/src/pages/finances/FinancesDashboard.tsx
+++ b/src/pages/finances/FinancesDashboard.tsx
@@ -27,10 +27,6 @@ import {
   PieChart,
   BarChart3,
   LineChart,
-  Target,
-  Award,
-  Users2,
-  CreditCard,
   Layers,
   ChevronRight,
 } from 'lucide-react';


### PR DESCRIPTION
## Summary
- clean up unused lucide-react icons in Finances dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685be275ab408326988573cf6d9666ae