### PR TITLE
Fix unstable hook order in GivingAddEdit

### DIFF
--- a/src/pages/finances/giving/GivingAddEdit.tsx
+++ b/src/pages/finances/giving/GivingAddEdit.tsx
@@ -110,6 +110,8 @@ function GivingAddEdit() {
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
 
+  const { currency } = useCurrencyStore();
+
   useEffect(() => {
     if (isEditMode && header) {
       setHeaderData({
@@ -189,8 +191,6 @@ function GivingAddEdit() {
     newEntries.splice(index, 1);
     setEntries(newEntries);
   };
-
-  const { currency } = useCurrencyStore();
 
   const totalAmount = React.useMemo(
     () => entries.reduce((sum, e) => sum + Number(e.amount || 0), 0),


### PR DESCRIPTION
## Summary
- call `useCurrencyStore` before returning loading UI in GivingAddEdit page

## Testing
- `npm run test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c32df7bf48326b7096e7f68d1bd50