### PR TITLE
Add Administration navigation

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -10,6 +10,8 @@ import {
   History,
   Wallet,
   Tag,
+  Shield,
+  UserCog,
   LucideIcon,
 } from 'lucide-react';
 
@@ -156,6 +158,41 @@ export const navigation: NavItem[] = [
             name: 'Expense Categories',
             href: '/finances/configuration/expense-categories',
             icon: Tag,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'Administration',
+    href: '/settings/administration',
+    icon: Shield,
+    permission: 'user.view',
+    submenu: [
+      {
+        name: 'User Management',
+        icon: UserCog,
+        submenu: [
+          {
+            name: 'Users',
+            href: '/settings/administration/users',
+            icon: UserCog,
+          },
+          {
+            name: 'Configuration',
+            icon: Tag,
+            submenu: [
+              {
+                name: 'Roles',
+                href: '/settings/administration/roles',
+                icon: Shield,
+              },
+              {
+                name: 'Permissions',
+                href: '/settings/administration/permissions',
+                icon: Shield,
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
## Summary
- extend lucide icon imports in navigation config
- add new Administration navigation item with nested user management and configuration links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb64218c83269998b37e69cf74cf