### PR TITLE
Add recordCount to DataGrid pagination

### DIFF
--- a/src/components/ui2/data-grid-pagination.tsx
+++ b/src/components/ui2/data-grid-pagination.tsx
@@ -3,15 +3,15 @@ import { Pagination } from './pagination';
 import { useDataGrid } from './data-grid/context';
 
 export function DataGridPagination() {
-  const { pageIndex, pageSize, data, handlePageChange, handlePageSizeChange } = useDataGrid<any, any>();
+  const { pageIndex, pageSize, recordCount, handlePageChange, handlePageSizeChange } = useDataGrid<any, any>();
 
   return (
     <Pagination
       currentPage={pageIndex + 1}
-      totalPages={Math.max(1, Math.ceil(data.length / pageSize))}
+      totalPages={Math.max(1, Math.ceil(recordCount / pageSize))}
       onPageChange={(p) => handlePageChange(p - 1)}
       itemsPerPage={pageSize}
-      totalItems={data.length}
+      totalItems={recordCount}
       onItemsPerPageChange={handlePageSizeChange}
       showItemsPerPage
       className="border-t"

--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -20,6 +20,7 @@ import * as XLSX from 'xlsx';
 export interface DataGridProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  recordCount?: number;
   loading?: boolean;
   title?: string;
   description?: string;
@@ -48,6 +49,7 @@ export interface DataGridContextValue<TData, TValue> {
   table: ReturnType<typeof useReactTable<TData>>;
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  recordCount: number;
   loading: boolean;
   rowActions?: (row: TData) => React.ReactNode;
   onRowClick?: (row: TData) => void;
@@ -80,6 +82,7 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
   const {
     columns,
     data,
+    recordCount = data.length,
     loading = false,
     title,
     description,
@@ -277,6 +280,7 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     table,
     columns,
     data,
+    recordCount,
     loading,
     rowActions,
     onRowClick,

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -216,6 +216,7 @@ function MemberList() {
         <div style={{ height: 600, width: '100%' }}>
           <DataGrid<Member>
             data={result?.data || []}
+            recordCount={result?.count ?? 0}
             columns={columns}
             loading={isLoading}
             error={error instanceof Error ? error.message : undefined}


### PR DESCRIPTION
## Summary
- extend `DataGridProps` with `recordCount`
- track `recordCount` in `DataGridProvider`
- use the supplied count when rendering pagination
- pass `recordCount` from `MemberList`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644b0f9a648326aa11b0950536153a