### PR TITLE
Implement server-side fund list filtering

### DIFF
--- a/src/adapters/base.adapter.ts
+++ b/src/adapters/base.adapter.ts
@@ -112,13 +112,29 @@ export class BaseAdapter<T extends BaseModel> {
       }
     };
 
-    if (Array.isArray(filter)) {
-      return query.or(
-        filter.map(f => `${key}.${f.operator}.${f.value}`).join(',')
-      );
-    } else {
-      return applyFilter(filter.operator, filter.value, filter.valueTo);
+    if (key === 'or') {
+      if (Array.isArray(filter)) {
+        return query.or(
+          filter
+            .map(f =>
+              f.field
+                ? `${f.field}.${f.operator}.${f.value}`
+                : `${key}.${f.operator}.${f.value}`
+            )
+            .join(',')
+        );
+      } else if (typeof filter === 'string') {
+        return query.or(filter);
+      } else if (filter?.field) {
+        return query.or(`${filter.field}.${filter.operator}.${filter.value}`);
+      }
     }
+
+    if (Array.isArray(filter)) {
+      return query.or(filter.map(f => `${key}.${f.operator}.${f.value}`).join(','));
+    }
+
+    return applyFilter(filter.operator, filter.value, filter.valueTo);
   }
 
   protected buildRelationshipQuery(relationships: QueryOptions['relationships'] = []): string {

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -22,18 +22,23 @@ function FundList() {
 
   const { data: result, isLoading, error } = useFundsQuery({
     pagination: { page: page + 1, pageSize },
+    filters: {
+      ...(searchTerm
+        ? {
+            or: [
+              { field: 'code', operator: 'ilike', value: `%${searchTerm}%` },
+              { field: 'name', operator: 'ilike', value: `%${searchTerm}%` },
+              { field: 'description', operator: 'ilike', value: `%${searchTerm}%` },
+            ],
+          }
+        : {}),
+      ...(typeFilter !== 'all'
+        ? { type: { operator: 'eq', value: typeFilter } }
+        : {}),
+    },
   });
   const funds = result?.data || [];
-
-  const filteredFunds = funds.filter((fund: Fund) => {
-    const search = searchTerm.toLowerCase();
-    const matchesSearch =
-      fund.code.toLowerCase().includes(search) ||
-      fund.name.toLowerCase().includes(search) ||
-      (fund.description ? fund.description.toLowerCase().includes(search) : false);
-    const matchesType = typeFilter === 'all' || fund.type === typeFilter;
-    return matchesSearch && matchesType;
-  });
+  const totalCount = result?.count;
 
   const columns: GridColDef[] = [
     {
@@ -128,8 +133,8 @@ function FundList() {
             ) : (
               <DataGrid<Fund>
                 columns={columns}
-                data={filteredFunds}
-                totalRows={filteredFunds.length}
+                data={funds}
+                totalRows={totalCount ?? 0}
                 loading={isLoading}
                 error={error instanceof Error ? error.message : undefined}
                 onPageChange={handlePageChange}

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -91,14 +91,30 @@ export class QueryUtils {
       }
     };
 
-    if (Array.isArray(filter)) {
-      // Handle OR conditions
-      return query.or(
-        filter.map(f => `${key}.${f.operator}.${f.value}`).join(',')
-      );
-    } else {
-      return applyFilter(filter.operator, filter.value, filter.valueTo);
+    if (key === 'or') {
+      if (Array.isArray(filter)) {
+        return query.or(
+          filter
+            .map(f =>
+              f.field
+                ? `${f.field}.${f.operator}.${f.value}`
+                : `${key}.${f.operator}.${f.value}`
+            )
+            .join(',')
+        );
+      } else if (typeof filter === 'string') {
+        return query.or(filter);
+      } else if (filter?.field) {
+        return query.or(`${filter.field}.${filter.operator}.${filter.value}`);
+      }
     }
+
+    if (Array.isArray(filter)) {
+      // Handle OR conditions for same column
+      return query.or(filter.map(f => `${key}.${f.operator}.${f.value}`).join(','));
+    }
+
+    return applyFilter(filter.operator, filter.value, filter.valueTo);
   }
 
   private buildRelationshipQuery(relationships: QueryOptions['relationships'] = []): string {


### PR DESCRIPTION
## Summary
- enable server-side filtering and pagination for Funds list
- return total record count from query
- pass count to DataGrid for correct pagination
- extend BaseAdapter and QueryUtils to allow `or` conditions across fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f13382f748326b1f273ffae69e2b7