### PR TITLE
Refactor role admin pages

### DIFF
--- a/src/pages/admin/roles/RoleAddEdit.tsx
+++ b/src/pages/admin/roles/RoleAddEdit.tsx
@@ -6,6 +6,11 @@ import { useRoleRepository } from '../../../hooks/useRoleRepository';
 import { NotificationService } from '../../../services/NotificationService';
 import { Save, Loader2, Shield } from 'lucide-react';
 import BackButton from '../../../components/BackButton';
+import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Textarea } from '../../../components/ui2/textarea';
+import { Checkbox } from '../../../components/ui2/checkbox';
+import { Button } from '../../../components/ui2/button';
 
 type Permission = {
   id: string;
@@ -165,110 +170,80 @@ function RoleAddEdit() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="w-full px-4 sm:px-6 lg:px-8">
       <div className="mb-6">
-      <BackButton fallbackPath="/administration/roles" label="Back to Roles" />
+        <BackButton fallbackPath="/administration/roles" label="Back to Roles" />
       </div>
 
-      <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-        <div className="px-4 py-5 sm:px-6">
-          <h3 className="text-lg leading-6 font-medium text-gray-900">
-            {id ? 'Edit Role' : 'Create New Role'}
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">
-            {id
-              ? 'Update role details and permission assignments'
-              : 'Define a new role and assign permissions'}
-          </p>
-        </div>
-
-        <form onSubmit={handleSubmit} className="border-t border-gray-200">
-          <div className="px-4 py-5 sm:px-6">
+      <form onSubmit={handleSubmit}>
+        <Card>
+          <CardHeader>
+            <div className="flex items-center">
+              <Shield className="h-6 w-6 text-primary mr-2" />
+              <h3 className="text-lg font-medium text-foreground">
+                {id ? 'Edit Role' : 'Create New Role'}
+              </h3>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {id
+                ? 'Update role details and permission assignments'
+                : 'Define a new role and assign permissions'}
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
             <div className="grid grid-cols-1 gap-y-6 gap-x-4">
               <div>
-                <label
-                  htmlFor="name"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Role Name *
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  id="name"
+                <Input
+                  label="Role Name"
                   required
                   value={formData.name}
                   onChange={(e) =>
                     setFormData((prev) => ({ ...prev, name: e.target.value }))
                   }
-                  className="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
                 />
               </div>
-
               <div>
-                <label
-                  htmlFor="description"
-                  className="block text-sm font-medium text-gray-700"
-                >
+                <label className="block text-sm font-medium mb-1.5 text-foreground">
                   Description
                 </label>
-                <textarea
-                  name="description"
-                  id="description"
-                  rows={3}
+                <Textarea
                   value={formData.description}
                   onChange={(e) =>
                     setFormData((prev) => ({ ...prev, description: e.target.value }))
                   }
-                  className="mt-1 focus:ring-primary-500 focus:border-primary-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md"
+                  rows={3}
                 />
               </div>
-
               <div>
-                <label className="block text-sm font-medium text-gray-700">
-                  Permissions
-                </label>
+                <label className="block text-sm font-medium text-foreground">Permissions</label>
                 <div className="mt-4 space-y-6">
                   {Object.entries(groupedPermissions).map(([module, modulePermissions]) => (
                     <div key={module} className="space-y-2">
                       <div className="flex items-center">
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           id={`module-${module}`}
-                          checked={modulePermissions.every((p) =>
-                            formData.permissions.includes(p.id)
-                          )}
-                          onChange={() => handleModuleToggle(module)}
-                          className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
+                          checked={modulePermissions.every((p) => formData.permissions.includes(p.id))}
+                          onCheckedChange={() => handleModuleToggle(module)}
                         />
-                        <label
-                          htmlFor={`module-${module}`}
-                          className="ml-3 text-sm font-medium text-gray-700"
-                        >
-                          {module.charAt(0).toUpperCase() + module.slice(1)}
+                        <label htmlFor={`module-${module}`} className="ml-2 text-sm font-medium capitalize">
+                          {module}
                         </label>
                       </div>
                       <div className="ml-7 space-y-2">
                         {modulePermissions.map((permission) => (
-                          <div key={permission.id} className="flex items-start">
-                            <div className="flex items-center h-5">
-                              <input
-                                type="checkbox"
-                                id={`permission-${permission.id}`}
-                                checked={formData.permissions.includes(permission.id)}
-                                onChange={() => handlePermissionToggle(permission.id)}
-                                className="focus:ring-primary-500 h-4 w-4 text-primary-600 border-gray-300 rounded"
-                              />
-                            </div>
-                            <div className="ml-3 text-sm">
-                              <label
-                                htmlFor={`permission-${permission.id}`}
-                                className="font-medium text-gray-700"
-                              >
+                          <div key={permission.id} className="flex items-start space-x-2">
+                            <Checkbox
+                              id={`permission-${permission.id}`}
+                              checked={formData.permissions.includes(permission.id)}
+                              onCheckedChange={() => handlePermissionToggle(permission.id)}
+                              size="sm"
+                            />
+                            <div className="text-sm">
+                              <label htmlFor={`permission-${permission.id}`} className="font-medium text-foreground">
                                 {permission.name}
                               </label>
                               {permission.description && (
-                                <p className="text-gray-500">
+                                <p className="text-muted-foreground">
                                   {permission.description}
                                 </p>
                               )}
@@ -281,36 +256,27 @@ function RoleAddEdit() {
                 </div>
               </div>
             </div>
-
-            <div className="mt-6 flex justify-end space-x-3">
-              <button
-                type="button"
-                onClick={() => navigate('/administration/roles')}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={createRoleMutation.isPending || updateRoleMutation.isPending}
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50"
-              >
-                {createRoleMutation.isPending || updateRoleMutation.isPending ? (
-                  <>
-                    <Loader2 className="animate-spin -ml-1 mr-2 h-5 w-5" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="-ml-1 mr-2 h-5 w-5" />
-                    {id ? 'Save Changes' : 'Create Role'}
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
+          </CardContent>
+          <CardFooter className="flex justify-end space-x-3">
+            <Button type="button" variant="outline" onClick={() => navigate('/administration/roles')}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createRoleMutation.isPending || updateRoleMutation.isPending}>
+              {createRoleMutation.isPending || updateRoleMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="mr-2 h-4 w-4" />
+                  {id ? 'Save Changes' : 'Create Role'}
+                </>
+              )}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
     </div>
   );
 }

--- a/src/pages/admin/roles/RoleList.tsx
+++ b/src/pages/admin/roles/RoleList.tsx
@@ -3,8 +3,20 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useRoleRepository } from '../../../hooks/useRoleRepository';
 import { usePermissions } from '../../../hooks/usePermissions';
 import PermissionGate from '../../../components/PermissionGate';
-import { Shield, Plus, Search, Edit2, Trash2, Loader2 } from 'lucide-react';
+import { Plus, Search, Edit2, Trash2, Loader2 } from 'lucide-react';
 import { Role } from '../../../models/role.model';
+import { Card, CardContent } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from '../../../components/ui2/table';
+import { Badge } from '../../../components/ui2/badge';
 
 function RoleList() {
   const navigate = useNavigate();
@@ -41,128 +53,103 @@ function RoleList() {
   );
 
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div className="sm:flex sm:items-center">
-        <div className="sm:flex-auto">
-          <h1 className="text-2xl font-semibold text-gray-900">Roles</h1>
-          <p className="mt-2 text-sm text-gray-700">
-            Manage roles and their associated permissions.
-          </p>
+    <div className="w-full px-4 sm:px-6 lg:px-8 space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">Roles</h1>
+          <p className="text-muted-foreground">Manage roles and their associated permissions.</p>
         </div>
         <PermissionGate permission="role.create">
-          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-            <Link
-              to="/administration/roles/add"
-              className="inline-flex items-center justify-center rounded-md border border-transparent bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 sm:w-auto"
-            >
+          <Link to="/administration/roles/add">
+            <Button className="flex items-center">
               <Plus className="h-4 w-4 mr-2" />
               Add Role
-            </Link>
-          </div>
+            </Button>
+          </Link>
         </PermissionGate>
       </div>
 
-      <div className="mt-6">
-        <div className="relative max-w-xs">
-          <div className="pointer-events-none absolute inset-y-0 left-0 pl-3 flex items-center">
-            <Search className="h-5 w-5 text-gray-400" />
-          </div>
-          <input
-            type="text"
-            className="block w-full rounded-md border border-gray-300 pl-10 pr-3 py-2 text-sm placeholder-gray-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
-            placeholder="Search roles..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-          />
-        </div>
+      <div className="max-w-xs">
+        <Input
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Search roles..."
+          icon={<Search className="h-5 w-5" />}
+        />
       </div>
 
-      {isLoading ? (
-        <div className="flex justify-center py-8">
-          <Loader2 className="h-8 w-8 animate-spin text-primary-600" />
-        </div>
-      ) : filteredRoles && filteredRoles.length > 0 ? (
-        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredRoles.map((role) => (
-            <div
-              key={role.id}
-              className="bg-white overflow-hidden shadow rounded-lg divide-y divide-gray-200"
-            >
-              <div className="px-4 py-5 sm:px-6">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900">
-                      {role.name.charAt(0).toUpperCase() + role.name.slice(1)}
-                    </h3>
-                    {role.description && (
-                      <p className="mt-1 text-sm text-gray-500">
-                        {role.description}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex space-x-2">
-                    <PermissionGate permission="role.edit">
-                      <button
-                        className="text-primary-600 hover:text-primary-900"
-                        onClick={() => handleEdit(role.id)}
-                      >
-                        <Edit2 className="h-4 w-4" />
-                      </button>
-                    </PermissionGate>
-                    <PermissionGate permission="role.delete">
-                      <button
-                        className="text-red-600 hover:text-red-900"
-                        onClick={() => handleDelete(role.id)}
-                        disabled={deleteRoleMutation.isPending}
-                      >
-                        {deleteRoleMutation.isPending ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="h-4 w-4" />
-                        )}
-                      </button>
-                    </PermissionGate>
-                  </div>
-                </div>
-              </div>
-              <div className="px-4 py-4 sm:px-6">
-                <h4 className="text-sm font-medium text-gray-900">Permissions</h4>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {role.permissions.map((rp, index) => (
-                    <span
-                      key={index}
-                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-100 text-primary-800"
-                    >
-                      {rp.permission.name}
-                    </span>
-                  ))}
-                </div>
-              </div>
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
             </div>
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-8 bg-white shadow sm:rounded-lg mt-8">
-          <Shield className="mx-auto h-12 w-12 text-gray-400" />
-          <h3 className="mt-2 text-sm font-medium text-gray-900">No roles found</h3>
-          <p className="mt-1 text-sm text-gray-500">
-            {searchTerm
-              ? 'No roles match your search criteria'
-              : 'Get started by adding a new role'}
-          </p>
-          <PermissionGate permission="role.create">
-            <div className="mt-6">
-              <Link
-                to="/administration/roles/add"
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Role
-              </Link>
+          ) : filteredRoles && filteredRoles.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Permissions</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredRoles.map((role) => (
+                  <TableRow key={role.id}>
+                    <TableCell className="font-medium capitalize">
+                      {role.name}
+                    </TableCell>
+                    <TableCell>{role.description || '-'}</TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {role.permissions.map((rp, index) => (
+                          <Badge key={index} variant="secondary">
+                            {rp.permission.name}
+                          </Badge>
+                        ))}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-2">
+                        <PermissionGate permission="role.edit">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleEdit(role.id)}
+                            icon={<Edit2 className="h-4 w-4" />}
+                          />
+                        </PermissionGate>
+                        <PermissionGate permission="role.delete">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleDelete(role.id)}
+                            disabled={deleteRoleMutation.isPending}
+                            icon={
+                              deleteRoleMutation.isPending ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="h-4 w-4" />
+                              )
+                            }
+                          />
+                        </PermissionGate>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="py-8 text-center text-muted-foreground">
+              {searchTerm
+                ? 'No roles found matching your search criteria'
+                : 'No roles found. Add your first role by clicking the "Add Role" button above.'}
             </div>
-          </PermissionGate>
-        </div>
-      )}
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use ui2 controls in role list and add/edit pages
- standardize layout and enable dark mode

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862fa323670832690ca827a65e1b2bd