### PR TITLE
Add AnnouncementService

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -103,6 +103,7 @@ import {
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { IncomeExpenseTransactionService } from '../services/IncomeExpenseTransactionService';
 import { SupabaseErrorLogService, type ErrorLogService } from '../services/ErrorLogService';
+import { SupabaseAnnouncementService, type AnnouncementService } from '../services/AnnouncementService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -203,6 +204,10 @@ container
 container
   .bind<ErrorLogService>(TYPES.ErrorLogService)
   .to(SupabaseErrorLogService)
+  .inSingletonScope();
+container
+  .bind<AnnouncementService>(TYPES.AnnouncementService)
+  .to(SupabaseAnnouncementService)
   .inSingletonScope();
 
 // Register repositories

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,5 +41,6 @@ export const TYPES = {
   ISourceRecentTransactionRepository: 'ISourceRecentTransactionRepository',
   AuditService: 'AuditService',
   ErrorLogService: 'ErrorLogService',
-  IncomeExpenseTransactionService: 'IncomeExpenseTransactionService'
+  IncomeExpenseTransactionService: 'IncomeExpenseTransactionService',
+  AnnouncementService: 'AnnouncementService'
 };

--- a/src/services/AnnouncementService.ts
+++ b/src/services/AnnouncementService.ts
@@ -1,0 +1,24 @@
+import { injectable, inject } from 'inversify';
+import type { IAnnouncementRepository } from '../repositories/announcement.repository';
+import type { Announcement } from '../models/announcement.model';
+import { TYPES } from '../lib/types';
+
+export interface AnnouncementService {
+  getActiveAnnouncements(): Promise<Announcement[]>;
+}
+
+@injectable()
+export class SupabaseAnnouncementService implements AnnouncementService {
+  constructor(
+    @inject(TYPES.IAnnouncementRepository)
+    private repo: IAnnouncementRepository,
+  ) {}
+
+  async getActiveAnnouncements(): Promise<Announcement[]> {
+    const { data } = await this.repo.find({
+      filters: { active: { operator: 'eq', value: true } },
+      order: { column: 'starts_at', ascending: true },
+    });
+    return data ?? [];
+  }
+}

--- a/tests/announcementService.test.ts
+++ b/tests/announcementService.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SupabaseAnnouncementService } from '../src/services/AnnouncementService';
+import type { IAnnouncementRepository } from '../src/repositories/announcement.repository';
+
+const repo: IAnnouncementRepository = {
+  find: vi.fn().mockResolvedValue({ data: [], count: 0 }),
+} as unknown as IAnnouncementRepository;
+
+const service = new SupabaseAnnouncementService(repo);
+
+describe('AnnouncementService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches active announcements', async () => {
+    await service.getActiveAnnouncements();
+    expect(repo.find).toHaveBeenCalledWith({
+      filters: { active: { operator: 'eq', value: true } },
+      order: { column: 'starts_at', ascending: true },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add AnnouncementService with method to fetch active announcements
- wire service into DI container under a new token
- expose new token in `types`
- add tests for AnnouncementService

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863b638f99083269c233db049f9e2fa