### PR TITLE
Update fund code formatting and validation

### DIFF
--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -4,6 +4,7 @@ export type FundType = 'restricted' | 'unrestricted';
 
 export interface Fund extends BaseModel {
   id: string;
+  code: string;
   name: string;
   description: string | null;
   type: FundType;

--- a/src/repositories/fund.repository.ts
+++ b/src/repositories/fund.repository.ts
@@ -37,6 +37,7 @@ export class FundRepository
   private formatFundData(data: Partial<Fund>): Partial<Fund> {
     return {
       ...data,
+      code: data.code?.trim().toUpperCase(),
       name: data.name?.trim(),
       description: data.description?.trim(),
     };

--- a/src/validators/fund.validator.ts
+++ b/src/validators/fund.validator.ts
@@ -6,6 +6,16 @@ export class FundValidator {
       throw new Error('Fund name is required');
     }
 
+    if (data.code !== undefined) {
+      const trimmed = data.code.trim();
+      if (!trimmed) {
+        throw new Error('Fund code is required');
+      }
+      if (!/^[A-Z0-9_]+$/.test(trimmed)) {
+        throw new Error('Invalid fund code. Only A-Z, 0-9 and _ allowed');
+      }
+    }
+
     if (data.type !== undefined) {
       const validTypes: Fund['type'][] = ['restricted', 'unrestricted'];
       if (!validTypes.includes(data.type)) {

--- a/tests/fundRepositoryValidation.test.ts
+++ b/tests/fundRepositoryValidation.test.ts
@@ -27,9 +27,16 @@ describe('FundRepository validation', () => {
 
   it('formats data on create', async () => {
     const repo = new TestFundRepository({} as IFundAdapter);
-    const data = await repo.runBeforeCreate({ name: '  My Fund ', description: '  Desc  ', type: 'restricted' });
+    const data = await repo.runBeforeCreate({ code: ' gf ', name: '  My Fund ', description: '  Desc  ', type: 'restricted' });
+    expect(data.code).toBe('GF');
     expect(data.name).toBe('My Fund');
     expect(data.description).toBe('Desc');
+  });
+
+  it('throws error for invalid fund code', async () => {
+    const repo = new TestFundRepository({} as IFundAdapter);
+    await expect(repo.runBeforeCreate({ code: '  ', name: 'Test' })).rejects.toThrow('Fund code is required');
+    await expect(repo.runBeforeCreate({ code: 'abc', name: 'Test' })).rejects.toThrow('Invalid fund code');
   });
 
   it('validates on update', async () => {


### PR DESCRIPTION
## Summary
- trim and uppercase Fund code when saving
- validate new `code` field for funds
- include `code` property in model
- extend tests for fund code validation and formatting

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e560e91a48326b46b43737bcecf2d