### PR TITLE
Add filters to income/expense list

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -28,6 +28,7 @@ export interface DataGridProps<T> extends Omit<MuiDataGridProps<T>, 'rows'> {
   loading?: boolean;
   error?: string;
   paginationMode?: 'client' | 'server';
+  showQuickFilter?: boolean;
 }
 
 // Style the DataGrid to match our theme
@@ -136,6 +137,7 @@ export function DataGrid<T>({
   error,
   paginationMode = 'server',
   columns,
+  showQuickFilter = true,
   ...props
 }: DataGridProps<T>) {
   const theme = useTheme();
@@ -194,7 +196,7 @@ export function DataGrid<T>({
         }}
         slotProps={{
           toolbar: {
-            showQuickFilter: true,
+            showQuickFilter,
             quickFilterProps: {
               debounceMs: 500,
               InputProps: { className: quickFilterClass },

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
+import { Input } from '../../../components/ui2/input';
+import { DateRangePickerField } from '../../../components/ui2/date-range-picker-field';
 import { DataGrid } from '../../../components/ui2/mui-datagrid';
 import { FinancialTransactionHeader } from '../../../models/financialTransactionHeader.model';
 import { GridColDef } from '@mui/x-data-grid';
-import { Plus } from 'lucide-react';
+import { Plus, Search, Calendar } from 'lucide-react';
 
 interface IncomeExpenseListProps {
   transactionType: 'income' | 'expense';
@@ -17,6 +19,11 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
   const navigate = useNavigate();
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [dateRange, setDateRange] = useState<{ from: Date; to: Date }>({
+    from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+    to: new Date(),
+  });
   const { useQuery: useEntryQuery } = useIncomeExpenseTransactionRepository();
   const { useQuery: useHeaderQuery } = useFinancialTransactionHeaderRepository();
 
@@ -45,12 +52,27 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
     isLoading: headerLoading,
     error: headerError,
   } = useHeaderQuery({
-    filters: { id: { operator: 'isAnyOf', value: headerIds } },
+    filters: {
+      id: { operator: 'isAnyOf', value: headerIds },
+      transaction_date: {
+        operator: 'between',
+        value: dateRange.from.toISOString().split('T')[0],
+        valueTo: dateRange.to.toISOString().split('T')[0],
+      },
+    },
     order: { column: 'transaction_date', ascending: false },
     enabled: headerIds.length > 0,
   });
   const headers = headerResult?.data || [];
   const isLoading = entriesLoading || headerLoading;
+
+  const filteredHeaders = useMemo(() => {
+    const term = searchTerm.toLowerCase();
+    return headers.filter(h =>
+      h.transaction_number.toLowerCase().includes(term) ||
+      (h.description || '').toLowerCase().includes(term)
+    );
+  }, [headers, searchTerm]);
 
   const columns: GridColDef[] = [
     { field: 'transaction_date', headerName: 'Date', flex: 1, minWidth: 120 },
@@ -81,13 +103,36 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
           </Link>
         </div>
       </div>
+      <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="w-full sm:max-w-xs">
+          <Input
+            placeholder="Search..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            icon={<Search className="h-4 w-4" />}
+          />
+        </div>
+
+        <DateRangePickerField
+          value={{ from: dateRange.from, to: dateRange.to }}
+          onChange={(range) => {
+            if (range.from && range.to) {
+              setDateRange({ from: range.from, to: range.to });
+            }
+          }}
+          placeholder="Select date range"
+          icon={<Calendar className="h-4 w-4" />}
+          showCompactInput
+        />
+      </div>
+
       <div className="mt-6">
         <Card className="dark:bg-slate-800">
           <CardContent className="p-0">
             <DataGrid<FinancialTransactionHeader>
               columns={columns}
-              data={headers}
-              totalRows={headers.length}
+              data={filteredHeaders}
+              totalRows={filteredHeaders.length}
               loading={isLoading}
               error={
                 entriesError instanceof Error
@@ -102,6 +147,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
               onRowClick={(params) => navigate(`/finances/${basePath}/${params.id}`)}
               autoHeight
               paginationMode="client"
+              showQuickFilter={false}
               page={page}
               pageSize={pageSize}
             />


### PR DESCRIPTION
## Summary
- add `showQuickFilter` option to DataGrid
- add search and date range filters to income/expense list
- disable quick filter for income/expense grid

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686163ba5a3c8326a13a93c037c9b385