### PR TITLE
Fix user role updates

### DIFF
--- a/src/pages/admin/users/UserAddEdit.tsx
+++ b/src/pages/admin/users/UserAddEdit.tsx
@@ -78,6 +78,12 @@ const UserAddEdit = () => {
       delete (payload as any).password;
     }
 
+    if (roles && roles.length) {
+      payload.roles = roles
+        .filter(r => formData.roles.includes(r.name))
+        .map(r => r.id);
+    }
+
     try {
       if (id) {
         await updateUserMutation.mutateAsync({ id, data: payload });


### PR DESCRIPTION
## Summary
- pass role IDs when editing users so `manage_user` function updates roles correctly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642072490c8326a7c7e84b1535fdb8