### PR TITLE
Restrict supabase views by tenant

### DIFF
--- a/supabase/migrations/20250705000000_emerald_forest.sql
+++ b/supabase/migrations/20250705000000_emerald_forest.sql
@@ -23,6 +23,9 @@ SELECT
     2
   ) AS percentage_change
 FROM monthly
+WHERE tenant_id = (
+  SELECT tenant_id FROM tenant_users WHERE user_id = auth.uid()
+)
 ORDER BY month;
 
 COMMENT ON VIEW finance_monthly_trends IS 'Monthly income and expense totals with percentage change from the previous month for each tenant';

--- a/supabase/migrations/20250706000000_update_double_entry_functions.sql
+++ b/supabase/migrations/20250706000000_update_double_entry_functions.sql
@@ -141,6 +141,9 @@ SELECT
   jsonb_object_agg(category_name, total) FILTER (WHERE type = 'income') AS income_by_category,
   jsonb_object_agg(category_name, total) FILTER (WHERE type = 'expense') AS expenses_by_category
 FROM tx
+WHERE tenant_id = (
+  SELECT tenant_id FROM tenant_users WHERE user_id = auth.uid()
+)
 GROUP BY tenant_id;
 
 COMMENT ON VIEW finance_monthly_stats IS 'Aggregated financial statistics for the current month per tenant';
@@ -163,6 +166,9 @@ SELECT
   ) AS balance
 FROM funds f
 LEFT JOIN financial_transactions t ON t.fund_id = f.id
+WHERE f.tenant_id = (
+  SELECT tenant_id FROM tenant_users WHERE user_id = auth.uid()
+)
 GROUP BY f.tenant_id, f.id, f.name;
 
 COMMENT ON VIEW fund_balances_view IS 'Current running balance for each fund';


### PR DESCRIPTION
## Summary
- update finance dashboard views to filter by tenant
- update emerald_forest migration for tenant filtering
- update double entry function views to filter by tenant
- add migration restricting finance views

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685e5e2db38c8326b2afa75f3b553419