### PR TITLE
Add fourth-level submenu support

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -77,7 +77,11 @@ function Sidebar({
         ? 'px-3'
         : level === 1
           ? 'pl-11 pr-3'
-          : 'pl-16 pr-3';
+          : level === 2
+            ? 'pl-16 pr-3'
+            : level === 3
+              ? 'pl-20 pr-3'
+              : 'pl-24 pr-3';
 
     if (hasChildren) {
       return (


### PR DESCRIPTION
## Summary
- allow Sidebar to indent a fourth submenu level

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863af1dfe54832690adc50492e597fe