### PR TITLE
Add AnnouncementRepository with validation

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -55,6 +55,10 @@ import {
   NotificationRepository,
   type INotificationRepository
 } from '../repositories/notification.repository';
+import {
+  AnnouncementRepository,
+  type IAnnouncementRepository
+} from '../repositories/announcement.repository';
 import { AccountRepository, type IAccountRepository } from '../repositories/account.repository';
 import {
   FinancialSourceRepository,
@@ -209,6 +213,10 @@ container
 container
   .bind<INotificationRepository>(TYPES.INotificationRepository)
   .to(NotificationRepository)
+  .inSingletonScope();
+container
+  .bind<IAnnouncementRepository>(TYPES.IAnnouncementRepository)
+  .to(AnnouncementRepository)
   .inSingletonScope();
 container
   .bind<IAccountRepository>(TYPES.IAccountRepository)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,7 @@ export const TYPES = {
   IPermissionAdapter: 'IPermissionAdapter',
   IMemberRepository: 'IMemberRepository',
   INotificationRepository: 'INotificationRepository',
+  IAnnouncementRepository: 'IAnnouncementRepository',
   IAccountRepository: 'IAccountRepository',
   IFinancialSourceRepository: 'IFinancialSourceRepository',
   IChartOfAccountRepository: 'IChartOfAccountRepository',

--- a/src/repositories/announcement.repository.ts
+++ b/src/repositories/announcement.repository.ts
@@ -1,0 +1,39 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { Announcement } from '../models/announcement.model';
+import type { IAnnouncementAdapter } from '../adapters/announcement.adapter';
+import { AnnouncementValidator } from '../validators/announcement.validator';
+
+export interface IAnnouncementRepository extends BaseRepository<Announcement> {}
+
+@injectable()
+export class AnnouncementRepository
+  extends BaseRepository<Announcement>
+  implements IAnnouncementRepository
+{
+  constructor(@inject('IAnnouncementAdapter') adapter: IAnnouncementAdapter) {
+    super(adapter);
+  }
+
+  protected override async beforeCreate(
+    data: Partial<Announcement>
+  ): Promise<Partial<Announcement>> {
+    AnnouncementValidator.validate(data);
+    return this.formatData(data);
+  }
+
+  protected override async beforeUpdate(
+    id: string,
+    data: Partial<Announcement>
+  ): Promise<Partial<Announcement>> {
+    AnnouncementValidator.validate(data);
+    return this.formatData(data);
+  }
+
+  private formatData(data: Partial<Announcement>): Partial<Announcement> {
+    return {
+      ...data,
+      message: data.message?.trim(),
+    };
+  }
+}

--- a/src/validators/announcement.validator.ts
+++ b/src/validators/announcement.validator.ts
@@ -1,0 +1,22 @@
+import { Announcement } from '../models/announcement.model';
+
+export class AnnouncementValidator {
+  static validate(data: Partial<Announcement>): void {
+    if (data.message !== undefined && !data.message.trim()) {
+      throw new Error('Message is required');
+    }
+    if (data.starts_at && isNaN(Date.parse(data.starts_at))) {
+      throw new Error('Invalid start date');
+    }
+    if (data.ends_at && isNaN(Date.parse(data.ends_at))) {
+      throw new Error('Invalid end date');
+    }
+    if (
+      data.starts_at &&
+      data.ends_at &&
+      Date.parse(data.ends_at) < Date.parse(data.starts_at)
+    ) {
+      throw new Error('End date must be after start date');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AnnouncementRepository` with validation hooks
- add validator for announcements
- register new repository in the IoC container
- expose repository type token

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b490f4308326af61cf5b14ef7ece