### PR TITLE
Allow registration tenant list without auth

### DIFF
--- a/src/pages/auth/MemberRegister.tsx
+++ b/src/pages/auth/MemberRegister.tsx
@@ -26,8 +26,9 @@ function MemberRegister() {
 
   useEffect(() => {
     async function fetchTenants() {
+      // use public view so registration works without auth
       const { data, error } = await supabase
-        .from('tenants')
+        .from('public_tenants')
         .select('id, name')
         .order('name');
       if (error) {

--- a/supabase/migrations/20250709005000_public_tenants_view.sql
+++ b/supabase/migrations/20250709005000_public_tenants_view.sql
@@ -1,0 +1,26 @@
+-- Public tenants view accessible by unauthenticated users
+
+-- Function returning active tenants ignoring RLS
+CREATE OR REPLACE FUNCTION list_public_tenants()
+RETURNS TABLE(id uuid, name text)
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE sql
+AS $$
+  SELECT id, name
+  FROM tenants
+  WHERE status = 'active'
+  ORDER BY name;
+$$;
+
+-- View selecting from the function
+DROP VIEW IF EXISTS public_tenants;
+CREATE VIEW public_tenants AS
+SELECT * FROM list_public_tenants();
+
+-- Permissions for anonymous access
+GRANT SELECT ON public_tenants TO anon;
+GRANT SELECT ON public_tenants TO authenticated;
+
+COMMENT ON FUNCTION list_public_tenants IS 'Returns active tenants for registration';
+COMMENT ON VIEW public_tenants IS 'View of active tenants accessible without authentication';


### PR DESCRIPTION
## Summary
- add public `public_tenants` view to expose active tenants via SECURITY DEFINER function
- update `MemberRegister` to read from the new view

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6862ceecf3888326a6a3cdf2349b2306