### PR TITLE
Add useEffect to validate datagrid page

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -191,6 +191,11 @@ export function DataGrid({
     [theme]
   );
 
+  React.useEffect(() => {
+    const lastPage = Math.max(0, Math.ceil(totalRows / pageSize) - 1);
+    if (page > lastPage) onPageChange?.(lastPage);
+  }, [totalRows, pageSize, page]);
+
   // Handle pagination changes
   const handlePaginationModelChange = (model: GridPaginationModel) => {
     onPageChange?.(model.page);


### PR DESCRIPTION
## Summary
- ensure DataGrid doesn't exceed last page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f099e2db083269d8709e22ae22964