### PR TITLE
Fix maximum update depth due to unstable query keys

### DIFF
--- a/src/hooks/useBaseRepository.ts
+++ b/src/hooks/useBaseRepository.ts
@@ -12,11 +12,17 @@ export function useBaseRepository<T extends BaseModel>(
   const queryClient = useQueryClient();
 
   const useQuery = (options: QueryOptions = {}) => {
+    // Serialize query options except for the "enabled" flag to ensure
+    // a stable query key across renders. Without this, passing inline
+    // objects would create new query keys on every render and trigger
+    // unnecessary re-fetching.
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
     return useReactQuery({
-      queryKey: [queryKey, options],
+      queryKey: [queryKey, serializedOptions],
       queryFn: () => repository.find(options),
       staleTime: 5 * 60 * 1000, // 5 minutes
-      enabled: options.enabled ?? true,
+      enabled: enabled ?? true,
     });
   };
 


### PR DESCRIPTION
## Summary
- stabilize query keys in `useBaseRepository` by serializing options

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c298bdc20832695a87a01d2abd416