### PR TITLE
Fix relationship query syntax

### DIFF
--- a/src/adapters/base.adapter.ts
+++ b/src/adapters/base.adapter.ts
@@ -143,7 +143,7 @@ export class BaseAdapter<T extends BaseModel> {
       const baseSelect = relationship.select?.join(',') || '*';
       
       if (!relationship.nestedRelationships?.length) {
-        return `${relationship.table}:${relationship.foreignKey}(${baseSelect})`;
+        return `${relationship.table}!${relationship.foreignKey}(${baseSelect})`;
       }
 
       const nestedSelects = relationship.nestedRelationships.map(nested => 
@@ -153,7 +153,7 @@ export class BaseAdapter<T extends BaseModel> {
         )
       );
 
-      return `${relationship.table}:${relationship.foreignKey}(${baseSelect},${nestedSelects.join(',')})`;
+      return `${relationship.table}!${relationship.foreignKey}(${baseSelect},${nestedSelects.join(',')})`;
     };
 
     return relationships.map(buildNestedSelect).join(',');

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -123,7 +123,7 @@ export class QueryUtils {
       const baseSelect = relationship.select?.join(',') || '*';
       
       if (!relationship.nestedRelationships?.length) {
-        return `${relationship.table}:${relationship.foreignKey}(${baseSelect})`;
+        return `${relationship.table}!${relationship.foreignKey}(${baseSelect})`;
       }
 
       const nestedSelects = relationship.nestedRelationships.map(nested => 
@@ -133,7 +133,7 @@ export class QueryUtils {
         )
       );
 
-      return `${relationship.table}:${relationship.foreignKey}(${baseSelect},${nestedSelects.join(',')})`;
+      return `${relationship.table}!${relationship.foreignKey}(${baseSelect},${nestedSelects.join(',')})`;
     };
 
     return relationships.map(buildNestedSelect).join(',');

--- a/tests/buildRelationshipQuery.test.ts
+++ b/tests/buildRelationshipQuery.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { BaseAdapter, QueryOptions } from '../src/adapters/base.adapter';
+
+class TestAdapter extends BaseAdapter<any> {
+  public runBuildRelationshipQuery(rel: QueryOptions['relationships'] = []) {
+    return this.buildRelationshipQuery(rel);
+  }
+}
+
+describe('buildRelationshipQuery', () => {
+  it('handles nested relationship objects', () => {
+    const adapter = new TestAdapter();
+    const query = adapter.runBuildRelationshipQuery([
+      {
+        table: 'role_permissions',
+        foreignKey: 'role_id',
+        nestedRelationships: [
+          {
+            table: 'permissions',
+            foreignKey: 'permission_id',
+            select: ['id', 'code']
+          }
+        ]
+      }
+    ]);
+    expect(query).toBe('role_permissions!role_id(*,permissions!permission_id(id,code))');
+  });
+
+  it('handles nested relationship strings', () => {
+    const adapter = new TestAdapter();
+    const query = adapter.runBuildRelationshipQuery([
+      {
+        table: 'role_permissions',
+        foreignKey: 'role_id',
+        nestedRelationships: ['permissions']
+      }
+    ]);
+    expect(query).toBe('role_permissions!role_id(*,permissions!id(*))');
+  });
+});


### PR DESCRIPTION
## Summary
- update relationship query syntax to use `!` instead of `:`
- cover nested relationship strings
- add tests for building relationship queries

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ec42ebac83268586eff3a77c73ba