### PR TITLE
Implement search-based tenant lookup

### DIFF
--- a/src/components/ui2/combobox.tsx
+++ b/src/components/ui2/combobox.tsx
@@ -29,6 +29,7 @@ interface ComboboxProps {
   className?: string;
   disabled?: boolean;
   onKeyDown?: (e: React.KeyboardEvent) => void;
+  onSearchChange?: (value: string) => void;
 }
 
 export function Combobox({
@@ -40,6 +41,7 @@ export function Combobox({
   className,
   disabled = false,
   onKeyDown,
+  onSearchChange,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -96,7 +98,10 @@ export function Combobox({
           <CommandInput 
             placeholder={`Search ${placeholder.toLowerCase()}...`}
             value={searchQuery}
-            onValueChange={setSearchQuery}
+            onValueChange={(v) => {
+              setSearchQuery(v);
+              onSearchChange?.(v);
+            }}
             onKeyDown={handleKeyDown}
             className="h-9"
           />


### PR DESCRIPTION
## Summary
- add `onSearchChange` callback to Combobox
- query tenants when searching during member registration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d43ef18483269a656b24370e730f