### PR TITLE
Add code to Fund model

### DIFF
--- a/src/adapters/fund.adapter.ts
+++ b/src/adapters/fund.adapter.ts
@@ -20,6 +20,7 @@ export class FundAdapter
 
   protected defaultSelect = `
     id,
+    code,
     name,
     description,
     type,

--- a/src/adapters/incomeExpenseTransaction.adapter.ts
+++ b/src/adapters/incomeExpenseTransaction.adapter.ts
@@ -39,7 +39,7 @@ export class IncomeExpenseTransactionAdapter
   protected defaultRelationships: QueryOptions['relationships'] = [
     { table: 'members', foreignKey: 'member_id', select: ['id','first_name','last_name','email'] },
     { table: 'categories', foreignKey: 'category_id', select: ['id','code','name'] },
-    { table: 'funds', foreignKey: 'fund_id', select: ['id','name','type'] },
+    { table: 'funds', foreignKey: 'fund_id', select: ['id','code','name','type'] },
     { table: 'financial_sources', foreignKey: 'source_id', select: ['id','name','source_type'] },
     { table: 'accounts', foreignKey: 'account_id', select: ['id','name'] }
   ];

--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -4,6 +4,7 @@ export type FundType = 'restricted' | 'unrestricted';
 
 export interface Fund extends BaseModel {
   id: string;
+  code: string;
   name: string;
   description: string | null;
   type: FundType;


### PR DESCRIPTION
## Summary
- extend `Fund` model with `code` field
- return fund `code` from default select in `FundAdapter`
- expose fund `code` through income/expense transaction relationships

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.app.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e560389448326818dcbbb1bedd191