### PR TITLE
Fix avatar children

### DIFF
--- a/src/components/ui2/avatar.tsx
+++ b/src/components/ui2/avatar.tsx
@@ -5,9 +5,6 @@ import { cn } from '@/lib/utils';
 import { BaseProps } from './types';
 
 interface AvatarProps extends BaseProps {
-  src?: string;
-  alt?: string;
-  fallback?: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
   shape?: 'circle' | 'square';
 }
@@ -20,7 +17,7 @@ const sizeClasses = {
 };
 
 const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
-  ({ className, src, alt, fallback, size = 'md', shape = 'circle', ...props }, ref) => (
+  ({ className, size = 'md', shape = 'circle', children, ...props }, ref) => (
     <AvatarPrimitive.Root
       ref={ref}
       className={cn(
@@ -31,21 +28,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
       )}
       {...props}
     >
-      <AvatarPrimitive.Image
-        src={src}
-        alt={alt || ''}
-        className="h-full w-full object-cover dark:border-gray-700"
-      />
-      <AvatarPrimitive.Fallback
-        className={cn(
-          'flex h-full w-full items-center justify-center bg-muted dark:bg-gray-700',
-          shape === 'circle' ? 'rounded-full' : 'rounded-lg',
-          'dark:text-gray-200'
-        )}
-        delayMs={600}
-      >
-        {fallback || alt?.charAt(0).toUpperCase() || '?'}
-      </AvatarPrimitive.Fallback>
+      {children}
     </AvatarPrimitive.Root>
   )
 );

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -100,7 +100,6 @@ function MemberList() {
             <AvatarImage
               src={row.original.profile_picture_url}
               alt={`${row.original.first_name} ${row.original.last_name}`}
-              crossOrigin="anonymous"
               onError={(e) => {
                 e.currentTarget.style.display = 'none';
               }}

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -120,7 +120,6 @@ function MemberProfile() {
                 <AvatarImage
                   src={member.profile_picture_url}
                   alt={`${member.first_name} ${member.last_name}`}
-                  crossOrigin="anonymous"
                   onError={(e) => {
                     e.currentTarget.style.display = 'none';
                   }}


### PR DESCRIPTION
## Summary
- fix `<Avatar>` to render children instead of always using internal image/fallback
- remove `crossOrigin` from member avatars to avoid blocked profile images

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644625068883269df1ad1c839df5f2