### PR TITLE
Fix hook order in ExpenseAddEdit

### DIFF
--- a/src/pages/finances/expenses/ExpenseAddEdit.tsx
+++ b/src/pages/finances/expenses/ExpenseAddEdit.tsx
@@ -101,6 +101,8 @@ function ExpenseAddEdit() {
   const entryRecords = entryResponse?.data || [];
   const isDisabled = isEditMode && header && header.status !== 'draft';
 
+  const { currency } = useCurrencyStore();
+
   useEffect(() => {
     if (isEditMode && header) {
       setHeaderData({
@@ -180,8 +182,6 @@ function ExpenseAddEdit() {
     newEntries.splice(index, 1);
     setEntries(newEntries);
   };
-
-  const { currency } = useCurrencyStore();
 
   const totalAmount = React.useMemo(
     () => entries.reduce((sum, e) => sum + Number(e.amount || 0), 0),


### PR DESCRIPTION
## Summary
- call `useCurrencyStore` before any conditional returns in `ExpenseAddEdit`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c369990c48326bca14e8eb997de5c