### PR TITLE
Add permissions management pages

### DIFF
--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
-import { UserCog, Shield, Building2, Tag } from 'lucide-react';
+import { UserCog, Shield, Building2, Tag, KeyRound } from 'lucide-react';
 import { usePermissions } from '../../hooks/usePermissions';
 import { Card } from '../../components/ui2/card';
 
@@ -9,6 +9,7 @@ import Users from './Users';
 import Roles from './Roles';
 import ChurchSettings from './ChurchSettings';
 import Categories from './Categories';
+import Permissions from './configuration/Permissions';
 
 function Administration() {
   const location = useLocation();
@@ -29,6 +30,13 @@ function Administration() {
       icon: <Shield className="h-5 w-5" />,
       href: '/settings/administration/roles',
       show: () => hasPermission('role.view')
+    },
+    {
+      id: 'permissions',
+      label: 'Permissions',
+      icon: <KeyRound className="h-5 w-5" />,
+      href: '/settings/administration/configuration/permissions',
+      show: () => hasPermission('permission.view')
     },
     {
       id: 'church',
@@ -88,6 +96,7 @@ function Administration() {
             <Routes>
               <Route path="users/*" element={<Users />} />
               <Route path="roles/*" element={<Roles />} />
+              <Route path="configuration/permissions/*" element={<Permissions />} />
               <Route path="church" element={<ChurchSettings />} />
               <Route path="categories/*" element={<Categories />} />
               <Route path="*" element={<Navigate to={adminTabs[0]?.href.split('/').pop() || 'users'} replace />} />

--- a/src/pages/admin/configuration/PermissionAddEdit.tsx
+++ b/src/pages/admin/configuration/PermissionAddEdit.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { usePermissionRepository } from '../../../hooks/usePermissionRepository';
+import { Permission } from '../../../models/permission.model';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Textarea } from '../../../components/ui2/textarea';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Save, Loader2 } from 'lucide-react';
+
+function PermissionAddEdit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isEditMode = !!id;
+
+  const { useQuery, useCreate, useUpdate } = usePermissionRepository();
+
+  const [formData, setFormData] = useState<Partial<Permission>>({
+    code: '',
+    name: '',
+    module: '',
+    description: '',
+  });
+
+  const { data: permData, isLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: isEditMode,
+  });
+
+  const createMutation = useCreate();
+  const updateMutation = useUpdate();
+
+  useEffect(() => {
+    if (isEditMode && permData?.data?.[0]) {
+      setFormData(permData.data[0]);
+    }
+  }, [isEditMode, permData]);
+
+  const handleInputChange = (field: keyof Permission, value: any) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isEditMode && id) {
+        await updateMutation.mutateAsync({ id, data: formData });
+        navigate(`/settings/administration/configuration/permissions/${id}`);
+      } else {
+        const result = await createMutation.mutateAsync({ data: formData });
+        navigate(`/settings/administration/configuration/permissions/${result.id}`);
+      }
+    } catch (err) {
+      console.error('Error saving permission:', err);
+    }
+  };
+
+  if (isEditMode && isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath="/settings/administration/configuration/permissions" label="Back to Permissions" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium text-foreground">
+            {isEditMode ? 'Edit Permission' : 'Add Permission'}
+          </h3>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Input
+                label="Code"
+                required
+                value={formData.code || ''}
+                onChange={(e) => handleInputChange('code', e.target.value)}
+                placeholder="module.action"
+                className="sm:col-span-2"
+              />
+              <Input
+                label="Name"
+                required
+                value={formData.name || ''}
+                onChange={(e) => handleInputChange('name', e.target.value)}
+                className="sm:col-span-2"
+              />
+              <Input
+                label="Module"
+                required
+                value={formData.module || ''}
+                onChange={(e) => handleInputChange('module', e.target.value)}
+                className="sm:col-span-2"
+              />
+              <Textarea
+                value={formData.description || ''}
+                onChange={(e) => handleInputChange('description', e.target.value)}
+                placeholder="Description (optional)"
+                className="sm:col-span-2"
+              />
+            </div>
+
+            <div className="flex justify-end space-x-3">
+              <Button type="button" variant="outline" onClick={() => navigate('/settings/administration/configuration/permissions')}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
+                {createMutation.isPending || updateMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="mr-2 h-4 w-4" /> {isEditMode ? 'Update Permission' : 'Create Permission'}
+                  </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default PermissionAddEdit;

--- a/src/pages/admin/configuration/PermissionList.tsx
+++ b/src/pages/admin/configuration/PermissionList.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { usePermissionRepository } from '../../../hooks/usePermissionRepository';
+import { Permission } from '../../../models/permission.model';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import { DataGrid } from '../../../components/ui2/mui-datagrid';
+import type { GridColDef } from '@mui/x-data-grid';
+import { Plus, Search, Loader2 } from 'lucide-react';
+
+function PermissionList() {
+  const navigate = useNavigate();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const { useQuery } = usePermissionRepository();
+  const { data: result, isLoading, error } = useQuery({
+    pagination: { page: page + 1, pageSize },
+    filters: searchTerm
+      ? {
+          or: [
+            { field: 'code', operator: 'ilike', value: `%${searchTerm}%` },
+            { field: 'name', operator: 'ilike', value: `%${searchTerm}%` },
+            { field: 'module', operator: 'ilike', value: `%${searchTerm}%` },
+          ],
+        }
+      : {},
+    order: { column: 'module' },
+  });
+
+  const permissions = (result?.data as Permission[]) || [];
+  const totalCount = result?.count;
+
+  const columns: GridColDef[] = [
+    { field: 'code', headerName: 'Code', flex: 1, minWidth: 150 },
+    { field: 'name', headerName: 'Name', flex: 2, minWidth: 200 },
+    { field: 'module', headerName: 'Module', flex: 1, minWidth: 150 },
+  ];
+
+  const handleRowClick = (params: any) => {
+    navigate(`${params.id}`);
+  };
+
+  const handlePageChange = (newPage: number) => setPage(newPage);
+  const handlePageSizeChange = (newSize: number) => {
+    setPageSize(newSize);
+    setPage(0);
+  };
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-foreground">Permissions</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Manage application permissions.
+          </p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <Link to="add">
+            <Button className="flex items-center">
+              <Plus className="h-4 w-4 mr-2" /> Add Permission
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-6 max-w-xs">
+        <Input
+          placeholder="Search permissions..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          icon={<Search />}
+        />
+      </div>
+
+      <div className="mt-6">
+        <Card>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex justify-center py-8">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              </div>
+            ) : (
+              <DataGrid<Permission>
+                columns={columns}
+                data={permissions}
+                totalRows={totalCount ?? 0}
+                loading={isLoading}
+                error={error instanceof Error ? error.message : undefined}
+                onRowClick={handleRowClick}
+                onPageChange={handlePageChange}
+                onPageSizeChange={handlePageSizeChange}
+                page={page}
+                pageSize={pageSize}
+                autoHeight
+                getRowId={(row) => row.id}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default PermissionList;

--- a/src/pages/admin/configuration/PermissionProfile.tsx
+++ b/src/pages/admin/configuration/PermissionProfile.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { usePermissionRepository } from '../../../hooks/usePermissionRepository';
+import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
+import { Button } from '../../../components/ui2/button';
+import BackButton from '../../../components/BackButton';
+import { Loader2, Pencil, Trash2, KeyRound } from 'lucide-react';
+
+function PermissionProfile() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const { useQuery, useDelete } = usePermissionRepository();
+  const { data: permData, isLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: !!id,
+  });
+  const deleteMutation = useDelete();
+
+  const permission = permData?.data?.[0];
+
+  const handleDelete = async () => {
+    if (!id) return;
+    if (window.confirm('Are you sure you want to delete this permission?')) {
+      try {
+        await deleteMutation.mutateAsync(id);
+        navigate('/settings/administration/configuration/permissions');
+      } catch (err) {
+        console.error('Error deleting permission', err);
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!permission) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">Permission not found</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath="/settings/administration/configuration/permissions" label="Back to Permissions" />
+      </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold flex items-center">
+              <KeyRound className="h-6 w-6 mr-2 text-primary" />
+              {permission.name}
+            </h2>
+            <div className="flex space-x-3">
+              <Button variant="outline" onClick={() => navigate('edit')} className="flex items-center">
+                <Pencil className="h-4 w-4 mr-2" /> Edit
+              </Button>
+              <Button variant="destructive" onClick={handleDelete} className="flex items-center">
+                {deleteMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4 mr-2" />
+                )}
+                Delete
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <dl className="divide-y divide-border">
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Code</dt>
+              <dd className="text-sm text-foreground col-span-2">{permission.code}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Module</dt>
+              <dd className="text-sm text-foreground col-span-2">{permission.module}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Description</dt>
+              <dd className="text-sm text-foreground col-span-2">{permission.description || '-'}</dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default PermissionProfile;

--- a/src/pages/admin/configuration/Permissions.tsx
+++ b/src/pages/admin/configuration/Permissions.tsx
@@ -1,0 +1,34 @@
+import React, { Suspense } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Loader2 } from 'lucide-react';
+
+const PermissionList = React.lazy(() => import('./PermissionList'));
+const PermissionAddEdit = React.lazy(() => import('./PermissionAddEdit'));
+const PermissionProfile = React.lazy(() => import('./PermissionProfile'));
+
+function LoadingSpinner() {
+  return (
+    <Card>
+      <CardContent className="flex justify-center items-center min-h-[200px]">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Permissions() {
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <Routes>
+        <Route index element={<PermissionList />} />
+        <Route path="list" element={<PermissionList />} />
+        <Route path="add" element={<PermissionAddEdit />} />
+        <Route path=":id/edit" element={<PermissionAddEdit />} />
+        <Route path=":id" element={<PermissionProfile />} />
+      </Routes>
+    </Suspense>
+  );
+}
+
+export default Permissions;


### PR DESCRIPTION
## Summary
- add Permissions page under administration configuration
- allow listing, adding, editing and viewing permissions
- expose new routes from Administration

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d4cac3cc8326bf51fec269f2ec1c