### PR TITLE
Fix alias conflict for mapping query

### DIFF
--- a/src/adapters/incomeExpenseTransactionMapping.adapter.ts
+++ b/src/adapters/incomeExpenseTransactionMapping.adapter.ts
@@ -32,12 +32,12 @@ export class IncomeExpenseTransactionMappingAdapter
 
   protected defaultRelationships: QueryOptions['relationships'] = [
     {
-      table: 'financial_transactions',
+      table: 'debit_transaction',
       foreignKey: 'debit_transaction_id',
       select: ['id', 'account_id', 'amount', 'debit', 'credit']
     },
     {
-      table: 'financial_transactions',
+      table: 'credit_transaction',
       foreignKey: 'credit_transaction_id',
       select: ['id', 'account_id', 'amount', 'debit', 'credit']
     }


### PR DESCRIPTION
## Summary
- assign unique table aliases for income/expense mapping relationships

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ddc5c75bc8326baf563abd3a4a163