### PR TITLE
Add useFindById hook for member repository

### DIFF
--- a/src/hooks/useBaseRepository.ts
+++ b/src/hooks/useBaseRepository.ts
@@ -26,6 +26,20 @@ export function useBaseRepository<T extends BaseModel>(
     });
   };
 
+  const useFindById = (
+    id: string,
+    options: Omit<QueryOptions, 'pagination'> = {}
+  ) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: [queryKey, id, serializedOptions],
+      queryFn: () => repository.findById(id, options),
+      staleTime: 5 * 60 * 1000, // 5 minutes
+      enabled: (enabled ?? true) && !!id,
+    });
+  };
+
   const useCreate = () => {
     return useMutation({
       mutationFn: ({ data, relations, fieldsToRemove }: 
@@ -82,6 +96,7 @@ export function useBaseRepository<T extends BaseModel>(
 
   return {
     useQuery,
+    useFindById,
     useCreate,
     useUpdate,
     useDelete,

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useMemberRepository } from '../../hooks/useMemberRepository';
 import {
@@ -44,22 +44,12 @@ import NotesTab from './tabs/NotesTab';
 function MemberProfile() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { useQuery, useDelete } = useMemberRepository();
+  const { useFindById, useDelete } = useMemberRepository();
   const [activeTab, setActiveTab] = useState('basic');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   // Fetch member data using repository
-  const { data: result, isLoading, error } = useQuery({
-    filters: {
-      id: {
-        operator: 'eq',
-        value: id
-      }
-    },
-    enabled: !!id
-  });
-
-  const member = result?.data?.[0];
+  const { data: member, isLoading, error } = useFindById(id || '');
 
   // Delete mutation
   const deleteMemberMutation = useDelete();


### PR DESCRIPTION
## Summary
- add `useFindById` helper to `useBaseRepository`
- update MemberProfile to use the new hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643eee66a483269dea3e7e90396a90