### PR TITLE
Disable quick filter for funds and sources

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -28,6 +28,7 @@ export interface DataGridProps<T> extends Omit<MuiDataGridProps<T>, 'rows'> {
   loading?: boolean;
   error?: string;
   paginationMode?: 'client' | 'server';
+  showQuickFilter?: boolean;
 }
 
 // Style the DataGrid to match our theme
@@ -135,6 +136,7 @@ export function DataGrid<T>({
   loading = false,
   error,
   paginationMode = 'server',
+  showQuickFilter = false,
   columns,
   ...props
 }: DataGridProps<T>) {
@@ -194,7 +196,7 @@ export function DataGrid<T>({
         }}
         slotProps={{
           toolbar: {
-            showQuickFilter: true,
+            showQuickFilter,
             quickFilterProps: {
               debounceMs: 500,
               InputProps: { className: quickFilterClass },

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -230,6 +230,7 @@ function FinancialSourceList() {
                 disableDensitySelector={false}
                 page={page}
                 pageSize={pageSize}
+                showQuickFilter={false}
               />
             )}
           </CardContent>

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -148,6 +148,7 @@ function FundList() {
                 getRowId={(row) => row.id}
                 page={page}
                 pageSize={pageSize}
+                showQuickFilter={false}
               />
             )}
           </CardContent>

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -495,10 +495,7 @@ function TransactionList() {
             disableDensitySelector={false}
             page={page}
             pageSize={pageSize}
-            toolbar={{
-              showQuickFilter: true,
-              quickFilterProps: { debounceMs: 500 },
-            }}
+            showQuickFilter
           />
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- add `showQuickFilter` prop to DataGrid so quick filter can be toggled
- hide the quick filter on FundList and FinancialSourceList
- update TransactionList to use new `showQuickFilter` prop

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686163c56b948326b0701fa118131ae8