### PR TITLE
Move ChurchSettings component

### DIFF
--- a/src/pages/admin/Admin.tsx
+++ b/src/pages/admin/Admin.tsx
@@ -5,7 +5,7 @@ import Users from './Users';
 import Roles from './Roles';
 import RoleForm from './RoleForm';
 import DatabaseManagement from './DatabaseManagement';
-import ChurchSettings from './ChurchSettings';
+import ChurchSettings from './account-management/ChurchSettings';
 import Categories from './Categories';
 
 function Admin() {

--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -7,7 +7,7 @@ import { Card } from '../../components/ui2/card';
 // Import admin pages
 import Users from './Users';
 import Roles from './Roles';
-import ChurchSettings from './ChurchSettings';
+import ChurchSettings from './account-management/ChurchSettings';
 import Permissions from './configuration/Permissions';
 
 function Administration() {

--- a/src/pages/admin/account-management/ChurchSettings.tsx
+++ b/src/pages/admin/account-management/ChurchSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
-import { useMessageStore } from '../../components/MessageHandler';
+import { supabase } from '../../../lib/supabase';
+import { useMessageStore } from '../../../components/MessageHandler';
 import {
   Building2,
   Save,

--- a/src/pages/settings/Administration.tsx
+++ b/src/pages/settings/Administration.tsx
@@ -7,7 +7,7 @@ import { Card } from '../../components/ui2/card';
 // Import admin pages
 import Users from '../admin/Users';
 import Roles from '../admin/Roles';
-import ChurchSettings from '../admin/ChurchSettings';
+import ChurchSettings from '../admin/account-management/ChurchSettings';
 
 function Administration() {
   const location = useLocation();


### PR DESCRIPTION
## Summary
- move `ChurchSettings.tsx` to an account-management folder
- update relative imports to match new location
- fix references to the component in Admin pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e07b2d808326a433aada40ea5bf0