### PR TITLE
Add generics to MUI DataGrid

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -13,8 +13,8 @@ import { useTheme } from '@mui/material/styles';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 
 // Extend the MUI DataGrid props to include our custom props
-export interface DataGridProps extends Omit<MuiDataGridProps, 'rows'> {
-  data?: any[];
+export interface DataGridProps<T> extends Omit<MuiDataGridProps<T>, 'rows'> {
+  data?: T[];
   totalRows?: number;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
@@ -156,7 +156,7 @@ function ErrorOverlay({ message }: { message?: string }) {
   );
 }
 
-export function DataGrid({
+export function DataGrid<T>({
   data = [],
   totalRows = 0,
   onPageChange,
@@ -170,7 +170,7 @@ export function DataGrid({
   error,
   columns,
   ...props
-}: DataGridProps) {
+}: DataGridProps<T>) {
   const theme = useTheme();
 
   // Create a custom theme that inherits from the current theme.

--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -230,7 +230,7 @@ function AccountList() {
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : (
-              <DataGrid
+              <DataGrid<Account>
                 columns={columns}
                 data={filteredAccounts}
                 totalRows={filteredAccounts.length}

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
@@ -8,6 +8,7 @@ import BackButton from '../../../components/BackButton';
 import { Badge } from '../../../components/ui2/badge';
 import { DateRangePickerField } from '../../../components/ui2/date-range-picker-field';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { FinancialTransaction } from '../../../models/financialTransaction.model';
 import { 
   AlertDialog,
   AlertDialogAction,
@@ -543,7 +544,7 @@ function ChartOfAccountProfile() {
         </CardHeader>
         
         <CardContent>
-          <DataGrid
+          <DataGrid<FinancialTransaction>
             columns={columns}
             data={transactionRows}
             loading={isTransactionsLoading}

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -212,7 +212,7 @@ function FinancialSourceList() {
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : (
-              <DataGrid
+              <DataGrid<FinancialSource>
                 columns={columns}
                 data={filteredSources}
                 totalRows={filteredSources.length}

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -126,7 +126,7 @@ function FundList() {
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : (
-              <DataGrid
+              <DataGrid<Fund>
                 columns={columns}
                 data={filteredFunds}
                 totalRows={filteredFunds.length}

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -5,6 +5,7 @@ import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeE
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { FinancialTransactionHeader } from '../../../models/financialTransactionHeader.model';
 import { GridColDef } from '@mui/x-data-grid';
 import { Plus } from 'lucide-react';
 
@@ -83,7 +84,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
       <div className="mt-6">
         <Card className="dark:bg-slate-800">
           <CardContent className="p-0">
-            <DataGrid
+            <DataGrid<FinancialTransactionHeader>
               columns={columns}
               data={headers}
               totalRows={headers.length}

--- a/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
@@ -5,6 +5,7 @@ import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeE
 import { Card, CardContent, CardHeader } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { IncomeExpenseTransaction } from '../../../models/incomeExpenseTransaction.model';
 import { GridColDef } from '@mui/x-data-grid';
 import { Loader2, Edit } from 'lucide-react';
 import BackButton from '../../../components/BackButton';
@@ -132,7 +133,7 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
           <h3 className="text-lg font-medium">Entries</h3>
         </CardHeader>
         <CardContent className="p-0">
-          <DataGrid
+          <DataGrid<IncomeExpenseTransaction>
             columns={columns}
             data={entries}
             totalRows={entries.length}

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -9,6 +9,7 @@ import { Input } from '../../../components/ui2/input';
 import { DateRangePickerField } from '../../../components/ui2/date-range-picker-field';
 import { Badge } from '../../../components/ui2/badge';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import { FinancialTransactionHeader } from '../../../models/financialTransactionHeader.model';
 import { 
   Plus, 
   Search, 
@@ -470,7 +471,7 @@ function TransactionList() {
           </CardHeader>
           
           <CardContent className="p-0">
-          <DataGrid
+          <DataGrid<FinancialTransactionHeader>
             columns={columns}
             data={filteredTransactions}
             totalRows={filteredTransactions.length}

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { GridColDef, GridValueGetterParams, GridFilterModel, GridSortModel } from '@mui/x-data-grid';
 import { useMemberRepository } from '../../hooks/useMemberRepository';
+import { Member } from '../../models/member.model';
 import { SubscriptionGate } from '../../components/SubscriptionGate';
 import { DataGrid } from '../../components/ui2/mui-datagrid';
 import { Button } from '../../components/ui2/button';
@@ -221,7 +222,7 @@ function MemberList() {
 
       <Card className="mt-6">
         <div style={{ height: 600, width: '100%' }}>
-          <DataGrid
+          <DataGrid<Member>
             data={result?.data || []}
             columns={columns}
             totalRows={result?.count || 0}


### PR DESCRIPTION
## Summary
- make `DataGridProps` generic
- type the `DataGrid` component with generics
- specify row types when using `<DataGrid>`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f084f908c8326bb74e68765e1e478