### PR TITLE
Add custom category menus

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -62,6 +62,27 @@ export const navigation: NavItem[] = [
         href: '/members/family',
         icon: Heart,
       },
+      {
+        name: 'Configuration',
+        icon: Tag,
+        submenu: [
+          {
+            name: 'Membership Types',
+            href: '/members/configuration/membership-types',
+            icon: Tag,
+          },
+          {
+            name: 'Membership Status',
+            href: '/members/configuration/membership-status',
+            icon: Tag,
+          },
+          {
+            name: 'Relationship Types',
+            href: '/members/configuration/relationship-types',
+            icon: Tag,
+          },
+        ],
+      },
     ],
   },
   {
@@ -157,6 +178,11 @@ export const navigation: NavItem[] = [
           {
             name: 'Expense Categories',
             href: '/finances/configuration/expense-categories',
+            icon: Tag,
+          },
+          {
+            name: 'Budget Categories',
+            href: '/finances/configuration/budget-categories',
             icon: Tag,
           },
         ],

--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
-import { UserCog, Shield, Building2, Tag, KeyRound } from 'lucide-react';
+import { UserCog, Shield, Building2, KeyRound } from 'lucide-react';
 import { usePermissions } from '../../hooks/usePermissions';
 import { Card } from '../../components/ui2/card';
 
@@ -8,7 +8,6 @@ import { Card } from '../../components/ui2/card';
 import Users from './Users';
 import Roles from './Roles';
 import ChurchSettings from './ChurchSettings';
-import Categories from './Categories';
 import Permissions from './configuration/Permissions';
 
 function Administration() {
@@ -45,13 +44,6 @@ function Administration() {
       href: '/settings/administration/church',
       show: () => hasPermission('user.view')
     },
-    {
-      id: 'categories',
-      label: 'Categories',
-      icon: <Tag className="h-5 w-5" />,
-      href: '/settings/administration/categories',
-      show: () => hasPermission('user.view')
-    }
   ].filter(tab => !tab.show || tab.show());
 
   const currentPath = location.pathname;
@@ -98,7 +90,6 @@ function Administration() {
               <Route path="roles/*" element={<Roles />} />
               <Route path="configuration/permissions/*" element={<Permissions />} />
               <Route path="church" element={<ChurchSettings />} />
-              <Route path="categories/*" element={<Categories />} />
               <Route path="*" element={<Navigate to={adminTabs[0]?.href.split('/').pop() || 'users'} replace />} />
             </Routes>
           </div>

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -109,6 +109,28 @@ function Finances() {
           path="configuration/expense-categories/:id"
           element={<CategoryProfile basePath="/finances/configuration/expense-categories" />}
         />
+        <Route
+          path="configuration/budget-categories"
+          element={
+            <CategoryList
+              categoryType="budget"
+              title="Budget Categories"
+              description="Manage budget categories."
+            />
+          }
+        />
+        <Route
+          path="configuration/budget-categories/add"
+          element={<CategoryAddEdit categoryType="budget" basePath="/finances/configuration/budget-categories" />}
+        />
+        <Route
+          path="configuration/budget-categories/:id/edit"
+          element={<CategoryAddEdit categoryType="budget" basePath="/finances/configuration/budget-categories" />}
+        />
+        <Route
+          path="configuration/budget-categories/:id"
+          element={<CategoryProfile basePath="/finances/configuration/budget-categories" />}
+        />
         <Route path="expenses" element={<IncomeExpenseList transactionType="expense" />} />
         <Route path="expenses/add" element={<IncomeExpenseAddEdit transactionType="expense" />} />
         <Route path="expenses/:id/edit" element={<IncomeExpenseAddEdit transactionType="expense" />} />

--- a/src/pages/members/Members.tsx
+++ b/src/pages/members/Members.tsx
@@ -6,6 +6,9 @@ import MemberAddEdit from './MemberAddEdit';
 import FamilyRelationships from './family/FamilyRelationships';
 import FamilyRelationshipProfile from './family/FamilyRelationshipProfile';
 import FamilyRelationshipAddEdit from './family/FamilyRelationshipAddEdit';
+import CategoryList from '../finances/configuration/CategoryList';
+import CategoryAddEdit from '../finances/configuration/CategoryAddEdit';
+import CategoryProfile from '../finances/configuration/CategoryProfile';
 
 function Members() {
   return (
@@ -21,6 +24,74 @@ function Members() {
       <Route path="family/add" element={<FamilyRelationshipAddEdit />} />
       <Route path="family/:id" element={<FamilyRelationshipProfile />} />
       <Route path="family/:id/edit" element={<FamilyRelationshipAddEdit />} />
+
+      {/* Configuration Routes */}
+      <Route
+        path="configuration/membership-types"
+        element={
+          <CategoryList
+            categoryType="membership"
+            title="Membership Types"
+            description="Manage membership types."
+          />
+        }
+      />
+      <Route
+        path="configuration/membership-types/add"
+        element={<CategoryAddEdit categoryType="membership" basePath="/members/configuration/membership-types" />}
+      />
+      <Route
+        path="configuration/membership-types/:id/edit"
+        element={<CategoryAddEdit categoryType="membership" basePath="/members/configuration/membership-types" />}
+      />
+      <Route
+        path="configuration/membership-types/:id"
+        element={<CategoryProfile basePath="/members/configuration/membership-types" />}
+      />
+      <Route
+        path="configuration/membership-status"
+        element={
+          <CategoryList
+            categoryType="member_status"
+            title="Membership Status"
+            description="Manage membership status options."
+          />
+        }
+      />
+      <Route
+        path="configuration/membership-status/add"
+        element={<CategoryAddEdit categoryType="member_status" basePath="/members/configuration/membership-status" />}
+      />
+      <Route
+        path="configuration/membership-status/:id/edit"
+        element={<CategoryAddEdit categoryType="member_status" basePath="/members/configuration/membership-status" />}
+      />
+      <Route
+        path="configuration/membership-status/:id"
+        element={<CategoryProfile basePath="/members/configuration/membership-status" />}
+      />
+      <Route
+        path="configuration/relationship-types"
+        element={
+          <CategoryList
+            categoryType="relationship_type"
+            title="Relationship Types"
+            description="Manage relationship types."
+          />
+        }
+      />
+      <Route
+        path="configuration/relationship-types/add"
+        element={<CategoryAddEdit categoryType="relationship_type" basePath="/members/configuration/relationship-types" />}
+      />
+      <Route
+        path="configuration/relationship-types/:id/edit"
+        element={<CategoryAddEdit categoryType="relationship_type" basePath="/members/configuration/relationship-types" />}
+      />
+      <Route
+        path="configuration/relationship-types/:id"
+        element={<CategoryProfile basePath="/members/configuration/relationship-types" />}
+      />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- add membership configuration items to navigation
- support budget category pages
- expose category management pages under Members
- remove obsolete Categories tab from Administration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862de1056908326a09709635585f099