### PR TITLE
Add custom DataGrid error overlay

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -6,6 +6,7 @@ import {
   GridPaginationModel,
   GridSortModel,
   GridToolbar,
+  GridOverlay,
 } from '@mui/x-data-grid';
 import { styled } from '@mui/material/styles';
 import { useTheme } from '@mui/material/styles';
@@ -145,6 +146,16 @@ const StyledDataGrid = styled(MuiDataGrid)(({ theme }) => ({
   },
 }));
 
+function ErrorOverlay({ message }: { message?: string }) {
+  return (
+    <GridOverlay>
+      <div className="p-4 text-destructive text-sm text-center w-full">
+        {message || 'An error occurred while loading data.'}
+      </div>
+    </GridOverlay>
+  );
+}
+
 export function DataGrid({
   data = [],
   totalRows = 0,
@@ -195,14 +206,17 @@ export function DataGrid({
         disableColumnFilter={false}
         disableColumnSelector={false}
         disableDensitySelector={false}
+        error={!!error}
         slots={{
           toolbar: GridToolbar,
+          ...(error ? { errorOverlay: ErrorOverlay } : {}),
         }}
         slotProps={{
           toolbar: {
             showQuickFilter: true,
             quickFilterProps: { debounceMs: 500 },
           },
+          ...(error ? { errorOverlay: { message: error } } : {}),
         }}
         onPaginationModelChange={handlePaginationModelChange}
         onSortModelChange={onSortChange}

--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -32,7 +32,7 @@ function AccountList() {
   const { useQuery: useAccountsQuery } = useAccountRepository();
   
   // Get accounts
-  const { data: result, isLoading } = useAccountsQuery();
+  const { data: result, isLoading, error } = useAccountsQuery();
   const accounts = result?.data || [];
   
   // Filter accounts
@@ -235,6 +235,7 @@ function AccountList() {
                 data={filteredAccounts}
                 totalRows={filteredAccounts.length}
                 loading={isLoading}
+                error={error instanceof Error ? error.message : undefined}
                 onPageChange={handlePageChange}
                 onPageSizeChange={handlePageSizeChange}
                 getRowId={(row) => row.id}

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
@@ -59,7 +59,11 @@ function ChartOfAccountProfile() {
   
   // Get account details
   const { useQuery, useDelete } = useChartOfAccountRepository();
-  const { data: accountData, isLoading: isAccountLoading } = useQuery({
+  const {
+    data: accountData,
+    isLoading: isAccountLoading,
+    error: accountError,
+  } = useQuery({
     filters: {
       id: {
         operator: 'eq',
@@ -80,13 +84,21 @@ function ChartOfAccountProfile() {
   
   // Get account balance
   const { useAccountBalance, useAccountTransactions } = useAccountingReports();
-  const { data: balance, isLoading: isBalanceLoading } = useAccountBalance(
+  const {
+    data: balance,
+    isLoading: isBalanceLoading,
+    error: balanceError,
+  } = useAccountBalance(
     id || '', 
     dateRange.to.toISOString().split('T')[0]
   );
   
   // Get account transactions
-  const { data: transactions, isLoading: isTransactionsLoading } = useAccountTransactions(
+  const {
+    data: transactions,
+    isLoading: isTransactionsLoading,
+    error: transactionsError,
+  } = useAccountTransactions(
     id || '',
     dateRange.from.toISOString().split('T')[0],
     dateRange.to.toISOString().split('T')[0]
@@ -535,6 +547,11 @@ function ChartOfAccountProfile() {
             columns={columns}
             data={transactionRows}
             loading={isTransactionsLoading}
+            error={
+              transactionsError instanceof Error
+                ? transactionsError.message
+                : undefined
+            }
             totalRows={transactionRows.length}
             autoHeight
             getRowId={(row) => row.id}

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -22,7 +22,7 @@ function FinancialSourceList() {
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
   
   // Get sources
-  const { data: result, isLoading } = useSourcesQuery();
+  const { data: result, isLoading, error } = useSourcesQuery();
   const sources = result?.data || [];
   
   // Filter sources
@@ -217,6 +217,7 @@ function FinancialSourceList() {
                 data={filteredSources}
                 totalRows={filteredSources.length}
                 loading={isLoading}
+                error={error instanceof Error ? error.message : undefined}
                 onPageChange={handlePageChange}
                 onPageSizeChange={handlePageSizeChange}
                 getRowId={(row) => row.id}

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -20,7 +20,7 @@ function FundList() {
 
   const { useQuery: useFundsQuery } = useFundRepository();
 
-  const { data: result, isLoading } = useFundsQuery({
+  const { data: result, isLoading, error } = useFundsQuery({
     pagination: { page: page + 1, pageSize },
   });
   const funds = result?.data || [];
@@ -131,6 +131,7 @@ function FundList() {
                 data={filteredFunds}
                 totalRows={filteredFunds.length}
                 loading={isLoading}
+                error={error instanceof Error ? error.message : undefined}
                 onPageChange={handlePageChange}
                 onPageSizeChange={handlePageSizeChange}
                 onRowClick={handleRowClick}

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -19,7 +19,11 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
   const { useQuery: useEntryQuery } = useIncomeExpenseTransactionRepository();
   const { useQuery: useHeaderQuery } = useFinancialTransactionHeaderRepository();
 
-  const { data: entryResult, isLoading: entriesLoading } = useEntryQuery({
+  const {
+    data: entryResult,
+    isLoading: entriesLoading,
+    error: entriesError,
+  } = useEntryQuery({
     filters: { transaction_type: { operator: 'eq', value: transactionType } },
   });
 
@@ -35,7 +39,11 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
     [entryResult]
   );
 
-  const { data: headerResult, isLoading: headerLoading } = useHeaderQuery({
+  const {
+    data: headerResult,
+    isLoading: headerLoading,
+    error: headerError,
+  } = useHeaderQuery({
     filters: { id: { operator: 'isAnyOf', value: headerIds } },
     order: { column: 'transaction_date', ascending: false },
     enabled: headerIds.length > 0,
@@ -80,6 +88,13 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
               data={headers}
               totalRows={headers.length}
               loading={isLoading}
+              error={
+                entriesError instanceof Error
+                  ? entriesError.message
+                  : headerError instanceof Error
+                    ? headerError.message
+                    : undefined
+              }
               onPageChange={setPage}
               onPageSizeChange={setPageSize}
               getRowId={(row) => row.id}

--- a/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
@@ -18,7 +18,11 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
   const navigate = useNavigate();
   const { useQuery } = useFinancialTransactionHeaderRepository();
   const { getByHeaderId } = useIncomeExpenseTransactionRepository();
-  const { data: headerData, isLoading: headerLoading } = useQuery({
+  const {
+    data: headerData,
+    isLoading: headerLoading,
+    error: headerError,
+  } = useQuery({
     filters: { id: { operator: 'eq', value: id } },
     enabled: !!id,
   });
@@ -26,13 +30,22 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
 
   const [entries, setEntries] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [entriesError, setEntriesError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadEntries = async () => {
       if (id) {
-        const data = await getByHeaderId(id);
-        setEntries(data || []);
-        setLoading(false);
+        try {
+          const data = await getByHeaderId(id);
+          setEntries(data || []);
+        } catch (err) {
+          console.error('Error loading entries:', err);
+          setEntriesError(
+            err instanceof Error ? err.message : 'Failed to load entries'
+          );
+        } finally {
+          setLoading(false);
+        }
       }
     };
     loadEntries();
@@ -124,6 +137,9 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
             data={entries}
             totalRows={entries.length}
             loading={loading}
+            error={
+              entriesError ?? (headerError instanceof Error ? headerError.message : undefined)
+            }
             autoHeight
           />
         </CardContent>

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -90,7 +90,7 @@ function TransactionList() {
   const updateMutation = useUpdate();
   const { hasPermission } = usePermissions();
   
-  const { data: result, isLoading } = useQuery({
+  const { data: result, isLoading, error } = useQuery({
     filters: {
       transaction_date: {
         operator: 'between',
@@ -475,6 +475,7 @@ function TransactionList() {
             data={filteredTransactions}
             totalRows={filteredTransactions.length}
             loading={isLoading}
+            error={error instanceof Error ? error.message : undefined}
             onPageChange={setPage}
             onPageSizeChange={setPageSize}
             getRowId={(row) => row.id}

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -40,7 +40,7 @@ function MemberList() {
   const { useQuery, useDelete } = useMemberRepository();
 
   // Get members with repository
-  const { data: result, isLoading } = useQuery({
+  const { data: result, isLoading, error } = useQuery({
     pagination: {
       page: page + 1, // MUI Data Grid uses 0-based pages
       pageSize,
@@ -226,6 +226,7 @@ function MemberList() {
             columns={columns}
             totalRows={result?.count || 0}
             loading={isLoading}
+            error={error instanceof Error ? error.message : undefined}
             onPageChange={setPage}
             onPageSizeChange={setPageSize}
             onSortChange={setSortModel}


### PR DESCRIPTION
## Summary
- create reusable `ErrorOverlay` slot for the MUI DataGrid wrapper
- forward the `error` prop so DataGrid shows the overlay
- surface data fetch errors in pages that use `DataGrid`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685f06b3a18083268f6c22a49039f61f