### PR TITLE
Add dedicated finance category pages

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -9,6 +9,7 @@ import {
   CreditCard,
   History,
   Wallet,
+  Tag,
   LucideIcon,
 } from 'lucide-react';
 
@@ -139,6 +140,22 @@ export const navigation: NavItem[] = [
             name: 'Chart of Accounts',
             href: '/accounts/chart-of-accounts',
             icon: FileText,
+          },
+        ],
+      },
+      {
+        name: 'Configuration',
+        icon: Tag,
+        submenu: [
+          {
+            name: 'Donation Categories',
+            href: '/finances/configuration/donation-categories',
+            icon: Tag,
+          },
+          {
+            name: 'Expense Categories',
+            href: '/finances/configuration/expense-categories',
+            icon: Tag,
           },
         ],
       },

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -20,6 +20,9 @@ const Statements = React.lazy(() => import('./Statements'));
 const IncomeExpenseList = React.lazy(() => import('./incomeExpense/IncomeExpenseList'));
 const IncomeExpenseAddEdit = React.lazy(() => import('./incomeExpense/IncomeExpenseAddEdit'));
 const IncomeExpenseProfile = React.lazy(() => import('./incomeExpense/IncomeExpenseProfile'));
+const CategoryList = React.lazy(() => import('./configuration/CategoryList'));
+const CategoryAddEdit = React.lazy(() => import('./configuration/CategoryAddEdit'));
+const CategoryProfile = React.lazy(() => import('./configuration/CategoryProfile'));
 
 function LoadingSpinner() {
   return (
@@ -62,6 +65,50 @@ function Finances() {
         <Route path="funds/add" element={<FundAddEdit />} />
         <Route path="funds/:id/edit" element={<FundAddEdit />} />
         <Route path="funds/:id" element={<FundProfile />} />
+        <Route
+          path="configuration/donation-categories"
+          element={
+            <CategoryList
+              categoryType="income_transaction"
+              title="Donation Categories"
+              description="Manage donation categories."
+            />
+          }
+        />
+        <Route
+          path="configuration/donation-categories/add"
+          element={<CategoryAddEdit categoryType="income_transaction" basePath="/finances/configuration/donation-categories" />}
+        />
+        <Route
+          path="configuration/donation-categories/:id/edit"
+          element={<CategoryAddEdit categoryType="income_transaction" basePath="/finances/configuration/donation-categories" />}
+        />
+        <Route
+          path="configuration/donation-categories/:id"
+          element={<CategoryProfile basePath="/finances/configuration/donation-categories" />}
+        />
+        <Route
+          path="configuration/expense-categories"
+          element={
+            <CategoryList
+              categoryType="expense_transaction"
+              title="Expense Categories"
+              description="Manage expense categories."
+            />
+          }
+        />
+        <Route
+          path="configuration/expense-categories/add"
+          element={<CategoryAddEdit categoryType="expense_transaction" basePath="/finances/configuration/expense-categories" />}
+        />
+        <Route
+          path="configuration/expense-categories/:id/edit"
+          element={<CategoryAddEdit categoryType="expense_transaction" basePath="/finances/configuration/expense-categories" />}
+        />
+        <Route
+          path="configuration/expense-categories/:id"
+          element={<CategoryProfile basePath="/finances/configuration/expense-categories" />}
+        />
         <Route path="expenses" element={<IncomeExpenseList transactionType="expense" />} />
         <Route path="expenses/add" element={<IncomeExpenseAddEdit transactionType="expense" />} />
         <Route path="expenses/:id/edit" element={<IncomeExpenseAddEdit transactionType="expense" />} />

--- a/src/pages/finances/configuration/CategoryAddEdit.tsx
+++ b/src/pages/finances/configuration/CategoryAddEdit.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCategoryRepository } from '../../../hooks/useCategoryRepository';
+import { useChartOfAccountRepository } from '../../../hooks/useChartOfAccountRepository';
+import { Category, CategoryType } from '../../../models/category.model';
+import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import { Textarea } from '../../../components/ui2/textarea';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '../../../components/ui2/select';
+import { Switch } from '../../../components/ui2/switch';
+import BackButton from '../../../components/BackButton';
+import { Save, Loader2, Tag } from 'lucide-react';
+
+interface CategoryAddEditProps {
+  categoryType: CategoryType;
+  basePath: string;
+}
+
+function CategoryAddEdit({ categoryType, basePath }: CategoryAddEditProps) {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const { useQuery, useCreate, useUpdate } = useCategoryRepository();
+  const { useQuery: useAccountsQuery } = useChartOfAccountRepository();
+
+  const [formData, setFormData] = useState<Partial<Category>>({
+    type: categoryType,
+    code: '',
+    name: '',
+    description: '',
+    is_active: true,
+    sort_order: 0,
+    chart_of_account_id: null
+  });
+  const [errors, setErrors] = useState<{ code?: string; name?: string; general?: string }>({});
+
+  const { data: categoryData, isLoading: isCategoryLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: isEditMode
+  });
+
+  const { data: accountsData } = useAccountsQuery();
+
+  useEffect(() => {
+    if (isEditMode && categoryData?.data?.[0]) {
+      setFormData(categoryData.data[0]);
+    }
+  }, [isEditMode, categoryData]);
+
+  const handleInputChange = (field: keyof Category, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    if (errors[field as keyof typeof errors]) {
+      setErrors(prev => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const validateForm = () => {
+    const newErrors: typeof errors = {};
+    if (!formData.code?.trim()) newErrors.code = 'Code is required';
+    if (!formData.name?.trim()) newErrors.name = 'Name is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const createMutation = useCreate();
+  const updateMutation = useUpdate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+    try {
+      if (isEditMode) {
+        await updateMutation.mutateAsync({ id: id!, data: formData });
+        navigate(`${basePath}/${id}`);
+      } else {
+        const result = await createMutation.mutateAsync({ data: formData });
+        navigate(`${basePath}/${result.id}`);
+      }
+    } catch (err) {
+      setErrors(prev => ({ ...prev, general: err instanceof Error ? err.message : 'Error saving category' }));
+    }
+  };
+
+  if (isEditMode && isCategoryLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath={basePath} label="Back to Categories" />
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <Card>
+          <CardHeader>
+            <div className="flex items-center">
+              <Tag className="h-6 w-6 text-primary mr-2" />
+              <h3 className="text-lg font-medium">
+                {isEditMode ? 'Edit Category' : 'Add New Category'}
+              </h3>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {errors.general && (
+              <div className="bg-destructive/10 border border-destructive/30 rounded-md p-4">
+                {errors.general}
+              </div>
+            )}
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <Input
+                  label="Code"
+                  value={formData.code || ''}
+                  onChange={(e) => handleInputChange('code', e.target.value)}
+                  error={errors.code}
+                  required
+                />
+              </div>
+              <div>
+                <Input
+                  label="Name"
+                  value={formData.name || ''}
+                  onChange={(e) => handleInputChange('name', e.target.value)}
+                  error={errors.name}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1.5">Chart of Account</label>
+                <Select
+                  value={formData.chart_of_account_id || undefined}
+                  onValueChange={(v) => handleInputChange('chart_of_account_id', v || null)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select account" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={undefined}>None</SelectItem>
+                    {accountsData?.data.map(acc => (
+                      <SelectItem key={acc.id} value={acc.id}>
+                        {acc.code} - {acc.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Input
+                  type="number"
+                  label="Sort Order"
+                  value={formData.sort_order ?? 0}
+                  onChange={(e) => handleInputChange('sort_order', parseInt(e.target.value) || 0)}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <Textarea
+                  label="Description"
+                  value={formData.description || ''}
+                  onChange={(e) => handleInputChange('description', e.target.value)}
+                  rows={3}
+                />
+              </div>
+              <div className="sm:col-span-2 flex items-center space-x-2">
+                <Switch
+                  checked={formData.is_active ?? true}
+                  onCheckedChange={(checked) => handleInputChange('is_active', checked)}
+                />
+                <label className="text-sm font-medium">Active</label>
+              </div>
+            </div>
+          </CardContent>
+          <CardFooter className="flex justify-end space-x-3">
+            <Button type="button" variant="outline" onClick={() => navigate(basePath)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+              {createMutation.isPending || updateMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-2 h-4 w-4" />
+              )}
+              {isEditMode ? 'Update Category' : 'Create Category'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}
+
+export default CategoryAddEdit;

--- a/src/pages/finances/configuration/CategoryList.tsx
+++ b/src/pages/finances/configuration/CategoryList.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useCategoryRepository } from '../../../hooks/useCategoryRepository';
+import { CategoryType } from '../../../models/category.model';
+import {
+  Card,
+  CardHeader,
+  CardContent
+} from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import { Input } from '../../../components/ui2/input';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell
+} from '../../../components/ui2/table';
+import { Badge } from '../../../components/ui2/badge';
+import { Plus, Eye, Edit, Trash2, Loader2 } from 'lucide-react';
+
+interface CategoryListProps {
+  categoryType: CategoryType;
+  title: string;
+  description: string;
+}
+
+function CategoryList({ categoryType, title, description }: CategoryListProps) {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { useQuery, useDelete } = useCategoryRepository();
+  const { data: result, isLoading } = useQuery({
+    filters: { type: { operator: 'eq', value: categoryType } }
+  });
+  const categories = result?.data || [];
+  const deleteMutation = useDelete();
+
+  const filteredCategories = categories.filter(cat =>
+    cat.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    cat.code.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (cat.description && cat.description.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+
+  const handleDelete = async (id: string) => {
+    if (window.confirm('Are you sure you want to delete this category?')) {
+      try {
+        await deleteMutation.mutateAsync(id);
+      } catch (err) {
+        console.error('Error deleting category', err);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+          <p className="text-muted-foreground">{description}</p>
+        </div>
+        <Button onClick={() => navigate('add')}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Category
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <div>
+              <h3 className="text-lg font-medium">Categories</h3>
+            </div>
+            <div className="w-full sm:w-auto">
+              <Input
+                placeholder="Search categories..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="max-w-sm"
+              />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+          ) : filteredCategories.length > 0 ? (
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[120px]">Code</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead className="hidden md:table-cell">Description</TableHead>
+                    <TableHead className="w-[120px]">Status</TableHead>
+                    <TableHead className="w-[120px]">Order</TableHead>
+                    <TableHead className="w-[180px]">Account</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredCategories.map(cat => (
+                    <TableRow key={cat.id}>
+                      <TableCell className="font-medium">{cat.code}</TableCell>
+                      <TableCell>{cat.name}</TableCell>
+                      <TableCell className="hidden md:table-cell">{cat.description || '-'}</TableCell>
+                      <TableCell>
+                        <Badge variant={cat.is_active ? 'success' : 'secondary'}>
+                          {cat.is_active ? 'Active' : 'Inactive'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{cat.sort_order}</TableCell>
+                      <TableCell>
+                        {cat.chart_of_accounts ? `${cat.chart_of_accounts.code} - ${cat.chart_of_accounts.name}` : '-'}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button variant="ghost" size="sm" onClick={() => navigate(`${cat.id}`)}>
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                          <Button variant="ghost" size="sm" onClick={() => navigate(`${cat.id}/edit`)} disabled={cat.is_system}>
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button variant="ghost" size="sm" onClick={() => handleDelete(cat.id)} disabled={cat.is_system}>
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-8">
+              <p className="text-muted-foreground mb-4">No categories found</p>
+              <Button onClick={() => navigate('add')}>
+                <Plus className="mr-2 h-4 w-4" />
+                Add Category
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default CategoryList;

--- a/src/pages/finances/configuration/CategoryProfile.tsx
+++ b/src/pages/finances/configuration/CategoryProfile.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCategoryRepository } from '../../../hooks/useCategoryRepository';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Badge } from '../../../components/ui2/badge';
+import { Loader2, Tag, Pencil, Trash2 } from 'lucide-react';
+
+interface CategoryProfileProps {
+  basePath: string;
+}
+
+function CategoryProfile({ basePath }: CategoryProfileProps) {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const { useQuery, useDelete } = useCategoryRepository();
+  const { data: categoryData, isLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: !!id
+  });
+  const deleteMutation = useDelete();
+
+  const category = categoryData?.data?.[0];
+
+  const handleDelete = async () => {
+    if (!id) return;
+    if (window.confirm('Are you sure you want to delete this category?')) {
+      try {
+        await deleteMutation.mutateAsync(id);
+        navigate(basePath);
+      } catch (err) {
+        console.error('Error deleting category', err);
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!category) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">Category not found</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath={basePath} label="Back to Categories" />
+      </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold flex items-center">
+              <Tag className="h-6 w-6 mr-2 text-primary" />
+              {category.name}
+              <Badge variant="secondary" className="ml-3 capitalize">
+                {category.type.replace('_', ' ')}
+              </Badge>
+            </h2>
+            <div className="flex space-x-3">
+              <Button variant="outline" onClick={() => navigate('edit')} className="flex items-center" disabled={category.is_system}>
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+              <Button variant="destructive" onClick={handleDelete} className="flex items-center" disabled={category.is_system}>
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <dl className="divide-y divide-border">
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Code</dt>
+              <dd className="text-sm text-foreground col-span-2">{category.code}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Description</dt>
+              <dd className="text-sm text-foreground col-span-2">{category.description || '-'}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Status</dt>
+              <dd className="text-sm text-foreground col-span-2">
+                <Badge variant={category.is_active ? 'success' : 'secondary'}>
+                  {category.is_active ? 'Active' : 'Inactive'}
+                </Badge>
+              </dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Sort Order</dt>
+              <dd className="text-sm text-foreground col-span-2">{category.sort_order}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Account</dt>
+              <dd className="text-sm text-foreground col-span-2">
+                {category.chart_of_accounts ? `${category.chart_of_accounts.code} - ${category.chart_of_accounts.name}` : '-'}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default CategoryProfile;


### PR DESCRIPTION
## Summary
- add generic category management components for finance configuration
- expose donation and expense categories under Accounting menu
- connect new pages to finance routes

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686151483a9c8326bba23100b82969b4