### PR TITLE
Add mapping table migration

### DIFF
--- a/supabase/migrations/20250705000000_silver_lake.sql
+++ b/supabase/migrations/20250705000000_silver_lake.sql
@@ -1,0 +1,12 @@
+-- Map income_expense_transactions to their financial transactions
+CREATE TABLE IF NOT EXISTS income_expense_transaction_mappings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_id UUID NOT NULL REFERENCES income_expense_transactions(id) ON DELETE CASCADE,
+  transaction_header_id UUID NOT NULL REFERENCES financial_transaction_headers(id) ON DELETE CASCADE,
+  debit_transaction_id UUID REFERENCES financial_transactions(id) ON DELETE CASCADE,
+  credit_transaction_id UUID REFERENCES financial_transactions(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ietm_transaction_id ON income_expense_transaction_mappings(transaction_id);


### PR DESCRIPTION
## Summary
- add `income_expense_transaction_mappings` migration to link income/expense transactions with financial transactions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc46042448326aae51bfb89571e61