### PR TITLE
Add flexible DataGrid container

### DIFF
--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -43,6 +43,10 @@ export interface DataGridProps<TData, TValue> {
     excel?: boolean;
   };
   quickFilterPlaceholder?: string;
+  /** Optional class name for the internal container */
+  containerClassName?: string;
+  /** Whether the container should take the full width */
+  fluid?: boolean;
 }
 
 export interface DataGridContextValue<TData, TValue> {
@@ -72,6 +76,10 @@ export interface DataGridContextValue<TData, TValue> {
   setGlobalFilter: React.Dispatch<React.SetStateAction<string>>;
   quickFilterPlaceholder?: string;
   className?: string;
+  /** Optional class name for the internal container */
+  containerClassName?: string;
+  /** Whether the container should take the full width */
+  fluid?: boolean;
   handleExportPDF: () => void;
   handleExportExcel: () => void;
 }
@@ -95,6 +103,8 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     onPageSizeChange,
     pagination = { pageSize: 10, pageSizeOptions: [5, 10, 20, 50, 100] },
     className,
+    containerClassName,
+    fluid = false,
     exportOptions = { enabled: true, fileName: 'export', pdf: true, excel: true },
     quickFilterPlaceholder,
   } = props;
@@ -303,6 +313,8 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     setGlobalFilter,
     quickFilterPlaceholder,
     className,
+    containerClassName,
+    fluid,
     handleExportPDF,
     handleExportExcel,
   };

--- a/src/components/ui2/data-grid/index.tsx
+++ b/src/components/ui2/data-grid/index.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Container } from '../container';
 import { Button } from '../button';
 import { Input } from '../input';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from '../dropdown-menu';
@@ -22,10 +21,19 @@ function DataGridContent() {
     setGlobalFilter,
     table,
     className,
+    containerClassName,
+    fluid,
   } = useDataGrid<any, any>();
 
   return (
-    <Container className={cn('space-y-4', className)}>
+    <div
+      className={cn(
+        'space-y-4 w-full',
+        fluid ? '' : 'max-w-screen-xl mx-auto',
+        containerClassName,
+        className
+      )}
+    >
       {(title || description || toolbar || exportOptions.enabled) && (
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           {(title || description) && (
@@ -92,7 +100,7 @@ function DataGridContent() {
 
       <DataGridTable />
       <DataGridPagination />
-    </Container>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- allow DataGrid to control its container
- remove default Container usage so width matches surrounding components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864521b18648326a08a65f31fe6938a