### PR TITLE
Fix account_id reset in IncomeExpense edit

### DIFF
--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -139,11 +139,16 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
 
   useEffect(() => {
     setEntries(prev =>
-      prev.map(e => ({
-        ...e,
-        source_account_id: sources.find(s => s.id === e.source_id)?.account_id || null,
-        category_account_id: categories.find(c => c.id === e.category_id)?.chart_of_account_id || null,
-      }))
+      prev.map(e => {
+        const sourceAccount = sources.find(s => s.id === e.source_id)?.account_id;
+        const categoryAccount = categories.find(c => c.id === e.category_id)?.chart_of_account_id;
+
+        return {
+          ...e,
+          source_account_id: sourceAccount ?? e.source_account_id,
+          category_account_id: categoryAccount ?? e.category_account_id,
+        };
+      })
     );
   }, [sources, categories]);
 


### PR DESCRIPTION
## Summary
- prevent overwriting existing source/category account references when editing Income/Expense entries

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*


------
https://chatgpt.com/codex/tasks/task_e_685ddfaabb2c83269a5f0e4802870944