### PR TITLE
Remove profile pictures after member deletion

### DIFF
--- a/src/repositories/member.repository.ts
+++ b/src/repositories/member.repository.ts
@@ -5,6 +5,8 @@ import type { IMemberAdapter } from '../adapters/member.adapter';
 import type { IAccountRepository } from './account.repository';
 import { NotificationService } from '../services/NotificationService';
 import { MemberValidator } from '../validators/member.validator';
+import { deleteProfilePicture } from '../utils/storage';
+import { tenantUtils } from '../utils/tenantUtils';
 
 export interface IMemberRepository extends BaseRepository<Member> {}
 
@@ -62,6 +64,16 @@ export class MemberRepository
   protected override async afterDelete(id: string): Promise<void> {
     // Additional repository-level cleanup after delete
     await this.cleanupRelatedRecords(id);
+
+    // Remove profile picture from storage
+    try {
+      const tenantId = await tenantUtils.getTenantId();
+      if (tenantId) {
+        await deleteProfilePicture(tenantId, id);
+      }
+    } catch (error) {
+      console.error('Failed to delete profile picture:', error);
+    }
   }
 
   // Private helper methods


### PR DESCRIPTION
## Summary
- clean up profile pictures when a member is removed

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6864378f32f4832684c70ab656e488c6