### PR TITLE
Use crypto.randomUUID for profile picture naming

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -25,7 +25,7 @@ export async function uploadProfilePicture(file: File, tenantId: string, memberI
 
   // Generate a unique filename with proper path structure
   const fileExt = file.name.split('.').pop();
-  const fileName = `${tenantId}/${memberId}/${Math.random()}.${fileExt}`;
+  const fileName = `${tenantId}/${memberId}/${crypto.randomUUID()}.${fileExt}`;
 
   try {
     // Delete any existing profile pictures for this user


### PR DESCRIPTION
## Summary
- update profile picture file naming to use `crypto.randomUUID`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864411ccd9c832689f59354b9b6741b