### PR TITLE
Refactor roles pages with new routing

### DIFF
--- a/src/pages/admin/RoleAddEdit.tsx
+++ b/src/pages/admin/RoleAddEdit.tsx
@@ -24,7 +24,7 @@ type Role = {
   }[];
 };
 
-function RoleForm() {
+function RoleAddEdit() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { useQuery: useRoleQuery, useCreate, useUpdate } = useRoleRepository();
@@ -124,7 +124,7 @@ function RoleForm() {
           await supabase.from('role_permissions').insert(assignments);
         }
       }
-      navigate('/admin/roles');
+        navigate('/settings/administration/roles');
     } catch (error) {
       console.error('Error saving role:', error);
       if (error instanceof Error) {
@@ -167,7 +167,7 @@ function RoleForm() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-        <BackButton fallbackPath="/admin/roles" label="Back to Roles" />
+      <BackButton fallbackPath="/settings/administration/roles" label="Back to Roles" />
       </div>
 
       <div className="bg-white shadow overflow-hidden sm:rounded-lg">
@@ -285,7 +285,7 @@ function RoleForm() {
             <div className="mt-6 flex justify-end space-x-3">
               <button
                 type="button"
-                onClick={() => navigate('/admin/roles')}
+                onClick={() => navigate('/settings/administration/roles')}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
               >
                 Cancel
@@ -315,4 +315,4 @@ function RoleForm() {
   );
 }
 
-export default RoleForm;
+export default RoleAddEdit;

--- a/src/pages/admin/RoleList.tsx
+++ b/src/pages/admin/RoleList.tsx
@@ -1,0 +1,171 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useRoleRepository } from '../../hooks/useRoleRepository';
+import { usePermissions } from '../../hooks/usePermissions';
+import PermissionGate from '../../components/PermissionGate';
+import { Shield, Plus, Search, Edit2, Trash2, Loader2 } from 'lucide-react';
+import { Role } from '../../models/role.model';
+
+function RoleList() {
+  const navigate = useNavigate();
+  const { hasPermission } = usePermissions();
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { useQuery, useDelete } = useRoleRepository();
+
+  const { data: result, isLoading } = useQuery({
+    order: { column: 'name' },
+    enabled: hasPermission('role.view'),
+  });
+  const roles = (result?.data as Role[]) || [];
+
+  const deleteRoleMutation = useDelete();
+
+  const handleDelete = async (roleId: string) => {
+    if (window.confirm('Are you sure you want to delete this role?')) {
+      try {
+        await deleteRoleMutation.mutateAsync(roleId);
+      } catch (error) {
+        console.error('Error deleting role:', error);
+      }
+    }
+  };
+
+  const handleEdit = (roleId: string) => {
+    navigate(`/settings/administration/roles/${roleId}/edit`);
+  };
+
+  const filteredRoles = roles.filter((role) =>
+    role.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    role.description?.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-gray-900">Roles</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            Manage roles and their associated permissions.
+          </p>
+        </div>
+        <PermissionGate permission="role.create">
+          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+            <Link
+              to="/settings/administration/roles/add"
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:w-auto"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Role
+            </Link>
+          </div>
+        </PermissionGate>
+      </div>
+
+      <div className="mt-6">
+        <div className="relative max-w-xs">
+          <div className="pointer-events-none absolute inset-y-0 left-0 pl-3 flex items-center">
+            <Search className="h-5 w-5 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            className="block w-full rounded-md border border-gray-300 pl-10 pr-3 py-2 text-sm placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+            placeholder="Search roles..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
+        </div>
+      ) : filteredRoles && filteredRoles.length > 0 ? (
+        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredRoles.map((role) => (
+            <div
+              key={role.id}
+              className="bg-white overflow-hidden shadow rounded-lg divide-y divide-gray-200"
+            >
+              <div className="px-4 py-5 sm:px-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-lg font-medium text-gray-900">
+                      {role.name.charAt(0).toUpperCase() + role.name.slice(1)}
+                    </h3>
+                    {role.description && (
+                      <p className="mt-1 text-sm text-gray-500">
+                        {role.description}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex space-x-2">
+                    <PermissionGate permission="role.edit">
+                      <button
+                        className="text-primary-600 hover:text-primary-900"
+                        onClick={() => handleEdit(role.id)}
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </button>
+                    </PermissionGate>
+                    <PermissionGate permission="role.delete">
+                      <button
+                        className="text-red-600 hover:text-red-900"
+                        onClick={() => handleDelete(role.id)}
+                        disabled={deleteRoleMutation.isPending}
+                      >
+                        {deleteRoleMutation.isPending ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </button>
+                    </PermissionGate>
+                  </div>
+                </div>
+              </div>
+              <div className="px-4 py-4 sm:px-6">
+                <h4 className="text-sm font-medium text-gray-900">Permissions</h4>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {role.permissions.map((rp, index) => (
+                    <span
+                      key={index}
+                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"
+                    >
+                      {rp.permission.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8 bg-white shadow sm:rounded-lg mt-8">
+          <Shield className="mx-auto h-12 w-12 text-gray-400" />
+          <h3 className="mt-2 text-sm font-medium text-gray-900">No roles found</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            {searchTerm
+              ? 'No roles match your search criteria'
+              : 'Get started by adding a new role'}
+          </p>
+          <PermissionGate permission="role.create">
+            <div className="mt-6">
+              <Link
+                to="/settings/administration/roles/add"
+                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+              >
+                <Plus className="h-4 w-4 mr-2" />
+                Add Role
+              </Link>
+            </div>
+          </PermissionGate>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default RoleList;
+

--- a/src/pages/admin/RoleProfile.tsx
+++ b/src/pages/admin/RoleProfile.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useRoleRepository } from '../../hooks/useRoleRepository';
+import { Card, CardHeader, CardContent } from '../../components/ui2/card';
+import { Button } from '../../components/ui2/button';
+import BackButton from '../../components/BackButton';
+import { Badge } from '../../components/ui2/badge';
+import { Loader2, Shield, Pencil, Trash2 } from 'lucide-react';
+
+function RoleProfile() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const { useQuery, useDelete } = useRoleRepository();
+  const { data: roleData, isLoading } = useQuery({
+    filters: { id: { operator: 'eq', value: id } },
+    enabled: !!id,
+  });
+  const deleteMutation = useDelete();
+
+  const role = roleData?.data?.[0];
+
+  const handleDelete = async () => {
+    if (!id) return;
+    if (window.confirm('Are you sure you want to delete this role?')) {
+      try {
+        await deleteMutation.mutateAsync(id);
+        navigate('/settings/administration/roles');
+      } catch (err) {
+        console.error('Error deleting role', err);
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
+      </div>
+    );
+  }
+
+  if (!role) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center">Role not found</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <BackButton fallbackPath="/settings/administration/roles" label="Back to Roles" />
+      </div>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold flex items-center">
+              <Shield className="h-6 w-6 mr-2 text-primary" />
+              {role.name}
+            </h2>
+            <div className="flex space-x-3">
+              <Button variant="outline" onClick={() => navigate('edit')} className="flex items-center">
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+              <Button variant="destructive" onClick={handleDelete} className="flex items-center">
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <dl className="divide-y divide-border">
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Description</dt>
+              <dd className="text-sm text-foreground col-span-2">{role.description || '-'}</dd>
+            </div>
+            <div className="py-3 grid grid-cols-3 gap-4">
+              <dt className="text-sm font-medium text-muted-foreground">Permissions</dt>
+              <dd className="text-sm text-foreground col-span-2">
+                <div className="flex flex-wrap gap-1">
+                  {role.permissions?.map((rp, i) => (
+                    <Badge key={i} variant="secondary">
+                      {rp.permission.name}
+                    </Badge>
+                  ))}
+                </div>
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default RoleProfile;
+

--- a/src/pages/admin/Roles.tsx
+++ b/src/pages/admin/Roles.tsx
@@ -1,178 +1,21 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useRoleRepository } from '../../hooks/useRoleRepository';
-import { usePermissions } from '../../hooks/usePermissions';
-import PermissionGate from '../../components/PermissionGate';
-import {
-  Shield,
-  Plus,
-  Search,
-  Edit2,
-  Trash2,
-  Loader2,
-} from 'lucide-react';
-import { Role } from '../../models/role.model';
-
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import RoleList from './RoleList';
+import RoleAddEdit from './RoleAddEdit';
+import RoleProfile from './RoleProfile';
 
 function Roles() {
-  const navigate = useNavigate();
-  const { hasPermission } = usePermissions();
-  const [searchTerm, setSearchTerm] = useState('');
-
-  const { useQuery, useDelete } = useRoleRepository();
-
-  const { data: result, isLoading } = useQuery({
-    order: { column: 'name' },
-    enabled: hasPermission('role.view'),
-  });
-  const roles = (result?.data as Role[]) || [];
-
-  const deleteRoleMutation = useDelete();
-
-  const handleDelete = async (roleId: string) => {
-    if (window.confirm('Are you sure you want to delete this role?')) {
-      try {
-        await deleteRoleMutation.mutateAsync(roleId);
-      } catch (error) {
-        console.error('Error deleting role:', error);
-      }
-    }
-  };
-
-  const handleEdit = (roleId: string) => {
-    navigate(`/admin/roles/${roleId}/edit`);
-  };
-
-  const filteredRoles = roles.filter((role) =>
-    role.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    role.description?.toLowerCase().includes(searchTerm.toLowerCase())
-  );
-
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div className="sm:flex sm:items-center">
-        <div className="sm:flex-auto">
-          <h1 className="text-2xl font-semibold text-gray-900">Roles</h1>
-          <p className="mt-2 text-sm text-gray-700">
-            Manage roles and their associated permissions.
-          </p>
-        </div>
-        <PermissionGate permission="role.create">
-          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-            <Link
-              to="/admin/roles/new"
-              className="inline-flex items-center justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:w-auto"
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Add Role
-            </Link>
-          </div>
-        </PermissionGate>
-      </div>
-
-      <div className="mt-6">
-        <div className="relative max-w-xs">
-          <div className="pointer-events-none absolute inset-y-0 left-0 pl-3 flex items-center">
-            <Search className="h-5 w-5 text-gray-400" />
-          </div>
-          <input
-            type="text"
-            className="block w-full rounded-md border border-gray-300 pl-10 pr-3 py-2 text-sm placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
-            placeholder="Search roles..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-          />
-        </div>
-      </div>
-
-      {isLoading ? (
-        <div className="flex justify-center py-8">
-          <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
-        </div>
-      ) : filteredRoles && filteredRoles.length > 0 ? (
-        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredRoles.map((role) => (
-            <div
-              key={role.id}
-              className="bg-white overflow-hidden shadow rounded-lg divide-y divide-gray-200"
-            >
-              <div className="px-4 py-5 sm:px-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900">
-                      {role.name.charAt(0).toUpperCase() + role.name.slice(1)}
-                    </h3>
-                    {role.description && (
-                      <p className="mt-1 text-sm text-gray-500">
-                        {role.description}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex space-x-2">
-                    <PermissionGate permission="role.edit">
-                      <button
-                        className="text-primary-600 hover:text-primary-900"
-                        onClick={() => handleEdit(role.id)}
-                      >
-                        <Edit2 className="h-4 w-4" />
-                      </button>
-                    </PermissionGate>
-                    <PermissionGate permission="role.delete">
-                      <button
-                        className="text-red-600 hover:text-red-900"
-                        onClick={() => handleDelete(role.id)}
-                        disabled={deleteRoleMutation.isPending}
-                      >
-                        {deleteRoleMutation.isPending ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="h-4 w-4" />
-                        )}
-                      </button>
-                    </PermissionGate>
-                  </div>
-                </div>
-              </div>
-              <div className="px-4 py-4 sm:px-6">
-                <h4 className="text-sm font-medium text-gray-900">Permissions</h4>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {role.permissions.map((rp, index) => (
-                    <span
-                      key={index}
-                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"
-                    >
-                      {rp.permission.name}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-8 bg-white shadow sm:rounded-lg mt-8">
-          <Shield className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No roles found</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            {searchTerm
-              ? 'No roles match your search criteria'
-              : 'Get started by adding a new role'}
-          </p>
-          <PermissionGate permission="role.create">
-            <div className="mt-6">
-              <Link
-                to="/admin/roles/new"
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Role
-              </Link>
-            </div>
-          </PermissionGate>
-        </div>
-      )}
-    </div>
+    <Routes>
+      <Route index element={<RoleList />} />
+      <Route path="list" element={<RoleList />} />
+      <Route path="add" element={<RoleAddEdit />} />
+      <Route path=":id" element={<RoleProfile />} />
+      <Route path=":id/edit" element={<RoleAddEdit />} />
+      <Route path="*" element={<Navigate to="list" replace />} />
+    </Routes>
   );
 }
 
 export default Roles;
+


### PR DESCRIPTION
## Summary
- move role list view into `RoleList.tsx`
- rename `RoleForm.tsx` to `RoleAddEdit.tsx`
- add `RoleProfile.tsx` for viewing single roles
- create route-based `Roles.tsx` component

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e5ac50ec8326b8bdf72e8f13e7a0