### PR TITLE
Implement batch update for income/expense transactions

### DIFF
--- a/src/adapters/incomeExpenseTransactionMapping.adapter.ts
+++ b/src/adapters/incomeExpenseTransactionMapping.adapter.ts
@@ -7,6 +7,7 @@ import { TYPES } from '../lib/types';
 
 export interface IIncomeExpenseTransactionMappingAdapter extends BaseAdapter<IncomeExpenseTransactionMapping> {
   getByTransactionId(id: string): Promise<IncomeExpenseTransactionMapping[]>;
+  getByHeaderId(id: string): Promise<IncomeExpenseTransactionMapping[]>;
 }
 
 @injectable()
@@ -47,6 +48,15 @@ export class IncomeExpenseTransactionMappingAdapter
   ): Promise<IncomeExpenseTransactionMapping[]> {
     const result = await this.fetch({
       filters: { transaction_id: { operator: 'eq', value: id } }
+    });
+    return result.data;
+  }
+
+  public async getByHeaderId(
+    id: string
+  ): Promise<IncomeExpenseTransactionMapping[]> {
+    const result = await this.fetch({
+      filters: { transaction_header_id: { operator: 'eq', value: id } }
     });
     return result.data;
   }

--- a/src/hooks/useIncomeExpenseService.ts
+++ b/src/hooks/useIncomeExpenseService.ts
@@ -26,7 +26,7 @@ export function useIncomeExpenseService(transactionType: TransactionType) {
 
   const updateMutation = useMutation({
     mutationFn: ({ id, header, entries }: { id: string; header: Partial<FinancialTransactionHeader>; entries: IncomeExpenseEntryBase[] }) =>
-      service.update(id, header, entries.map(e => ({ ...e, transaction_type: transactionType }))),
+      service.updateBatch(id, header, entries.map(e => ({ ...e, transaction_type: transactionType }))),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['financial_transaction_headers'] });
       NotificationService.showSuccess('Transaction updated successfully');

--- a/src/repositories/incomeExpenseTransactionMapping.repository.ts
+++ b/src/repositories/incomeExpenseTransactionMapping.repository.ts
@@ -7,6 +7,7 @@ import { IncomeExpenseTransactionMappingValidator } from '../validators/incomeEx
 
 export interface IIncomeExpenseTransactionMappingRepository extends BaseRepository<IncomeExpenseTransactionMapping> {
   getByTransactionId(id: string): Promise<IncomeExpenseTransactionMapping[]>;
+  getByHeaderId(id: string): Promise<IncomeExpenseTransactionMapping[]>;
 }
 
 @injectable()
@@ -57,5 +58,13 @@ export class IncomeExpenseTransactionMappingRepository
     return (
       this.adapter as unknown as IIncomeExpenseTransactionMappingAdapter
     ).getByTransactionId(id);
+  }
+
+  public async getByHeaderId(
+    id: string
+  ): Promise<IncomeExpenseTransactionMapping[]> {
+    return (
+      this.adapter as unknown as IIncomeExpenseTransactionMappingAdapter
+    ).getByHeaderId(id);
   }
 }


### PR DESCRIPTION
## Summary
- add header based mapping lookup
- implement `updateBatch` service to replace lines for a header
- update hook to use `updateBatch`
- extend tests for batch updates

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd352a62483268a8d530403bcb1fd