### PR TITLE
Add unique index for source_recent_transactions_view

### DIFF
--- a/supabase/migrations/20250709002000_source_recent_transactions_view_unique_index.sql
+++ b/supabase/migrations/20250709002000_source_recent_transactions_view_unique_index.sql
@@ -1,0 +1,6 @@
+-- Add unique index on header_id for REFRESH MATERIALIZED VIEW CONCURRENTLY
+-- This index is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
+
+CREATE UNIQUE INDEX CONCURRENTLY
+  IF NOT EXISTS source_recent_transactions_view_header_id_uidx
+  ON source_recent_transactions_view(header_id);


### PR DESCRIPTION
## Summary
- add migration to create unique index on `source_recent_transactions_view(header_id)`

This index is required to use `REFRESH MATERIALIZED VIEW CONCURRENTLY`.

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628de0e30c8326b05061c512918efe