### PR TITLE
Add member profile picture upload

### DIFF
--- a/src/components/ui2/image-input.tsx
+++ b/src/components/ui2/image-input.tsx
@@ -53,6 +53,11 @@ export const ImageInput = React.forwardRef<HTMLInputElement, ImageInputProps>(
   }, ref) => {
     const [preview, setPreview] = useState<string | null>(value || null);
     const [isHovered, setIsHovered] = useState(false);
+
+    // Update preview when value prop changes (e.g. after data load)
+    React.useEffect(() => {
+      setPreview(value || null);
+    }, [value]);
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     const handleClick = () => {

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -8,6 +8,7 @@ import { DataGrid } from '../../components/ui2/mui-datagrid';
 import { Button } from '../../components/ui2/button';
 import { Badge } from '../../components/ui2/badge';
 import { Input } from '../../components/ui2/input';
+import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui2/avatar';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -92,6 +93,24 @@ function MemberList() {
   };
 
   const columns: GridColDef[] = [
+    {
+      field: 'profile_picture_url',
+      headerName: '',
+      width: 80,
+      sortable: false,
+      filterable: false,
+      renderCell: (params) => (
+        <Avatar size="md">
+          {params.value ? (
+            <AvatarImage src={params.value} alt={`${params.row.first_name} ${params.row.last_name}`} />
+          ) : (
+            <AvatarFallback>
+              {params.row.first_name?.charAt(0)}{params.row.last_name?.charAt(0)}
+            </AvatarFallback>
+          )}
+        </Avatar>
+      )
+    },
     {
       field: 'first_name',
       headerName: 'First Name',

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -4,13 +4,13 @@ import { supabase } from '../lib/supabase';
  * Uploads a profile picture for a member
  * @param file The file to upload
  * @param tenantId The tenant ID
- * @param userId The user ID
+ * @param memberId The member ID
  * @returns The public URL of the uploaded file
  */
-export async function uploadProfilePicture(file: File, tenantId: string, userId: string) {
+export async function uploadProfilePicture(file: File, tenantId: string, memberId: string) {
   // Validate parameters
-  if (!tenantId || !userId) {
-    throw new Error('Tenant ID and User ID are required');
+  if (!tenantId || !memberId) {
+    throw new Error('Tenant ID and Member ID are required');
   }
 
   // Validate file type
@@ -25,18 +25,18 @@ export async function uploadProfilePicture(file: File, tenantId: string, userId:
 
   // Generate a unique filename with proper path structure
   const fileExt = file.name.split('.').pop();
-  const fileName = `${tenantId}/${userId}/${Math.random()}.${fileExt}`;
+  const fileName = `${tenantId}/${memberId}/${Math.random()}.${fileExt}`;
 
   try {
     // Delete any existing profile pictures for this user
     const { data: existingFiles } = await supabase.storage
       .from('profiles')
-      .list(`${tenantId}/${userId}`);
+      .list(`${tenantId}/${memberId}`);
 
     if (existingFiles && existingFiles.length > 0) {
       await supabase.storage
         .from('profiles')
-        .remove(existingFiles.map(file => `${tenantId}/${userId}/${file.name}`));
+        .remove(existingFiles.map(file => `${tenantId}/${memberId}/${file.name}`));
     }
 
     // Upload the new file
@@ -64,22 +64,22 @@ export async function uploadProfilePicture(file: File, tenantId: string, userId:
 }
 
 /**
- * Deletes all profile pictures for a user
+ * Deletes all profile pictures for a member
  * @param tenantId The tenant ID
- * @param userId The user ID
+ * @param memberId The member ID
  */
-export async function deleteProfilePicture(tenantId: string, userId: string) {
+export async function deleteProfilePicture(tenantId: string, memberId: string) {
   try {
     // Get list of files in the user's directory
     const { data: files } = await supabase.storage
       .from('profiles')
-      .list(`${tenantId}/${userId}`);
+      .list(`${tenantId}/${memberId}`);
 
     if (files && files.length > 0) {
       // Delete all files in the directory
       const { error } = await supabase.storage
         .from('profiles')
-        .remove(files.map(file => `${tenantId}/${userId}/${file.name}`));
+        .remove(files.map(file => `${tenantId}/${memberId}/${file.name}`));
 
       if (error) throw error;
     }

--- a/supabase/migrations/20250715022000_store_member_profile_pictures.sql
+++ b/supabase/migrations/20250715022000_store_member_profile_pictures.sql
@@ -1,0 +1,47 @@
+-- Adjust profile picture storage policies to allow storing per member
+-- Drop previous policies
+DROP POLICY IF EXISTS "Profile pictures are publicly accessible" ON storage.objects;
+DROP POLICY IF EXISTS "Users can upload profile pictures" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update profile pictures" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete profile pictures" ON storage.objects;
+
+-- Ensure bucket exists
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('profiles', 'profiles', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow anyone in the tenant to access member pictures
+CREATE POLICY "Profile pictures are publicly accessible"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'profiles');
+
+CREATE POLICY "Users can upload profile pictures"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'profiles' AND
+    (storage.foldername(name))[1] IN (
+      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can update profile pictures"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'profiles' AND
+    (storage.foldername(name))[1] IN (
+      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete profile pictures"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'profiles' AND
+    (storage.foldername(name))[1] IN (
+      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+    )
+  );
+


### PR DESCRIPTION
## Summary
- refresh ImageInput preview when value changes
- allow uploading and saving member profile pictures
- show member pictures in list view
- rename storage helper arguments and update path
- adjust database policy so any tenant user can manage member pictures

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864243f0fe08326ab3d71d478b8c3a8