### PR TITLE
Fix footer alignment with sidebar collapse

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { Heart, FileText, Shield } from 'lucide-react';
 import { Modal } from './ui2/modal';
 
-function Footer() {
+interface FooterProps {
+  sidebarCollapsed: boolean;
+}
+
+function Footer({ sidebarCollapsed }: FooterProps) {
   const [showPrivacyModal, setShowPrivacyModal] = useState(false);
   const [showTermsModal, setShowTermsModal] = useState(false);
 
@@ -11,7 +15,9 @@ function Footer() {
 
   return (
     <>
-      <footer className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 py-4 px-6 lg:pl-64">
+      <footer
+        className={`fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 py-4 px-6 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+      >
         <div className="max-w-7xl mx-auto flex items-center justify-between flex-wrap space-y-2 sm:space-y-0">
           <div className="flex items-center space-x-4">
             <p className="text-gray-600 dark:text-gray-300 text-sm">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -44,7 +44,7 @@ function Layout() {
         </main>
 
         {/* Footer */}
-        <Footer />
+        <Footer sidebarCollapsed={sidebarCollapsed} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- pass sidebar collapsed state into Footer
- adjust Footer left padding when sidebar is collapsed

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ec66d51c48326b137f229df75ff49