### PR TITLE
Extend sidebar width

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ function Footer({ sidebarCollapsed }: FooterProps) {
   return (
     <>
       <footer
-        className={`fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 py-4 px-6 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+        className={`fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t dark:border-gray-700 py-4 px-6 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
       >
         <div className="max-w-7xl mx-auto flex items-center justify-between flex-wrap space-y-2 sm:space-y-0">
           <div className="flex items-center space-x-4">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,7 +27,7 @@ function Layout() {
 
       {/* Main content wrapper */}
       <div
-        className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 pt-16 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+        className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 pt-16 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
       >
         {/* Top navigation */}
         <Topbar

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -280,7 +280,7 @@ function Sidebar({
           transform transition-transform duration-300 ease-in-out
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
           lg:translate-x-0
-          w-64 ${collapsed ? 'lg:w-20' : 'lg:w-64'}
+          w-72 ${collapsed ? 'lg:w-20' : 'lg:w-72'}
           transition-all
         `}
         onMouseEnter={() => {

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -27,7 +27,7 @@ function Topbar({ setSidebarOpen, sidebarCollapsed }: TopbarProps) {
 
   return (
     <header
-      className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-64'}`}
+      className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
     >
       {/* Sidebar toggle, only on mobile */}
       <button

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -646,7 +646,7 @@ module.exports = {
         style1: {
           sidebar: {
             width: {
-              desktop: '280px',
+              desktop: '288px',
               desktopCollapse: '80px',
               mobile: '280px'
             }


### PR DESCRIPTION
## Summary
- enlarge the sidebar to avoid truncating menu item text
- adjust layout spacing to match new sidebar width
- update sidebar width variable in Tailwind config

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863added578832690fa14b7bb6aff51