### PR TITLE
Add member profile picture upload

### DIFF
--- a/src/components/ui2/image-input.tsx
+++ b/src/components/ui2/image-input.tsx
@@ -53,6 +53,11 @@ export const ImageInput = React.forwardRef<HTMLInputElement, ImageInputProps>(
   }, ref) => {
     const [preview, setPreview] = useState<string | null>(value || null);
     const [isHovered, setIsHovered] = useState(false);
+
+    // Update preview when value prop changes (e.g. after data load)
+    React.useEffect(() => {
+      setPreview(value || null);
+    }, [value]);
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     const handleClick = () => {

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -8,6 +8,7 @@ import { DataGrid } from '../../components/ui2/mui-datagrid';
 import { Button } from '../../components/ui2/button';
 import { Badge } from '../../components/ui2/badge';
 import { Input } from '../../components/ui2/input';
+import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui2/avatar';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -92,6 +93,24 @@ function MemberList() {
   };
 
   const columns: GridColDef[] = [
+    {
+      field: 'profile_picture_url',
+      headerName: '',
+      width: 80,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <Avatar size="md">
+          {params.value ? (
+            <AvatarImage src={params.value} alt={`${params.row.first_name} ${params.row.last_name}`} />
+          ) : (
+            <AvatarFallback>
+              {params.row.first_name?.charAt(0)}{params.row.last_name?.charAt(0)}
+            </AvatarFallback>
+          )}
+        </Avatar>
+      )
+    },
     {
       field: 'first_name',
       headerName: 'First Name',


### PR DESCRIPTION
## Summary
- refresh ImageInput preview when value changes
- allow uploading and saving member profile pictures
- show member pictures in list view

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864243f0fe08326ab3d71d478b8c3a8