### PR TITLE
Include fund code in queries

### DIFF
--- a/src/adapters/fund.adapter.ts
+++ b/src/adapters/fund.adapter.ts
@@ -20,6 +20,7 @@ export class FundAdapter
 
   protected defaultSelect = `
     id,
+    code,
     name,
     description,
     type,

--- a/src/models/fund.model.ts
+++ b/src/models/fund.model.ts
@@ -4,6 +4,7 @@ export type FundType = 'restricted' | 'unrestricted';
 
 export interface Fund extends BaseModel {
   id: string;
+  code: string | null;
   name: string;
   description: string | null;
   type: FundType;


### PR DESCRIPTION
## Summary
- expose `code` field when selecting funds
- extend Fund model with `code`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e560c54a48326b56c8155ec8869ee