### PR TITLE
Fix sidebar pin toggle for mobile

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -302,7 +302,7 @@ function Sidebar({
               alt="StewardTrack Logo"
               className="h-8"
             />
-            <div className="flex items-center space-x-1">
+            <div className="hidden lg:flex items-center space-x-1">
               <Button
                 variant="ghost"
                 size="icon"


### PR DESCRIPTION
## Summary
- show the pin toggle only on large screens so mobile users don't see a collapsed sidebar control that has no effect

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ee5f17b808326a847abfed86333a2