### PR TITLE
Update batch transaction updates

### DIFF
--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -18,6 +18,7 @@ import { useCurrencyStore } from '../../../stores/currencyStore';
 import { formatCurrency } from '../../../utils/currency';
 
 interface Entry {
+  id?: string;
   accounts_account_id: string;
   fund_id: string;
   category_id: string;
@@ -123,6 +124,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
     if (isEditMode && entryRecords.length > 0) {
       setEntries(
         entryRecords.map((e: any) => ({
+          id: e.id,
           accounts_account_id: e.account_id || '',
           fund_id: e.fund_id || '',
           category_id: e.category_id || '',


### PR DESCRIPTION
## Summary
- allow edited income/expense entries to include an optional id
- update `updateBatch` to update existing lines, delete removed ones and create new ones
- wire up id handling in income/expense add/edit page
- revise service unit tests for new behaviour

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd8bf8bdc832698dc82900bd0e01c