### PR TITLE
Use typed jspdf-autotable

### DIFF
--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -14,7 +14,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { jsPDF } from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 
 export interface DataGridProps<TData, TValue> {
@@ -227,7 +227,7 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
       footStyles: { fillColor: [240, 240, 240], textColor: 0, fontStyle: 'bold' },
     } as any;
 
-    (doc as any).autoTable(tableOptions);
+    autoTable(doc, tableOptions);
     doc.save(`${exportOptions.fileName || 'export'}.pdf`);
   };
 

--- a/src/components/ui2/pdf-renderer.tsx
+++ b/src/components/ui2/pdf-renderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { jsPDF } from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 import { format } from 'date-fns';
 
 interface PDFRendererProps {
@@ -66,7 +66,7 @@ export function PDFRenderer({ title, content, footer, className = '' }: PDFRende
         // Handle table data
         if (section.content.type === PDFTable) {
           const { headers, data } = section.content.props;
-          (doc as any).autoTable({
+          autoTable(doc, {
             head: [headers],
             body: data,
             startY: yPos,
@@ -149,7 +149,7 @@ export function PDFRenderer({ title, content, footer, className = '' }: PDFRende
               }
             }
           });
-          yPos = (doc as any).lastAutoTable.finalY + 15;
+          yPos = doc.lastAutoTable.finalY + 15;
         }
       }
     });

--- a/src/types/jspdf-autotable.d.ts
+++ b/src/types/jspdf-autotable.d.ts
@@ -1,0 +1,17 @@
+declare module 'jspdf-autotable' {
+  import { jsPDF } from 'jspdf';
+
+  export interface UserOptions {
+    head?: any[][];
+    body?: any[][];
+    [key: string]: any;
+  }
+
+  export default function autoTable(doc: jsPDF, options: UserOptions): jsPDF;
+}
+
+declare module 'jspdf' {
+  interface jsPDF {
+    lastAutoTable: { finalY: number };
+  }
+}


### PR DESCRIPTION
## Summary
- import `autoTable` directly from `jspdf-autotable`
- drop unsafe casts when generating PDFs
- add local typings for `jspdf-autotable`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644c2ea7308326a0b9dd4326aeda0d