### PR TITLE
Add fund code display across fund pages

### DIFF
--- a/src/pages/finances/funds/FundAddEdit.tsx
+++ b/src/pages/finances/funds/FundAddEdit.tsx
@@ -9,7 +9,7 @@ import { Button } from '../../../components/ui2/button';
 import BackButton from '../../../components/BackButton';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../../components/ui2/select';
 
-import { Save, Loader2, AlertCircle } from 'lucide-react';
+import { Save, Loader2, AlertCircle, Hash } from 'lucide-react';
 
 function FundAddEdit() {
   const { id } = useParams<{ id: string }>();
@@ -19,6 +19,7 @@ function FundAddEdit() {
   const { useQuery: useFundQuery, useCreate, useUpdate } = useFundRepository();
 
   const [formData, setFormData] = useState<Partial<Fund>>({
+    code: '',
     name: '',
     description: '',
     type: 'unrestricted',
@@ -46,6 +47,11 @@ function FundAddEdit() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    if (!formData.code?.trim()) {
+      setError('Fund code is required');
+      return;
+    }
 
     if (!formData.name?.trim()) {
       setError('Fund name is required');
@@ -91,7 +97,17 @@ function FundAddEdit() {
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="sm:col-span-2">
+              <div>
+                <Input
+                  label="Code"
+                  required
+                  value={formData.code || ''}
+                  onChange={(e) => handleInputChange('code', e.target.value)}
+                  placeholder="Enter fund code"
+                  icon={<Hash className="h-4 w-4" />}
+                />
+              </div>
+              <div>
                 <Input
                   label="Fund Name"
                   required

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -28,6 +28,7 @@ function FundList() {
   const filteredFunds = funds.filter((fund: Fund) => {
     const search = searchTerm.toLowerCase();
     const matchesSearch =
+      fund.code.toLowerCase().includes(search) ||
       fund.name.toLowerCase().includes(search) ||
       (fund.description ? fund.description.toLowerCase().includes(search) : false);
     const matchesType = typeFilter === 'all' || fund.type === typeFilter;
@@ -35,6 +36,12 @@ function FundList() {
   });
 
   const columns: GridColDef[] = [
+    {
+      field: 'code',
+      headerName: 'Code',
+      flex: 1,
+      minWidth: 100,
+    },
     {
       field: 'name',
       headerName: 'Fund Name',

--- a/src/pages/finances/funds/FundProfile.tsx
+++ b/src/pages/finances/funds/FundProfile.tsx
@@ -186,6 +186,10 @@ function FundProfile() {
             <CardContent className="pt-0">
               <dl className="divide-y divide-border">
                 <div className="py-3 grid grid-cols-3 gap-4">
+                  <dt className="text-sm font-medium text-muted-foreground">Code</dt>
+                  <dd className="text-sm text-foreground col-span-2">{fund.code}</dd>
+                </div>
+                <div className="py-3 grid grid-cols-3 gap-4">
                   <dt className="text-sm font-medium text-muted-foreground">Name</dt>
                   <dd className="text-sm text-foreground col-span-2">{fund.name}</dd>
                 </div>


### PR DESCRIPTION
## Summary
- show code column in FundList and include it in search filter
- add code field to FundAddEdit form with validation
- display code in FundProfile details

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5ccebca88326945b51e45de47fb1