### PR TITLE
Add quick access and announcement components

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,5 @@ export * from './container';
 export * from './menu';
 export * from './tabs';
 export * from './tooltip';
+
+export * from "./welcome";

--- a/src/components/welcome/Announcements.tsx
+++ b/src/components/welcome/Announcements.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent } from '../ui2/card';
+
+interface AnnouncementsProps {
+  messages?: string[];
+}
+
+interface Announcement {
+  id: number;
+  message: string;
+}
+
+export function Announcements({ messages }: AnnouncementsProps) {
+  const { data } = useQuery<Announcement[]>({
+    queryKey: ['announcements'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('announcements')
+        .select('id, message')
+        .eq('active', true);
+      if (error) {
+        console.error('Error fetching announcements:', error);
+        return [];
+      }
+      return data as Announcement[];
+    },
+    enabled: !messages,
+  });
+
+  const toRender = messages
+    ? messages.map((m, i) => ({ id: i, message: m }))
+    : data || [];
+
+  if (toRender.length === 0) return null;
+
+  return (
+    <Card className="max-w-md">
+      <CardContent className="p-4 space-y-2">
+        {toRender.map((a) => (
+          <p key={a.id} className="text-sm text-muted-foreground">
+            {a.message}
+          </p>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Announcements;

--- a/src/components/welcome/QuickAccessCard.tsx
+++ b/src/components/welcome/QuickAccessCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { LucideIcon } from 'lucide-react';
+import { Card, CardContent } from '../ui2/card';
+
+interface QuickAccessCardProps {
+  icon: LucideIcon;
+  label: string;
+  to: string;
+}
+
+export function QuickAccessCard({ icon: Icon, label, to }: QuickAccessCardProps) {
+  return (
+    <Link to={to}>
+      <Card className="hover:shadow-lg transition-shadow duration-200">
+        <CardContent className="p-4 flex items-center space-x-3">
+          <Icon className="h-6 w-6 text-primary" />
+          <span className="font-medium text-foreground">{label}</span>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+export default QuickAccessCard;

--- a/src/components/welcome/index.ts
+++ b/src/components/welcome/index.ts
@@ -1,0 +1,2 @@
+export * from './QuickAccessCard';
+export * from './Announcements';

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -7,6 +7,7 @@ import { usePermissions } from '../hooks/usePermissions';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui2/card';
 import { Button } from '../components/ui2/button';
 import { Building2, DollarSign, BarChart3, Users, Plus } from 'lucide-react';
+import { QuickAccessCard, Announcements } from '../components/welcome';
 
 function Welcome() {
   const { hasPermission } = usePermissions();
@@ -81,14 +82,12 @@ function Welcome() {
         {quickLinks
           .filter((q) => !q.permission || hasPermission(q.permission))
           .map((q) => (
-            <Link to={q.href} key={q.label}>
-              <Card className="hover:shadow-lg transition-shadow duration-200">
-                <CardContent className="p-4 flex items-center space-x-3">
-                  <q.icon className="h-6 w-6 text-primary" />
-                  <span className="font-medium text-foreground">{q.label}</span>
-                </CardContent>
-              </Card>
-            </Link>
+            <QuickAccessCard
+              key={q.label}
+              to={q.href}
+              icon={q.icon}
+              label={q.label}
+            />
           ))}
       </div>
 
@@ -106,13 +105,9 @@ function Welcome() {
       </div>
 
       {/* Announcement / Tip */}
-      <Card className="max-w-md">
-        <CardContent className="p-4">
-          <p className="text-sm text-muted-foreground">
-            Tip: Use the sidebar to quickly navigate between modules.
-          </p>
-        </CardContent>
-      </Card>
+      <Announcements messages={[
+        'Tip: Use the sidebar to quickly navigate between modules.'
+      ]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `QuickAccessCard` component for consistent quick link styling
- create `Announcements` component to show announcements from static props or Supabase
- export new components from `components/welcome`
- use the components inside `Welcome` page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863af759afc8326917dda0eb4a669eb