### PR TITLE
Update church settings routes and references

### DIFF
--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -41,7 +41,7 @@ function Administration() {
       id: 'church',
       label: 'Church Settings',
       icon: <Building2 className="h-5 w-5" />,
-      href: '/settings/administration/church',
+      href: '/settings/administration/account-management/church',
       show: () => hasPermission('user.view')
     },
   ].filter(tab => !tab.show || tab.show());
@@ -89,7 +89,7 @@ function Administration() {
               <Route path="users/*" element={<Users />} />
               <Route path="roles/*" element={<Roles />} />
               <Route path="configuration/permissions/*" element={<Permissions />} />
-              <Route path="church" element={<ChurchSettings />} />
+              <Route path="account-management/church" element={<ChurchSettings />} />
               <Route path="*" element={<Navigate to={adminTabs[0]?.href.split('/').pop() || 'users'} replace />} />
             </Routes>
           </div>

--- a/src/pages/settings/Administration.tsx
+++ b/src/pages/settings/Administration.tsx
@@ -33,7 +33,7 @@ function Administration() {
       id: 'church',
       label: 'Church Settings',
       icon: <Building2 className="h-5 w-5" />,
-      href: '/settings/administration/church',
+      href: '/settings/administration/account-management/church',
       show: () => hasPermission('user.view')
     }
   ].filter(tab => !tab.show || tab.show());
@@ -80,7 +80,7 @@ function Administration() {
             <Routes>
               <Route path="users/*" element={<Users />} />
               <Route path="roles/*" element={<Roles />} />
-              <Route path="church" element={<ChurchSettings />} />
+              <Route path="account-management/church" element={<ChurchSettings />} />
               <Route path="*" element={<Navigate to={adminTabs[0]?.href || '/settings'} replace />} />
             </Routes>
           </div>


### PR DESCRIPTION
## Summary
- update church settings route paths
- keep default redirects working

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862e1558b448326bbfdb9bedfc7d5a1