### PR TITLE
Fix ambiguous tenant_id column

### DIFF
--- a/supabase/migrations/20250715022000_store_member_profile_pictures.sql
+++ b/supabase/migrations/20250715022000_store_member_profile_pictures.sql
@@ -21,7 +21,7 @@ CREATE POLICY "Users can upload profile pictures"
   WITH CHECK (
     bucket_id = 'profiles' AND
     (storage.foldername(name))[1] IN (
-      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+      SELECT tu.tenant_id::text FROM tenant_users tu WHERE tu.user_id = auth.uid()
     )
   );
 
@@ -31,7 +31,7 @@ CREATE POLICY "Users can update profile pictures"
   USING (
     bucket_id = 'profiles' AND
     (storage.foldername(name))[1] IN (
-      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+      SELECT tu.tenant_id::text FROM tenant_users tu WHERE tu.user_id = auth.uid()
     )
   );
 
@@ -41,7 +41,7 @@ CREATE POLICY "Users can delete profile pictures"
   USING (
     bucket_id = 'profiles' AND
     (storage.foldername(name))[1] IN (
-      SELECT tenant_id::text FROM tenant_users WHERE user_id = auth.uid()
+      SELECT tu.tenant_id::text FROM tenant_users tu WHERE tu.user_id = auth.uid()
     )
   );
 


### PR DESCRIPTION
## Summary
- fix `store_member_profile_pictures` migration subqueries so tenant_id is fully-qualified

## Testing
- `npm run lint` *(fails: cannot find ESLint package)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68642e4703908326822c3dd0acff0c75