### PR TITLE
Wrap DataGrid theme in useMemo

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -162,18 +162,23 @@ export function DataGrid({
 }: DataGridProps) {
   const theme = useTheme();
 
-  // Create a custom theme that inherits from the current theme
-  const customTheme = createTheme(theme, {
-    components: {
-      MuiDataGrid: {
-        styleOverrides: {
-          root: {
-            border: 'none',
+  // Create a custom theme that inherits from the current theme.
+  // Memoize the theme to avoid unnecessary recalculations.
+  const customTheme = React.useMemo(
+    () =>
+      createTheme(theme, {
+        components: {
+          MuiDataGrid: {
+            styleOverrides: {
+              root: {
+                border: 'none',
+              },
+            },
           },
         },
-      },
-    },
-  });
+      }),
+    [theme]
+  );
 
   // Handle pagination changes
   const handlePaginationModelChange = (model: GridPaginationModel) => {


### PR DESCRIPTION
## Summary
- memoize DataGrid theme so it only recalculates when the base theme changes

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f06b726688326bca2d53d9cfda18e