### PR TITLE
Migrate members to membership_type tables

### DIFF
--- a/src/adapters/member.adapter.ts
+++ b/src/adapters/member.adapter.ts
@@ -47,19 +47,19 @@ export class MemberAdapter
     prayer_requests,
     created_at,
     updated_at,
-    membership_category_id,
-    status_category_id
+    membership_type_id,
+    membership_status_id
   `;
 
   protected defaultRelationships: QueryOptions['relationships'] = [
     {
-      table: 'membership_categories',
-      foreignKey: 'membership_category_id',
+      table: 'membership_type',
+      foreignKey: 'membership_type_id',
       select: ['id', 'name', 'code']
     },
     {
-      table: 'status_categories',
-      foreignKey: 'status_category_id',
+      table: 'membership_status',
+      foreignKey: 'membership_status_id',
       select: ['id', 'name', 'code']
     }
   ];

--- a/src/models/member.model.ts
+++ b/src/models/member.model.ts
@@ -8,8 +8,8 @@ export interface Member extends BaseModel {
   contact_number: string;
   address: string;
   email?: string;
-  membership_category_id: string;
-  status_category_id: string;
+  membership_type_id: string;
+  membership_status_id: string;
   membership_date: string | null;
   birthday: string | null;
   profile_picture_url: string | null;
@@ -28,12 +28,12 @@ export interface Member extends BaseModel {
   last_attendance_date?: string;
   pastoral_notes?: string;
   prayer_requests?: string[];
-  membership_categories?: {
+  membership_type?: {
     id: string;
     name: string;
     code: string;
   };
-  status_categories?: {
+  membership_status?: {
     id: string;
     name: string;
     code: string;

--- a/src/pages/members/MemberAddEdit.tsx
+++ b/src/pages/members/MemberAddEdit.tsx
@@ -100,15 +100,15 @@ function MemberAddEdit() {
     
     try {
       if (id) {
-        await updateMemberMutation.mutateAsync({ 
-          id, 
+        await updateMemberMutation.mutateAsync({
+          id,
           data: formData,
-          fieldsToRemove: ['membership_categories', 'status_categories']
+          fieldsToRemove: ['membership_type', 'membership_status']
         });
       } else {
-        await createMemberMutation.mutateAsync({ 
+        await createMemberMutation.mutateAsync({
           data: formData,
-          fieldsToRemove: ['membership_categories', 'status_categories']
+          fieldsToRemove: ['membership_type', 'membership_status']
         });
       }
       navigate('/members/list');

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -135,19 +135,19 @@ function MemberList() {
       ),
     },
     {
-      field: 'status_categories.name',
+      field: 'membership_status.name',
       headerName: 'Status',
       flex: 1,
       minWidth: 150,
       renderCell: (params) => (
         <div className="space-y-1">
-          <Badge variant={getStatusColor(params.row.status_categories?.code)}>
-            {params.row.status_categories?.name}
+          <Badge variant={getStatusColor(params.row.membership_status?.code)}>
+            {params.row.membership_status?.name}
           </Badge>
         </div>
       ),
-      valueGetter: (params: GridValueGetterParams) => 
-        `${params.row.status_categories?.name}`,
+      valueGetter: (params: GridValueGetterParams) =>
+        `${params.row.membership_status?.name}`,
     },
     {
       field: 'membership_date',

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -144,11 +144,11 @@ function MemberProfile() {
                   </h1>
                   
                   <div className="flex flex-wrap gap-2 mt-2">
-                    {member.membership_categories && (
-                      <Badge variant="secondary">{member.membership_categories.name}</Badge>
+                    {member.membership_type && (
+                      <Badge variant="secondary">{member.membership_type.name}</Badge>
                     )}
-                    {member.status_categories && (
-                      <Badge variant="outline">{member.status_categories.name}</Badge>
+                    {member.membership_status && (
+                      <Badge variant="outline">{member.membership_status.name}</Badge>
                     )}
                     {member.envelope_number && (
                       <Badge variant="outline" className="bg-primary-50 text-primary border-primary-200">

--- a/src/pages/members/tabs/BasicInfoTab.tsx
+++ b/src/pages/members/tabs/BasicInfoTab.tsx
@@ -78,12 +78,12 @@ function BasicInfoTab({ member, onChange, mode = 'view' }: BasicInfoTabProps) {
             <dl className="space-y-4">
               <div>
                 <dt className="text-sm font-medium text-muted-foreground">Membership Type</dt>
-                <dd className="mt-1">{member.membership_categories?.name || 'Not specified'}</dd>
+                <dd className="mt-1">{member.membership_type?.name || 'Not specified'}</dd>
               </div>
               
               <div>
                 <dt className="text-sm font-medium text-muted-foreground">Status</dt>
-                <dd className="mt-1">{member.status_categories?.name || 'Not specified'}</dd>
+                <dd className="mt-1">{member.membership_status?.name || 'Not specified'}</dd>
               </div>
               
               {member.membership_date && (
@@ -179,8 +179,8 @@ function BasicInfoTab({ member, onChange, mode = 'view' }: BasicInfoTabProps) {
           </div>
           <div className="space-y-4">
             <Select
-              value={member.membership_category_id || ''}
-              onValueChange={value => onChange('membership_category_id', value)}
+              value={member.membership_type_id || ''}
+              onValueChange={value => onChange('membership_type_id', value)}
             >
               <SelectTrigger label="Membership Type">
                 <SelectValue placeholder="Select membership type" />
@@ -194,8 +194,8 @@ function BasicInfoTab({ member, onChange, mode = 'view' }: BasicInfoTabProps) {
               </SelectContent>
             </Select>
             <Select
-              value={member.status_category_id || ''}
-              onValueChange={value => onChange('status_category_id', value)}
+              value={member.membership_status_id || ''}
+              onValueChange={value => onChange('membership_status_id', value)}
             >
               <SelectTrigger label="Status">
                 <SelectValue placeholder="Select status" />

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -30,8 +30,8 @@ export interface CategoryDataProvider {
 class SupabaseCategoryDataProvider implements CategoryDataProvider {
   async fetchCategories(tenantId: string, type: CategoryType): Promise<Category[]> {
     const table = {
-      membership: 'membership_categories',
-      member_status: 'status_categories',
+      membership: 'membership_type',
+      member_status: 'membership_status',
       income_transaction: 'income_categories',
       expense_transaction: 'expense_categories',
       budget: 'budget_categories',

--- a/supabase/migrations/20250715010000_update_membership_type_status_columns.sql
+++ b/supabase/migrations/20250715010000_update_membership_type_status_columns.sql
@@ -1,0 +1,69 @@
+-- Add membership_type_id and membership_status_id columns referencing new tables
+ALTER TABLE members
+ADD COLUMN membership_type_id uuid REFERENCES membership_type(id),
+ADD COLUMN membership_status_id uuid REFERENCES membership_status(id);
+
+-- Create indexes for new columns
+CREATE INDEX IF NOT EXISTS idx_members_membership_type ON members(membership_type_id);
+CREATE INDEX IF NOT EXISTS idx_members_membership_status ON members(membership_status_id);
+
+-- Add comments for clarity
+COMMENT ON COLUMN members.membership_type_id IS 'Reference to membership_type table';
+COMMENT ON COLUMN members.membership_status_id IS 'Reference to membership_status table';
+
+-- Migrate existing data from categories
+DO $$
+DECLARE
+  v_tenant_id uuid;
+  v_membership_cat_id uuid;
+  v_status_cat_id uuid;
+  v_type_code text;
+  v_status_code text;
+  v_type_id uuid;
+  v_status_id uuid;
+BEGIN
+  FOR v_tenant_id, v_membership_cat_id, v_status_cat_id IN
+    SELECT DISTINCT tenant_id, membership_category_id, status_category_id
+    FROM members
+    WHERE deleted_at IS NULL
+  LOOP
+    -- Map membership category to membership_type
+    SELECT code INTO v_type_code FROM categories WHERE id = v_membership_cat_id;
+    SELECT id INTO v_type_id
+    FROM membership_type
+    WHERE tenant_id = v_tenant_id
+      AND code = v_type_code
+      AND deleted_at IS NULL;
+    IF v_type_id IS NOT NULL THEN
+      UPDATE members
+      SET membership_type_id = v_type_id
+      WHERE tenant_id = v_tenant_id
+        AND membership_category_id = v_membership_cat_id
+        AND deleted_at IS NULL;
+    END IF;
+
+    -- Map status category to membership_status
+    SELECT code INTO v_status_code FROM categories WHERE id = v_status_cat_id;
+    SELECT id INTO v_status_id
+    FROM membership_status
+    WHERE tenant_id = v_tenant_id
+      AND code = v_status_code
+      AND deleted_at IS NULL;
+    IF v_status_id IS NOT NULL THEN
+      UPDATE members
+      SET membership_status_id = v_status_id
+      WHERE tenant_id = v_tenant_id
+        AND status_category_id = v_status_cat_id
+        AND deleted_at IS NULL;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Drop old indexes
+DROP INDEX IF EXISTS idx_members_membership_category;
+DROP INDEX IF EXISTS idx_members_status_category;
+
+-- Remove old category reference columns
+ALTER TABLE members
+DROP COLUMN membership_category_id,
+DROP COLUMN status_category_id;


### PR DESCRIPTION
## Summary
- add migration to copy membership category values into new membership_type and membership_status columns
- drop old membership category columns and indexes
- update codebase to use new membership_type_id and membership_status_id columns

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c75d61083269c630c8b5b6bd9e0