### PR TITLE
Fix materialized view refresh permissions

### DIFF
--- a/supabase/migrations/20250708002000_source_recent_transactions_view.sql
+++ b/supabase/migrations/20250708002000_source_recent_transactions_view.sql
@@ -29,7 +29,7 @@ begin
   refresh materialized view concurrently source_recent_transactions_view;
   return null;
 end;
-$$ language plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 create trigger refresh_source_recent_transactions_view
 after insert or update or delete on financial_transactions

--- a/supabase/migrations/20250709000000_update_source_recent_transactions_view.sql
+++ b/supabase/migrations/20250709000000_update_source_recent_transactions_view.sql
@@ -37,7 +37,7 @@ BEGIN
   REFRESH MATERIALIZED VIEW CONCURRENTLY source_recent_transactions_view;
   RETURN NULL;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 CREATE TRIGGER refresh_source_recent_transactions_view
 AFTER INSERT OR UPDATE OR DELETE ON financial_transactions

--- a/supabase/migrations/20250709001000_source_recent_transactions_tenant.sql
+++ b/supabase/migrations/20250709001000_source_recent_transactions_tenant.sql
@@ -38,7 +38,7 @@ BEGIN
   REFRESH MATERIALIZED VIEW CONCURRENTLY source_recent_transactions_view;
   RETURN NULL;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 CREATE TRIGGER refresh_source_recent_transactions_view
 AFTER INSERT OR UPDATE OR DELETE ON financial_transactions

--- a/supabase/migrations/20250709003000_add_fund_id_to_source_recent_transactions_view.sql
+++ b/supabase/migrations/20250709003000_add_fund_id_to_source_recent_transactions_view.sql
@@ -45,7 +45,7 @@ BEGIN
   REFRESH MATERIALIZED VIEW CONCURRENTLY source_recent_transactions_view;
   RETURN NULL;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 CREATE TRIGGER refresh_source_recent_transactions_view
 AFTER INSERT OR UPDATE OR DELETE ON financial_transactions


### PR DESCRIPTION
## Summary
- run `refresh_source_recent_transactions_view` as `SECURITY DEFINER` so the trigger can refresh the materialized view without errors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630d33fa048326953c6e96fae03bca