### PR TITLE
Add DataGrid header utilities

### DIFF
--- a/src/components/ui2/data-grid-column-filter.tsx
+++ b/src/components/ui2/data-grid-column-filter.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Column } from '@tanstack/react-table';
+import { Filter } from 'lucide-react';
+import { Button } from './button';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from './dropdown-menu';
+import { Input } from './input';
+import { cn } from '@/lib/utils';
+import { useDataGrid } from './data-grid/context';
+
+export interface DataGridColumnFilterProps<TData, TValue> {
+  column: Column<TData, TValue>;
+}
+
+export function DataGridColumnFilter<TData, TValue>({ column }: DataGridColumnFilterProps<TData, TValue>) {
+  const {
+    openFilterMenus,
+    setOpenFilterMenus,
+    tempFilters,
+    setTempFilters,
+    handleApplyFilter,
+    handleClearFilter,
+  } = useDataGrid<TData, TValue>();
+
+  return (
+    <DropdownMenu
+      open={openFilterMenus[column.id]}
+      onOpenChange={(open) => {
+        setOpenFilterMenus((prev) => ({ ...prev, [column.id]: open }));
+        if (open) {
+          setTempFilters((prev) => ({
+            ...prev,
+            [column.id]: (column.getFilterValue() as string) ?? '',
+          }));
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-8 w-8 p-0',
+            column.getIsFiltered() && 'text-primary dark:text-primary'
+          )}
+        >
+          <Filter className="h-4 w-4 dark:text-gray-400" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[200px] p-2">
+        <div className="space-y-2">
+          <Input
+            placeholder={`Filter ${column.id}...`}
+            value={tempFilters[column.id] ?? ''}
+            onChange={(e) =>
+              setTempFilters((prev) => ({
+                ...prev,
+                [column.id]: e.target.value,
+              }))
+            }
+            className="h-8"
+          />
+          <div className="flex items-center justify-between space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleClearFilter(column.id)}
+              className="flex-1"
+            >
+              Clear
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => handleApplyFilter(column.id)}
+              className="flex-1"
+            >
+              Apply
+            </Button>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/ui2/data-grid-column-header.tsx
+++ b/src/components/ui2/data-grid-column-header.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { flexRender, Header } from '@tanstack/react-table';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { DataGridColumnFilter } from './data-grid-column-filter';
+
+export interface DataGridColumnHeaderProps<TData, TValue> {
+  header: Header<TData, TValue>;
+}
+
+export function DataGridColumnHeader<TData, TValue>({ header }: DataGridColumnHeaderProps<TData, TValue>) {
+  const column = header.column;
+
+  return (
+    <div className="flex items-center space-x-2">
+      <div
+        className={cn(
+          'flex items-center space-x-2',
+          column.getCanSort() && 'cursor-pointer select-none'
+        )}
+        onClick={column.getToggleSortingHandler()}
+      >
+        {flexRender(column.columnDef.header, header.getContext())}
+        {column.getCanSort() && (
+          <span>
+            {{
+              asc: <ArrowUp className="h-4 w-4 dark:text-gray-300" />,
+              desc: <ArrowDown className="h-4 w-4 dark:text-gray-300" />,
+            }[column.getIsSorted() as string] ?? (
+              <ArrowUpDown className="h-4 w-4 dark:text-gray-400" />
+            )}
+          </span>
+        )}
+      </div>
+      {column.getCanFilter() && <DataGridColumnFilter column={column} />}
+    </div>
+  );
+}

--- a/src/components/ui2/data-grid-table.tsx
+++ b/src/components/ui2/data-grid-table.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { flexRender } from '@tanstack/react-table';
-import { ArrowUpDown, ArrowUp, ArrowDown, Filter, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableFooter } from './table';
-import { Button } from './button';
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from './dropdown-menu';
-import { Input } from './input';
+import { DataGridColumnHeader } from './data-grid-column-header';
 import { cn } from '@/lib/utils';
 import { useDataGrid } from './data-grid/context';
 
@@ -15,12 +13,6 @@ export function DataGridTable() {
     loading,
     rowActions,
     onRowClick,
-    openFilterMenus,
-    setOpenFilterMenus,
-    tempFilters,
-    setTempFilters,
-    handleApplyFilter,
-    handleClearFilter,
   } = useDataGrid<any, any>();
 
   return (
@@ -31,89 +23,7 @@ export function DataGridTable() {
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
                 <TableHead key={header.id}>
-                  {header.isPlaceholder ? null : (
-                    <div className="flex items-center space-x-2">
-                      <div
-                        className={cn(
-                          'flex items-center space-x-2',
-                          header.column.getCanSort() && 'cursor-pointer select-none'
-                        )}
-                        onClick={header.column.getToggleSortingHandler()}
-                      >
-                        {flexRender(header.column.columnDef.header, header.getContext())}
-                        {header.column.getCanSort() && (
-                          <span>
-                            {{
-                              asc: <ArrowUp className="h-4 w-4 dark:text-gray-300" />,
-                              desc: <ArrowDown className="h-4 w-4 dark:text-gray-300" />,
-                            }[header.column.getIsSorted() as string] ?? (
-                              <ArrowUpDown className="h-4 w-4 dark:text-gray-400" />
-                            )}
-                          </span>
-                        )}
-                      </div>
-                      {header.column.getCanFilter() && (
-                        <DropdownMenu
-                          open={openFilterMenus[header.id]}
-                          onOpenChange={(open) => {
-                            setOpenFilterMenus((prev) => ({ ...prev, [header.id]: open }));
-                            if (open) {
-                              setTempFilters((prev) => ({
-                                ...prev,
-                                [header.column.id]: (header.column.getFilterValue() as string) ?? '',
-                              }));
-                            }
-                          }}
-                        >
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className={cn(
-                                'h-8 w-8 p-0',
-                                header.column.getIsFiltered() && 'text-primary dark:text-primary'
-                              )}
-                            >
-                              <Filter className="h-4 w-4 dark:text-gray-400" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" className="w-[200px] p-2">
-                            <div className="space-y-2">
-                              <Input
-                                placeholder={`Filter ${header.column.id}...`}
-                                value={tempFilters[header.column.id] ?? ''}
-                                onChange={(e) =>
-                                  setTempFilters((prev) => ({
-                                    ...prev,
-                                    [header.column.id]: e.target.value,
-                                  }))
-                                }
-                                className="h-8"
-                              />
-                              <div className="flex items-center justify-between space-x-2">
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  onClick={() => handleClearFilter(header.column.id)}
-                                  className="flex-1"
-                                >
-                                  Clear
-                                </Button>
-                                <Button
-                                  variant="default"
-                                  size="sm"
-                                  onClick={() => handleApplyFilter(header.column.id)}
-                                  className="flex-1"
-                                >
-                                  Apply
-                                </Button>
-                              </div>
-                            </div>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                    </div>
-                  )}
+                  {header.isPlaceholder ? null : <DataGridColumnHeader header={header} />}
                 </TableHead>
               ))}
               {rowActions && <TableHead>Actions</TableHead>}


### PR DESCRIPTION
## Summary
- add reusable DataGrid column header and filter components
- simplify DataGrid table to use these new components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644d2fedbc8326b2e7a39c2d97642b