### PR TITLE
Refactor finance dashboard

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,3 +16,4 @@ export * from './useFundRepository';
 export * from './useOfferingBatchRepository';
 export * from './useCategoryRepository';
 export * from './useIncomeExpenseTransactionRepository';
+export * from './useFinanceDashboardData';

--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -1,0 +1,238 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabase';
+import { format, subMonths, startOfMonth, endOfMonth, startOfDay, endOfDay } from 'date-fns';
+import { useCurrencyStore } from '../stores/currencyStore';
+import { formatCurrency } from '../utils/currency';
+
+export function useFinanceDashboardData() {
+  const { currency } = useCurrencyStore();
+
+  const { data: currentTenant } = useQuery({
+    queryKey: ['current-tenant'],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_current_tenant');
+      if (error) throw error;
+      return data?.[0];
+    },
+  });
+
+  const { data: monthlyTrends, isLoading: trendsLoading } = useQuery({
+    queryKey: ['monthly-trends', currentTenant?.id],
+    queryFn: async () => {
+      const today = new Date();
+      const months = Array.from({ length: 12 }, (_, i) => {
+        const date = subMonths(today, i);
+        return {
+          start: startOfMonth(date),
+          end: endOfMonth(date),
+          month: format(date, 'MMM yyyy'),
+        };
+      }).reverse();
+
+      const monthlyData = await Promise.all(
+        months.map(async ({ start, end, month }) => {
+          const { data: transactions, error } = await supabase
+            .from('financial_transactions')
+            .select(
+              `type, amount, category:category_id (name, type), fund:fund_id (name, code)`
+            )
+            .eq('tenant_id', currentTenant?.id)
+            .gte('date', format(startOfDay(start), 'yyyy-MM-dd'))
+            .lte('date', format(endOfDay(end), 'yyyy-MM-dd'));
+
+          if (error) throw error;
+
+          const income =
+            transactions?.filter(t => t.type === 'income').reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+
+          const expenses =
+            transactions?.filter(t => t.type === 'expense').reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+
+          const previousMonth = subMonths(start, 1);
+          const { data: prevTransactions } = await supabase
+            .from('financial_transactions')
+            .select('amount')
+            .eq('tenant_id', currentTenant?.id)
+            .eq('type', 'income')
+            .gte('date', format(startOfDay(startOfMonth(previousMonth)), 'yyyy-MM-dd'))
+            .lte('date', format(endOfDay(endOfMonth(previousMonth)), 'yyyy-MM-dd'));
+
+          const previousIncome = prevTransactions?.reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+
+          const percentageChange =
+            previousIncome === 0 ? null : ((income - previousIncome) / previousIncome) * 100;
+
+          return {
+            month,
+            income,
+            expenses,
+            percentageChange,
+          };
+        })
+      );
+
+      return monthlyData;
+    },
+    enabled: !!currentTenant?.id,
+  });
+
+  const { data: stats, isLoading: statsLoading } = useQuery({
+    queryKey: ['finance-stats', currentTenant?.id],
+    queryFn: async () => {
+      const today = new Date();
+      const firstDayOfMonth = startOfMonth(today);
+      const lastDayOfMonth = endOfMonth(today);
+
+      const { data: transactions, error: transactionsError } = await supabase
+        .from('financial_transactions')
+        .select(
+          `type, amount, category:category_id (id, name, type), fund:fund_id (id, name, code)`
+        )
+        .eq('tenant_id', currentTenant?.id)
+        .gte('date', format(startOfDay(firstDayOfMonth), 'yyyy-MM-dd'))
+        .lte('date', format(endOfDay(lastDayOfMonth), 'yyyy-MM-dd'));
+
+      if (transactionsError) throw transactionsError;
+
+      const monthlyIncome =
+        transactions?.filter(t => t.type === 'income').reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+
+      const monthlyExpenses =
+        transactions?.filter(t => t.type === 'expense').reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+
+      const incomeByCategory =
+        transactions?.filter(t => t.type === 'income').reduce((acc, t) => {
+          const categoryName = t.category?.name || 'Uncategorized';
+          acc[categoryName] = (acc[categoryName] || 0) + Number(t.amount);
+          return acc;
+        }, {} as Record<string, number>) || {};
+
+      const expensesByCategory =
+        transactions?.filter(t => t.type === 'expense').reduce((acc, t) => {
+          const categoryName = t.category?.name || 'Uncategorized';
+          acc[categoryName] = (acc[categoryName] || 0) + Number(t.amount);
+          return acc;
+        }, {} as Record<string, number>) || {};
+
+      const { data: activeBudgets, error: budgetsError } = await supabase
+        .from('budgets')
+        .select('id')
+        .eq('tenant_id', currentTenant?.id)
+        .gte('end_date', format(today, 'yyyy-MM-dd'))
+        .lte('start_date', format(today, 'yyyy-MM-dd'));
+
+      if (budgetsError) throw budgetsError;
+
+      return {
+        monthlyIncome,
+        monthlyExpenses,
+        activeBudgets: activeBudgets?.length || 0,
+        incomeByCategory,
+        expensesByCategory,
+      };
+    },
+    enabled: !!currentTenant?.id,
+  });
+
+  const { data: fundBalances } = useQuery({
+    queryKey: ['fund-balances', currentTenant?.id],
+    queryFn: async () => {
+      const { data: funds, error } = await supabase
+        .from('funds')
+        .select('id, name, type')
+        .eq('tenant_id', currentTenant?.id)
+        .is('deleted_at', null);
+      if (error) throw error;
+
+      if (!funds) return [];
+
+      const { data: txs, error: txError } = await supabase
+        .from('financial_transactions')
+        .select('fund_id, type, amount, debit, credit')
+        .eq('tenant_id', currentTenant?.id)
+        .not('fund_id', 'is', null);
+      if (txError) throw txError;
+
+      return funds.map(f => {
+        const total = (txs || []).filter(t => t.fund_id === f.id).reduce((sum, t) => {
+          if (t.type) {
+            return sum + (t.type === 'income' ? Number(t.amount) : -Number(t.amount));
+          }
+          return sum + (Number(t.debit || 0) - Number(t.credit || 0));
+        }, 0);
+        return { ...f, balance: total };
+      });
+    },
+    enabled: !!currentTenant?.id,
+  });
+
+  const monthlyTrendsChartData = useMemo(() => {
+    return {
+      series: [
+        { name: 'Income', data: monthlyTrends?.map(m => m.income) || [] },
+        { name: 'Expenses', data: monthlyTrends?.map(m => m.expenses) || [] },
+      ],
+      options: {
+        chart: { type: 'area', stacked: false, height: 350, toolbar: { show: false } },
+        dataLabels: { enabled: false },
+        stroke: { curve: 'smooth', width: [2, 2] },
+        xaxis: {
+          categories: monthlyTrends?.map(m => m.month) || [],
+          labels: { style: { colors: 'hsl(var(--muted-foreground))' } },
+        },
+        yaxis: {
+          labels: {
+            formatter: (value: number) => formatCurrency(value, currency),
+            style: { colors: 'hsl(var(--muted-foreground))' },
+          },
+        },
+        legend: { labels: { colors: 'hsl(var(--foreground))' } },
+        fill: {
+          type: 'gradient',
+          gradient: { shadeIntensity: 1, opacityFrom: 0.7, opacityTo: 0.2, stops: [0, 90, 100] },
+        },
+        tooltip: { y: { formatter: (value: number) => formatCurrency(value, currency) } },
+      },
+    };
+  }, [monthlyTrends, currency]);
+
+  const incomeCategoryChartData = useMemo(() => {
+    return {
+      series: Object.values(stats?.incomeByCategory || {}),
+      options: {
+        chart: { type: 'donut' },
+        labels: Object.keys(stats?.incomeByCategory || {}),
+        legend: { position: 'bottom', labels: { colors: 'hsl(var(--foreground))' } },
+        dataLabels: { enabled: true, formatter: (value: number) => `${value.toFixed(2)}%` },
+        tooltip: { y: { formatter: (value: number) => formatCurrency(value, currency) } },
+      },
+    };
+  }, [stats, currency]);
+
+  const expenseCategoryChartData = useMemo(() => {
+    return {
+      series: Object.values(stats?.expensesByCategory || {}),
+      options: {
+        chart: { type: 'donut' },
+        labels: Object.keys(stats?.expensesByCategory || {}),
+        legend: { position: 'bottom', labels: { colors: 'hsl(var(--foreground))' } },
+        dataLabels: { enabled: true, formatter: (value: number) => `${value.toFixed(2)}%` },
+        tooltip: { y: { formatter: (value: number) => formatCurrency(value, currency) } },
+      },
+    };
+  }, [stats, currency]);
+
+  const isLoading = trendsLoading || statsLoading;
+
+  return {
+    currency,
+    monthlyTrends,
+    stats,
+    fundBalances,
+    monthlyTrendsChartData,
+    incomeCategoryChartData,
+    expenseCategoryChartData,
+    isLoading,
+  };
+}

--- a/src/pages/finances/FinancesDashboard.tsx
+++ b/src/pages/finances/FinancesDashboard.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
-import { format, subMonths, startOfMonth, endOfMonth, endOfDay, startOfDay } from 'date-fns';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Button } from '../../components/ui2/button';
 import { Badge } from '../../components/ui2/badge';
 import { Progress } from '../../components/ui2/progress';
-import { Charts } from '../../components/ui2/charts';
 import { SubscriptionGate } from '../../components/SubscriptionGate';
 import { DropdownButton } from '../../components/ui2/dropdown-button';
 import {
@@ -19,217 +15,31 @@ import {
   FileText,
   TrendingUp,
   TrendingDown,
-  DollarSign,
-  Calendar,
   Loader2,
-  ChevronUp,
-  ChevronDown,
-  PieChart,
   BarChart3,
-  LineChart,
   Layers,
   ChevronRight,
 } from 'lucide-react';
+import { useFinanceDashboardData } from '../../hooks/useFinanceDashboardData';
+import { StatsCards } from './dashboard/StatsCards';
+import { FundBalances } from './dashboard/FundBalances';
+import { MonthlyTrendsChart } from './dashboard/MonthlyTrendsChart';
+import { CategoryDistributionCharts } from './dashboard/CategoryDistributionCharts';
+import { QuickLinks } from './dashboard/QuickLinks';
 
 function FinancesDashboard() {
   const navigate = useNavigate();
   const { currency } = useCurrencyStore();
 
-  // Get current tenant
-  const { data: currentTenant } = useQuery({
-    queryKey: ['current-tenant'],
-    queryFn: async () => {
-      const { data, error } = await supabase.rpc('get_current_tenant');
-      if (error) throw error;
-      return data?.[0];
-    },
-  });
-
-  // Get monthly trends data
-  const { data: monthlyTrends, isLoading: trendsLoading } = useQuery({
-    queryKey: ['monthly-trends', currentTenant?.id],
-    queryFn: async () => {
-      const today = new Date();
-      const months = Array.from({ length: 12 }, (_, i) => {
-        const date = subMonths(today, i);
-        return {
-          start: startOfMonth(date),
-          end: endOfMonth(date),
-          month: format(date, 'MMM yyyy'),
-        };
-      }).reverse();
-
-      const monthlyData = await Promise.all(
-        months.map(async ({ start, end, month }) => {
-          const { data: transactions, error } = await supabase
-            .from('financial_transactions')
-            .select(`
-              type,
-              amount,
-              category:category_id (
-                name,
-                type
-              ),
-              fund:fund_id (
-                name,
-                code
-              )
-            `)
-            .eq('tenant_id', currentTenant?.id)
-            .gte('date', format(startOfDay(start), 'yyyy-MM-dd'))
-            .lte('date', format(endOfDay(end), 'yyyy-MM-dd'));
-
-          if (error) throw error;
-
-          const income = transactions
-            ?.filter(t => t.type === 'income')
-            .reduce((sum, t) => sum + Number(t.amount), 0) || 0;
-
-          const expenses = transactions
-            ?.filter(t => t.type === 'expense')
-            .reduce((sum, t) => sum + Number(t.amount), 0) || 0;
-
-          const previousMonth = subMonths(start, 1);
-          const { data: prevTransactions } = await supabase
-            .from('financial_transactions')
-            .select('amount')
-            .eq('tenant_id', currentTenant?.id)
-            .eq('type', 'income')
-            .gte('date', format(startOfDay(startOfMonth(previousMonth)), 'yyyy-MM-dd'))
-            .lte('date', format(endOfDay(endOfMonth(previousMonth)), 'yyyy-MM-dd'));
-
-          const previousIncome = prevTransactions
-            ?.reduce((sum, t) => sum + Number(t.amount), 0) || 0;
-
-          const percentageChange = previousIncome === 0
-            ? null
-            : ((income - previousIncome) / previousIncome) * 100;
-
-          return {
-            month,
-            income,
-            expenses,
-            percentageChange,
-          };
-        })
-      );
-
-      return monthlyData;
-    },
-    enabled: !!currentTenant?.id,
-  });
-
-  // Get current month's data
-  const { data: stats, isLoading: statsLoading } = useQuery({
-    queryKey: ['finance-stats', currentTenant?.id],
-    queryFn: async () => {
-      const today = new Date();
-      const firstDayOfMonth = startOfMonth(today);
-      const lastDayOfMonth = endOfMonth(today);
-
-      const { data: transactions, error: transactionsError } = await supabase
-        .from('financial_transactions')
-        .select(`
-          type,
-          amount,
-          category:category_id (
-            id,
-            name,
-            type
-          ),
-          fund:fund_id (
-            id,
-            name,
-            code
-          )
-        `)
-        .eq('tenant_id', currentTenant?.id)
-        .gte('date', format(startOfDay(firstDayOfMonth), 'yyyy-MM-dd'))
-        .lte('date', format(endOfDay(lastDayOfMonth), 'yyyy-MM-dd'));
-
-      if (transactionsError) throw transactionsError;
-
-      const monthlyIncome = transactions
-        ?.filter(t => t.type === 'income')
-        .reduce((sum, t) => sum + Number(t.amount), 0) || 0;
-
-      const monthlyExpenses = transactions
-        ?.filter(t => t.type === 'expense')
-        .reduce((sum, t) => sum + Number(t.amount), 0) || 0;
-
-      // Calculate category breakdowns
-      const incomeByCategory = transactions
-        ?.filter(t => t.type === 'income')
-        .reduce((acc, t) => {
-          const categoryName = t.category?.name || 'Uncategorized';
-          acc[categoryName] = (acc[categoryName] || 0) + Number(t.amount);
-          return acc;
-        }, {} as Record<string, number>);
-
-      const expensesByCategory = transactions
-        ?.filter(t => t.type === 'expense')
-        .reduce((acc, t) => {
-          const categoryName = t.category?.name || 'Uncategorized';
-          acc[categoryName] = (acc[categoryName] || 0) + Number(t.amount);
-          return acc;
-        }, {} as Record<string, number>);
-
-      // Get active budgets count
-      const { data: activeBudgets, error: budgetsError } = await supabase
-        .from('budgets')
-        .select('id')
-        .eq('tenant_id', currentTenant?.id)
-        .gte('end_date', format(today, 'yyyy-MM-dd'))
-        .lte('start_date', format(today, 'yyyy-MM-dd'));
-
-      if (budgetsError) throw budgetsError;
-
-      return {
-        monthlyIncome,
-        monthlyExpenses,
-        activeBudgets: activeBudgets?.length || 0,
-        incomeByCategory,
-        expensesByCategory,
-      };
-    },
-    enabled: !!currentTenant?.id,
-  });
-
-  // Get fund balances
-  const { data: fundBalances } = useQuery({
-    queryKey: ['fund-balances', currentTenant?.id],
-    queryFn: async () => {
-      const { data: funds, error } = await supabase
-        .from('funds')
-        .select('id, name, type')
-        .eq('tenant_id', currentTenant?.id)
-        .is('deleted_at', null);
-      if (error) throw error;
-
-      if (!funds) return [];
-
-      const { data: txs, error: txError } = await supabase
-        .from('financial_transactions')
-        .select('fund_id, type, amount, debit, credit')
-        .eq('tenant_id', currentTenant?.id)
-        .not('fund_id', 'is', null);
-      if (txError) throw txError;
-
-      return funds.map(f => {
-        const total = (txs || []).filter(t => t.fund_id === f.id)
-          .reduce((sum, t) => {
-            if (t.type) {
-              return sum + (t.type === 'income' ? Number(t.amount) : -Number(t.amount));
-            }
-            return sum + (Number(t.debit || 0) - Number(t.credit || 0));
-          }, 0);
-        return { ...f, balance: total };
-      });
-    },
-    enabled: !!currentTenant?.id,
-  });
-
-  const isLoading = trendsLoading || statsLoading;
+  const {
+    stats,
+    fundBalances,
+    monthlyTrends,
+    monthlyTrendsChartData,
+    incomeCategoryChartData,
+    expenseCategoryChartData,
+    isLoading,
+  } = useFinanceDashboardData();
 
   if (isLoading) {
     return (
@@ -239,151 +49,6 @@ function FinancesDashboard() {
     );
   }
 
-  const lastTrend = monthlyTrends && monthlyTrends.length
-    ? monthlyTrends[monthlyTrends.length - 1]
-    : undefined;
-
-  const cards = [
-    {
-      name: 'Monthly Income',
-      value: formatCurrency(stats?.monthlyIncome || 0, currency),
-      icon: <TrendingUp className="text-emerald-500" />,
-      color: 'bg-emerald-100 dark:bg-emerald-900/50',
-      trend: lastTrend?.percentageChange
-    },
-    {
-      name: 'Monthly Expenses',
-      value: formatCurrency(stats?.monthlyExpenses || 0, currency),
-      icon: <TrendingDown className="text-rose-500" />,
-      color: 'bg-rose-100 dark:bg-rose-900/50',
-      description: "Total expenses this month"
-    },
-    {
-      name: 'Net Balance',
-      value: formatCurrency((stats?.monthlyIncome || 0) - (stats?.monthlyExpenses || 0), currency),
-      icon: <DollarSign className="text-blue-500" />,
-      color: 'bg-blue-100 dark:bg-blue-900/50',
-      description: "Net balance this month"
-    },
-    {
-      name: 'Active Budgets',
-      value: stats?.activeBudgets || 0,
-      icon: <PiggyBank className="text-violet-500" />,
-      color: 'bg-violet-100 dark:bg-violet-900/50',
-      description: "Currently active budgets"
-    }
-  ];
-
-  // Prepare chart data
-  const monthlyTrendsChartData = {
-    series: [
-      {
-        name: 'Income',
-        data: monthlyTrends?.map(m => m.income) || []
-      },
-      {
-        name: 'Expenses',
-        data: monthlyTrends?.map(m => m.expenses) || []
-      }
-    ],
-    options: {
-      chart: {
-        type: 'area',
-        stacked: false,
-        height: 350,
-        toolbar: {
-          show: false
-        }
-      },
-      dataLabels: {
-        enabled: false
-      },
-      stroke: {
-        curve: 'smooth',
-        width: [2, 2]
-      },
-      xaxis: {
-        categories: monthlyTrends?.map(m => m.month) || [],
-        labels: {
-          style: {
-            colors: 'hsl(var(--muted-foreground))'
-          }
-        }
-      },
-      yaxis: {
-        labels: {
-          formatter: (value: number) => formatCurrency(value, currency),
-          style: {
-            colors: 'hsl(var(--muted-foreground))'
-          }
-        }
-      },
-      fill: {
-        type: 'gradient',
-        gradient: {
-          shadeIntensity: 1,
-          opacityFrom: 0.7,
-          opacityTo: 0.2,
-          stops: [0, 90, 100]
-        }
-      },
-      tooltip: {
-        y: {
-          formatter: (value: number) => formatCurrency(value, currency)
-        }
-      }
-    }
-  };
-
-  const incomeCategoryChartData = {
-    series: Object.values(stats?.incomeByCategory || {}),
-    options: {
-      chart: {
-        type: 'donut',
-      },
-      labels: Object.keys(stats?.incomeByCategory || {}),
-      legend: {
-        position: 'bottom',
-        labels: {
-          colors: 'hsl(var(--foreground))'
-        }
-      },
-      dataLabels: {
-        enabled: true,
-        formatter: (value: number) => `${value.toFixed(2)}%`
-      },
-      tooltip: {
-        y: {
-          formatter: (value: number) => formatCurrency(value, currency)
-        }
-      }
-    }
-  };
-
-  const expenseCategoryChartData = {
-    series: Object.values(stats?.expensesByCategory || {}),
-    options: {
-      chart: {
-        type: 'donut',
-      },
-      labels: Object.keys(stats?.expensesByCategory || {}),
-      legend: {
-        position: 'bottom',
-        labels: {
-          colors: 'hsl(var(--foreground))'
-        }
-      },
-      dataLabels: {
-        enabled: true,
-        formatter: (value: number) => `${value.toFixed(2)}%`
-      },
-      tooltip: {
-        y: {
-          formatter: (value: number) => formatCurrency(value, currency)
-        }
-      }
-    }
-  };
 
   return (
     <div>
@@ -455,123 +120,17 @@ function FinancesDashboard() {
       </div>
 
       {/* Stats Overview */}
-      <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {cards.map((card) => (
-          <Card 
-            key={card.name} 
-            className="overflow-hidden hover:shadow-lg transition-shadow duration-200"
-          >
-            <CardContent className="p-4">
-              <div className="flex items-center justify-between">
-                <div className={`${card.color} p-2 rounded-lg`}>
-                  {card.icon}
-                </div>
-                {card.trend != null ? (
-                  <Badge
-                    variant={card.trend >= 0 ? 'success' : 'destructive'}
-                    className="flex items-center space-x-1"
-                  >
-                    {card.trend >= 0 ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-                    <span>{Math.abs(card.trend).toFixed(1)}%</span>
-                  </Badge>
-                ) : (
-                  <Badge variant="secondary">N/A</Badge>
-                )}
-              </div>
-              <div className="mt-2">
-                <p className="text-2xl font-semibold text-foreground">
-                  {card.value}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  {card.name}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-
-        {/* Fund Balances */}
-        <Card className="mt-6">
-          <CardContent className="p-4">
-        <div className="flex items-center mb-4">
-          <DollarSign className="h-5 w-5 text-muted-foreground mr-2" />
-          <h3 className="text-base font-medium text-foreground">Fund Balances</h3>
-        </div>
-        <ul className="space-y-2">
-          {fundBalances?.map(f => (
-            <li key={f.id} className="flex justify-between text-sm">
-              <span>{f.name}</span>
-              <span>{formatCurrency(f.balance, currency)}</span>
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-      </div>
+      <StatsCards stats={stats} trends={monthlyTrends} currency={currency} />
+      <FundBalances funds={fundBalances} currency={currency} />
 
       {/* Monthly Trends Chart */}
-      <Card className="mt-6">
-        <CardContent className="p-4">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center">
-              <LineChart className="h-5 w-5 text-muted-foreground mr-2" />
-              <h3 className="text-base font-medium text-foreground">
-                Monthly Income vs Expenses
-              </h3>
-            </div>
-            <Badge variant="secondary">Last 12 Months</Badge>
-          </div>
-          <Charts
-            type="area"
-            series={monthlyTrendsChartData.series}
-            options={monthlyTrendsChartData.options}
-            height={350}
-          />
-        </CardContent>
-      </Card>
+      <MonthlyTrendsChart data={monthlyTrendsChartData} />
 
       {/* Category Distribution Charts */}
-      <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
-        {/* Income Categories */}
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center">
-                <PieChart className="h-5 w-5 text-emerald-500 mr-2" />
-                <h3 className="text-base font-medium text-foreground">
-                  Income Distribution
-                </h3>
-              </div>
-            </div>
-            <Charts
-              type="donut"
-              series={incomeCategoryChartData.series}
-              options={incomeCategoryChartData.options}
-              height={350}
-            />
-          </CardContent>
-        </Card>
-
-        {/* Expense Categories */}
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center">
-                <PieChart className="h-5 w-5 text-rose-500 mr-2" />
-                <h3 className="text-base font-medium text-foreground">
-                  Expense Distribution
-                </h3>
-              </div>
-            </div>
-            <Charts
-              type="donut"
-              series={expenseCategoryChartData.series}
-              options={expenseCategoryChartData.options}
-              height={350}
-            />
-          </CardContent>
-        </Card>
-      </div>
+      <CategoryDistributionCharts
+        incomeData={incomeCategoryChartData}
+        expenseData={expenseCategoryChartData}
+      />
 
       {/* Financial Summary */}
       <Card className="mt-6">
@@ -634,123 +193,7 @@ function FinancesDashboard() {
       </Card>
 
       {/* Quick Links */}
-      <div className="mt-6 grid grid-cols-1 gap-8 lg:grid-cols-2">
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center mb-4">
-              <Calendar className="h-5 w-5 text-muted-foreground mr-2" />
-              <h3 className="text-base font-medium text-foreground">Quick Links</h3>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Link to="/finances/transactions">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center space-x-3">
-                    <div className="flex-shrink-0">
-                      <DollarSign className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-foreground">Transactions</h4>
-                      <p className="text-xs text-muted-foreground">View all financial records</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/finances/budgets">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center space-x-3">
-                    <div className="flex-shrink-0">
-                      <PiggyBank className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-foreground">Budgets</h4>
-                      <p className="text-xs text-muted-foreground">Manage budget allocations</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/finances/reports">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center space-x-3">
-                    <div className="flex-shrink-0">
-                      <FileText className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-foreground">Reports</h4>
-                      <p className="text-xs text-muted-foreground">Generate financial reports</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/finances/transactions/add">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center space-x-3">
-                    <div className="flex-shrink-0">
-                      <Layers className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h4 className="text-sm font-medium text-foreground">Bulk Entry</h4>
-                      <p className="text-xs text-muted-foreground">Enter multiple transactions</p>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="p-4">
-            <div className="flex items-center mb-4">
-              <DollarSign className="h-5 w-5 text-muted-foreground mr-2" />
-              <h3 className="text-base font-medium text-foreground">Bulk Operations</h3>
-            </div>
-            <div className="space-y-4 grid grid-cols-1 gap-2">
-              <Link to="/finances/transactions/add">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center justify-between">
-                    <div className="flex items-center space-x-3">
-                      <Layers className="h-6 w-6 text-primary" />
-                      <div>
-                        <h4 className="text-sm font-medium text-foreground">Bulk Transaction Entry</h4>
-                        <p className="text-xs text-muted-foreground">Enter multiple transactions at once</p>
-                      </div>
-                    </div>
-                    <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/finances/transactions/add?type=income">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center justify-between">
-                    <div className="flex items-center space-x-3">
-                      <TrendingUp className="h-6 w-6 text-success" />
-                      <div>
-                        <h4 className="text-sm font-medium text-foreground">Bulk Income Entry</h4>
-                        <p className="text-xs text-muted-foreground">Record multiple income transactions</p>
-                      </div>
-                    </div>
-                    <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                  </CardContent>
-                </Card>
-              </Link>
-              <Link to="/finances/transactions/add?type=expense">
-                <Card className="hover:shadow-lg transition-shadow duration-200">
-                  <CardContent className="p-4 flex items-center justify-between">
-                    <div className="flex items-center space-x-3">
-                      <TrendingDown className="h-6 w-6 text-destructive" />
-                      <div>
-                        <h4 className="text-sm font-medium text-foreground">Bulk Expense Entry</h4>
-                        <p className="text-xs text-muted-foreground">Record multiple expense transactions</p>
-                      </div>
-                    </div>
-                    <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                  </CardContent>
-                </Card>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <QuickLinks />
     </div>
   );
 }

--- a/src/pages/finances/dashboard/CategoryDistributionCharts.tsx
+++ b/src/pages/finances/dashboard/CategoryDistributionCharts.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { PieChart } from 'lucide-react';
+import { Charts } from '../../../components/ui2/charts';
+
+interface ChartData {
+  series: any[];
+  options: any;
+}
+
+interface Props {
+  incomeData: ChartData;
+  expenseData: ChartData;
+}
+
+export function CategoryDistributionCharts({ incomeData, expenseData }: Props) {
+  return (
+    <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center">
+              <PieChart className="h-5 w-5 text-emerald-500 mr-2" />
+              <h3 className="text-base font-medium text-foreground">Income Distribution</h3>
+            </div>
+          </div>
+          <Charts type="donut" series={incomeData.series} options={incomeData.options} height={350} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center">
+              <PieChart className="h-5 w-5 text-rose-500 mr-2" />
+              <h3 className="text-base font-medium text-foreground">Expense Distribution</h3>
+            </div>
+          </div>
+          <Charts type="donut" series={expenseData.series} options={expenseData.options} height={350} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/finances/dashboard/FundBalances.tsx
+++ b/src/pages/finances/dashboard/FundBalances.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { DollarSign } from 'lucide-react';
+import { formatCurrency } from '../../../utils/currency';
+
+interface FundBalance {
+  id: string;
+  name: string;
+  balance: number;
+}
+
+interface Props {
+  funds?: FundBalance[];
+  currency: string;
+}
+
+export function FundBalances({ funds, currency }: Props) {
+  if (!funds || funds.length === 0) return null;
+  return (
+    <Card className="mt-6">
+      <CardContent className="p-4">
+        <div className="flex items-center mb-4">
+          <DollarSign className="h-5 w-5 text-muted-foreground mr-2" />
+          <h3 className="text-base font-medium text-foreground">Fund Balances</h3>
+        </div>
+        <ul className="space-y-2">
+          {funds.map(f => (
+            <li key={f.id} className="flex justify-between text-sm">
+              <span>{f.name}</span>
+              <span>{formatCurrency(f.balance, currency)}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/finances/dashboard/MonthlyTrendsChart.tsx
+++ b/src/pages/finances/dashboard/MonthlyTrendsChart.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Badge } from '../../../components/ui2/badge';
+import { LineChart } from 'lucide-react';
+import { Charts } from '../../../components/ui2/charts';
+
+interface ChartData {
+  series: any[];
+  options: any;
+}
+
+interface Props {
+  data: ChartData;
+}
+
+export function MonthlyTrendsChart({ data }: Props) {
+  return (
+    <Card className="mt-6">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center">
+            <LineChart className="h-5 w-5 text-muted-foreground mr-2" />
+            <h3 className="text-base font-medium text-foreground">Monthly Income vs Expenses</h3>
+          </div>
+          <Badge variant="secondary">Last 12 Months</Badge>
+        </div>
+        <Charts type="area" series={data.series} options={data.options} height={350} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/finances/dashboard/QuickLinks.tsx
+++ b/src/pages/finances/dashboard/QuickLinks.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { DollarSign, PiggyBank, FileText, Layers, ChevronRight, TrendingUp, TrendingDown, Calendar } from 'lucide-react';
+
+export function QuickLinks() {
+  return (
+    <div className="mt-6 grid grid-cols-1 gap-8 lg:grid-cols-2">
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center mb-4">
+            <Calendar className="h-5 w-5 text-muted-foreground mr-2" />
+            <h3 className="text-base font-medium text-foreground">Quick Links</h3>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link to="/finances/transactions">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center space-x-3">
+                  <div className="flex-shrink-0">
+                    <DollarSign className="h-6 w-6 text-primary" />
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-medium text-foreground">Transactions</h4>
+                    <p className="text-xs text-muted-foreground">View all financial records</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+            <Link to="/finances/budgets">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center space-x-3">
+                  <div className="flex-shrink-0">
+                    <PiggyBank className="h-6 w-6 text-primary" />
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-medium text-foreground">Budgets</h4>
+                    <p className="text-xs text-muted-foreground">Manage budget allocations</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+            <Link to="/finances/reports">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center space-x-3">
+                  <div className="flex-shrink-0">
+                    <FileText className="h-6 w-6 text-primary" />
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-medium text-foreground">Reports</h4>
+                    <p className="text-xs text-muted-foreground">Generate financial reports</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+            <Link to="/finances/transactions/add">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center space-x-3">
+                  <div className="flex-shrink-0">
+                    <Layers className="h-6 w-6 text-primary" />
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-medium text-foreground">Bulk Entry</h4>
+                    <p className="text-xs text-muted-foreground">Enter multiple transactions</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-center mb-4">
+            <DollarSign className="h-5 w-5 text-muted-foreground mr-2" />
+            <h3 className="text-base font-medium text-foreground">Bulk Operations</h3>
+          </div>
+          <div className="space-y-4 grid grid-cols-1 gap-2">
+            <Link to="/finances/transactions/add">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <Layers className="h-6 w-6 text-primary" />
+                    <div>
+                      <h4 className="text-sm font-medium text-foreground">Bulk Transaction Entry</h4>
+                      <p className="text-xs text-muted-foreground">Enter multiple transactions at once</p>
+                    </div>
+                  </div>
+                  <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                </CardContent>
+              </Card>
+            </Link>
+            <Link to="/finances/transactions/add?type=income">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <TrendingUp className="h-6 w-6 text-success" />
+                    <div>
+                      <h4 className="text-sm font-medium text-foreground">Bulk Income Entry</h4>
+                      <p className="text-xs text-muted-foreground">Record multiple income transactions</p>
+                    </div>
+                  </div>
+                  <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                </CardContent>
+              </Card>
+            </Link>
+            <Link to="/finances/transactions/add?type=expense">
+              <Card className="hover:shadow-lg transition-shadow duration-200">
+                <CardContent className="p-4 flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <TrendingDown className="h-6 w-6 text-destructive" />
+                    <div>
+                      <h4 className="text-sm font-medium text-foreground">Bulk Expense Entry</h4>
+                      <p className="text-xs text-muted-foreground">Record multiple expense transactions</p>
+                    </div>
+                  </div>
+                  <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/pages/finances/dashboard/StatsCards.tsx
+++ b/src/pages/finances/dashboard/StatsCards.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Badge } from '../../../components/ui2/badge';
+import { ChevronUp, ChevronDown, TrendingUp, TrendingDown, DollarSign, PiggyBank } from 'lucide-react';
+import { formatCurrency } from '../../../utils/currency';
+
+interface StatsData {
+  monthlyIncome: number;
+  monthlyExpenses: number;
+  activeBudgets: number;
+}
+
+interface TrendData {
+  month: string;
+  income: number;
+  expenses: number;
+  percentageChange: number | null;
+}
+
+interface Props {
+  stats?: StatsData;
+  trends?: TrendData[];
+  currency: string;
+}
+
+export function StatsCards({ stats, trends, currency }: Props) {
+  const lastTrend = trends && trends.length ? trends[trends.length - 1] : undefined;
+
+  const cards = [
+    {
+      name: 'Monthly Income',
+      value: formatCurrency(stats?.monthlyIncome || 0, currency),
+      icon: <TrendingUp className="text-emerald-500" />,
+      color: 'bg-emerald-100 dark:bg-emerald-900/50',
+      trend: lastTrend?.percentageChange,
+    },
+    {
+      name: 'Monthly Expenses',
+      value: formatCurrency(stats?.monthlyExpenses || 0, currency),
+      icon: <TrendingDown className="text-rose-500" />,
+      color: 'bg-rose-100 dark:bg-rose-900/50',
+    },
+    {
+      name: 'Net Balance',
+      value: formatCurrency((stats?.monthlyIncome || 0) - (stats?.monthlyExpenses || 0), currency),
+      icon: <DollarSign className="text-blue-500" />,
+      color: 'bg-blue-100 dark:bg-blue-900/50',
+    },
+    {
+      name: 'Active Budgets',
+      value: stats?.activeBudgets || 0,
+      icon: <PiggyBank className="text-violet-500" />,
+      color: 'bg-violet-100 dark:bg-violet-900/50',
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map(card => (
+        <Card key={card.name} className="overflow-hidden hover:shadow-lg transition-shadow duration-200">
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div className={`${card.color} p-2 rounded-lg`}>{card.icon}</div>
+              {'trend' in card && card.trend != null ? (
+                <Badge variant={card.trend >= 0 ? 'success' : 'destructive'} className="flex items-center space-x-1">
+                  {card.trend >= 0 ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+                  <span>{Math.abs(card.trend).toFixed(1)}%</span>
+                </Badge>
+              ) : null}
+            </div>
+            <div className="mt-2">
+              <p className="text-2xl font-semibold text-foreground">{card.value}</p>
+              <p className="text-sm text-muted-foreground">{card.name}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- encapsulate dashboard queries and chart prep in `useFinanceDashboardData`
- split major UI pieces into components under `finances/dashboard`
- simplify `FinancesDashboard` page to orchestrate new components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be3ca162883269d686e88e357eaf9