### PR TITLE
Remove amount field from transactions

### DIFF
--- a/src/adapters/financialTransaction.adapter.ts
+++ b/src/adapters/financialTransaction.adapter.ts
@@ -22,7 +22,6 @@ export class FinancialTransactionAdapter
   protected defaultSelect = `
     id,
     type,
-    amount,
     description,
     date,
     budget_id,

--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -247,7 +247,6 @@ export class FinancialTransactionHeaderAdapter
         `
         id,
         type,
-        amount,
         description,
         date,
         debit,

--- a/src/models/financialTransaction.model.ts
+++ b/src/models/financialTransaction.model.ts
@@ -8,7 +8,6 @@ export type TransactionType = 'income' | 'expense';
 export interface FinancialTransaction extends BaseModel {
   id: string;
   type: TransactionType | null;
-  amount: number | null;
   description: string;
   date: string;
   budget_id: string | null;

--- a/src/pages/accounts/account/AccountProfile.tsx
+++ b/src/pages/accounts/account/AccountProfile.tsx
@@ -84,7 +84,8 @@ function AccountProfile() {
         .select(`
           id,
           type,
-          amount,
+          debit,
+          credit,
           date,
           description,
           category:category_id (name),
@@ -464,10 +465,10 @@ function AccountProfile() {
                             {transaction.description}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-medium">
-                            <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
+                          <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
                               {transaction.type === 'income' ? '+' : '-'}
-                              ${transaction.amount.toFixed(2)}
-                            </span>
+                              ${(transaction.debit - transaction.credit).toFixed(2)}
+                          </span>
                           </td>
                         </tr>
                       ))}

--- a/src/pages/accounts/financial-sources/FinancialSourceProfile.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceProfile.tsx
@@ -58,7 +58,8 @@ function FinancialSourceProfile() {
         .select(`
           id,
           type,
-          amount,
+          debit,
+          credit,
           date,
           description,
           category:category_id (name),
@@ -350,7 +351,7 @@ function FinancialSourceProfile() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-medium">
                           <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
                             {transaction.type === 'income' ? '+' : '-'}
-                            ${transaction.amount.toFixed(2)}
+                            ${(transaction.debit - transaction.credit).toFixed(2)}
                           </span>
                         </td>
                       </tr>

--- a/src/pages/finances/budgets/BudgetList.tsx
+++ b/src/pages/finances/budgets/BudgetList.tsx
@@ -95,13 +95,17 @@ function BudgetList() {
         (budgets || []).map(async (budget) => {
           const { data: transactions, error: transactionsError } = await supabase
             .from('financial_transactions')
-            .select('amount')
+            .select('debit, credit')
             .eq('budget_id', budget.id)
             .eq('type', 'expense');
 
           if (transactionsError) throw transactionsError;
 
-          const used_amount = transactions?.reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+          const used_amount =
+            transactions?.reduce(
+              (sum, t) => sum + Number(t.debit || 0) - Number(t.credit || 0),
+              0
+            ) || 0;
           const transaction_count = transactions?.length || 0;
 
           return {

--- a/src/pages/finances/budgets/BudgetProfile.tsx
+++ b/src/pages/finances/budgets/BudgetProfile.tsx
@@ -39,7 +39,8 @@ type Transaction = {
   id: string;
   type: 'income' | 'expense';
   category_id: string;
-  amount: number;
+  debit: number;
+  credit: number;
   description: string;
   date: string;
   member?: {
@@ -98,7 +99,13 @@ function BudgetProfile() {
       const { data, error } = await supabase
         .from('financial_transactions')
         .select(`
-          *,
+          id,
+          type,
+          category_id,
+          debit,
+          credit,
+          description,
+          date,
           member:member_id (
             first_name,
             last_name
@@ -136,7 +143,11 @@ function BudgetProfile() {
     return matchesSearch && matchesType && matchesCategory;
   });
 
-  const totalExpenses = transactions?.reduce((sum, t) => sum + Number(t.amount), 0) || 0;
+  const totalExpenses =
+    transactions?.reduce(
+      (sum, t) => sum + Number(t.debit || 0) - Number(t.credit || 0),
+      0
+    ) || 0;
   const remainingBudget = budget ? budget.amount - totalExpenses : 0;
   const usagePercentage = budget ? (totalExpenses / budget.amount) * 100 : 0;
 
@@ -332,7 +343,7 @@ function BudgetProfile() {
                             : 'text-destructive'
                         }
                       >
-                        {formatCurrency(transaction.amount, currency)}
+                        {formatCurrency(transaction.debit - transaction.credit, currency)}
                       </span>
                     </td>
                   </tr>

--- a/src/pages/finances/funds/FundProfile.tsx
+++ b/src/pages/finances/funds/FundProfile.tsx
@@ -56,7 +56,8 @@ function FundProfile() {
         .select(`
           id,
           type,
-          amount,
+          debit,
+          credit,
           date,
           description,
           category:category_id (name)
@@ -257,9 +258,9 @@ function FundProfile() {
                           </td>
                           <td className="px-6 py-4 text-sm text-foreground">{transaction.description}</td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-medium">
-                            <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
-                              {transaction.type === 'income' ? '+' : '-'}${transaction.amount.toFixed(2)}
-                            </span>
+                          <span className={transaction.type === 'income' ? 'text-success' : 'text-destructive'}>
+                              {transaction.type === 'income' ? '+' : '-'}${(transaction.debit - transaction.credit).toFixed(2)}
+                          </span>
                           </td>
                         </tr>
                       ))}

--- a/tests/postedHeaderBalance.test.ts
+++ b/tests/postedHeaderBalance.test.ts
@@ -3,10 +3,10 @@ import { isTransactionsBalanced } from '../src/utils/accounting';
 
 describe('posted transaction headers', () => {
   const sample = [
-    { header_id: 'h1', debit: 100, credit: 0, fund_id: 'f1', batch_id: 'b1', amount: 100 },
-    { header_id: 'h1', debit: 0, credit: 100, fund_id: 'f1', batch_id: 'b1', amount: -100 },
-    { header_id: 'h2', debit: 50, credit: 0, fund_id: 'f2', batch_id: 'b2', amount: 50 },
-    { header_id: 'h2', debit: 0, credit: 50, fund_id: 'f2', batch_id: 'b2', amount: -50 }
+    { header_id: 'h1', debit: 100, credit: 0, fund_id: 'f1', batch_id: 'b1' },
+    { header_id: 'h1', debit: 0, credit: 100, fund_id: 'f1', batch_id: 'b1' },
+    { header_id: 'h2', debit: 50, credit: 0, fund_id: 'f2', batch_id: 'b2' },
+    { header_id: 'h2', debit: 0, credit: 50, fund_id: 'f2', batch_id: 'b2' }
   ];
 
   it('ensures each posted header is balanced', () => {
@@ -28,7 +28,8 @@ describe('posted transaction headers', () => {
   it('aggregates totals by batch after migration', () => {
     const batchTotals: Record<string, number> = {};
     for (const t of sample) {
-      batchTotals[t.batch_id] = (batchTotals[t.batch_id] ?? 0) + (t.amount ?? 0);
+      batchTotals[t.batch_id] =
+        (batchTotals[t.batch_id] ?? 0) + (t.debit || 0) - (t.credit || 0);
     }
     expect(batchTotals['b1']).toBe(0);
     expect(batchTotals['b2']).toBe(0);


### PR DESCRIPTION
## Summary
- drop `amount` from `FinancialTransaction` model
- update adapters and queries to select `debit`/`credit`
- refactor pages and tests to derive amounts from debit/credit

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5544706c83268c80a160aab006c7