### PR TITLE
Fix topbar branding layout

### DIFF
--- a/src/components/ChurchBranding.tsx
+++ b/src/components/ChurchBranding.tsx
@@ -50,7 +50,7 @@ function ChurchBranding() {
           <Building2 className="h-5 w-5 text-primary-600" />
         </div>
       )}
-      <div className="ml-2 min-w-0">
+      <div className="ml-2 min-w-0 hidden lg:block">
         <h1 
           ref={nameRef}
           className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate group relative"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,7 +30,10 @@ function Layout() {
         className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 pt-16 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
       >
         {/* Top navigation */}
-        <Topbar setSidebarOpen={setSidebarOpen} />
+        <Topbar
+          setSidebarOpen={setSidebarOpen}
+          sidebarCollapsed={sidebarCollapsed}
+        />
 
         {/* Main content */}
         <main className={`flex-1 w-full ${isSettingsPage ? '' : 'bg-white dark:bg-gray-800'}`}>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Menu, AlignJustify, Bell, User } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { Button } from '../ui2/button';
 import { Avatar, AvatarImage, AvatarFallback } from '../ui2/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '../ui2/dropdown-menu';
@@ -12,9 +12,10 @@ import NotificationDropdown from './NotificationDropdown';
 
 interface TopbarProps {
   setSidebarOpen: (open: boolean) => void;
+  sidebarCollapsed: boolean;
 }
 
-function Topbar({ setSidebarOpen }: TopbarProps) {
+function Topbar({ setSidebarOpen, sidebarCollapsed }: TopbarProps) {
   const { user, signOut } = useAuthStore();
   const navigate = useNavigate();
   const { settings, handleThemeToggle } = useThemeSwitcher();
@@ -25,7 +26,9 @@ function Topbar({ setSidebarOpen }: TopbarProps) {
   };
 
   return (
-    <header className="fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
+    <header
+      className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+    >
       {/* Sidebar toggle, only on mobile */}
       <button
         type="button"


### PR DESCRIPTION
## Summary
- hide church name on small screens
- align topbar with sidebar state

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eff1b57948326bf40e1fa921b1f3d