### PR TITLE
Prevent horizontal scrollbars in layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,7 +14,7 @@ function Layout() {
   const isSettingsPage = location.pathname.startsWith('/settings');
 
   return (
-    <div className="min-h-screen flex bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen w-screen flex bg-gray-100 dark:bg-gray-900 overflow-x-hidden">
       {/* Sidebar */}
       <Sidebar
         sidebarOpen={sidebarOpen}
@@ -27,13 +27,13 @@ function Layout() {
 
       {/* Main content wrapper */}
       <div
-        className={`flex-1 flex flex-col min-h-screen pb-24 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+        className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
       >
         {/* Top navigation */}
         <Topbar setSidebarOpen={setSidebarOpen} />
 
         {/* Main content */}
-        <main className={`flex-1 ${isSettingsPage ? '' : 'bg-white dark:bg-gray-800'}`}>
+        <main className={`flex-1 w-full ${isSettingsPage ? '' : 'bg-white dark:bg-gray-800'}`}>
           {isSettingsPage ? (
             <Outlet />
           ) : (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,7 +14,7 @@
 
 @layer base {
   body {
-    @apply font-sans;
+    @apply font-sans overflow-x-hidden;
   }
 
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Summary
- hide horizontal overflow on the body in global styles
- ensure layout containers always use the full viewport width without horizontal scroll

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecb1b93e883268ec71cf425e6affd