### PR TITLE
Reduce padding on mobile

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -40,7 +40,7 @@ function Layout() {
           {isSettingsPage ? (
             <Outlet />
           ) : (
-            <div className="px-8 py-6">
+            <div className="px-4 py-4 sm:px-6 sm:py-6">
               <Outlet />
             </div>
           )}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -496,14 +496,14 @@ module.exports = {
         container: {
           fixed: {
             px: {
-              DEFAULT: theme('spacing')['6'],
+              DEFAULT: theme('spacing')['4'],
               xl: theme('spacing')['7.5']
             },
             'max-width': theme('screens.xl')
           },
           fluid: {
             px: {
-              DEFAULT: theme('spacing')['6'],
+              DEFAULT: theme('spacing')['4'],
               xl: theme('spacing')['7.5']
             }
           }


### PR DESCRIPTION
## Summary
- tweak main layout spacing to use responsive padding
- reduce Tailwind container spacing on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd507c0a88326932cfc701d4620d6