### PR TITLE
Enable column resizing in DataGrid

### DIFF
--- a/src/components/ui2/data-grid-column-header.tsx
+++ b/src/components/ui2/data-grid-column-header.tsx
@@ -12,7 +12,7 @@ export function DataGridColumnHeader<TData, TValue>({ header }: DataGridColumnHe
   const column = header.column;
 
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center space-x-2 relative">
       <div
         className={cn(
           'flex items-center space-x-2',
@@ -33,6 +33,16 @@ export function DataGridColumnHeader<TData, TValue>({ header }: DataGridColumnHe
         )}
       </div>
       {column.getCanFilter() && <DataGridColumnFilter column={column} />}
+      {column.getCanResize() && (
+        <div
+          onMouseDown={header.getResizeHandler()}
+          onTouchStart={header.getResizeHandler()}
+          className={cn(
+            'absolute right-0 top-0 h-full w-2 cursor-col-resize select-none touch-none',
+            header.column.getIsResizing() && 'bg-primary/20'
+          )}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ui2/data-grid-table.tsx
+++ b/src/components/ui2/data-grid-table.tsx
@@ -22,7 +22,11 @@ export function DataGridTable() {
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead
+                  key={header.id}
+                  style={{ width: header.getSize() }}
+                  className="relative"
+                >
                   {header.isPlaceholder ? null : <DataGridColumnHeader header={header} />}
                 </TableHead>
               ))}
@@ -51,7 +55,9 @@ export function DataGridTable() {
                 )}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  <TableCell key={cell.id} style={{ width: cell.column.getSize() }}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
                 ))}
                 {rowActions && (
                   <TableCell>
@@ -75,7 +81,7 @@ export function DataGridTable() {
             {table.getFooterGroups().map((footerGroup) => (
               <TableRow key={footerGroup.id}>
                 {footerGroup.headers.map((header) => (
-                  <TableCell key={header.id}>
+                  <TableCell key={header.id} style={{ width: header.column.getSize() }}>
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.footer, header.getContext())}
                   </TableCell>
                 ))}

--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -4,6 +4,8 @@ import {
   ColumnFiltersState,
   SortingState,
   VisibilityState,
+  ColumnSizingState,
+  ColumnSizingInfoState,
   flexRender,
   getCoreRowModel,
   getFacetedRowModel,
@@ -68,6 +70,10 @@ export interface DataGridContextValue<TData, TValue> {
   pageSizeOptions: number[];
   handlePageChange: (page: number) => void;
   handlePageSizeChange: (size: number) => void;
+  columnSizing: ColumnSizingState;
+  columnSizingInfo: ColumnSizingInfoState;
+  setColumnSizing: React.Dispatch<React.SetStateAction<ColumnSizingState>>;
+  setColumnSizingInfo: React.Dispatch<React.SetStateAction<ColumnSizingInfoState>>;
   title?: string;
   description?: string;
   toolbar?: React.ReactNode;
@@ -112,6 +118,8 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [columnSizing, setColumnSizing] = React.useState<ColumnSizingState>({});
+  const [columnSizingInfo, setColumnSizingInfo] = React.useState<ColumnSizingInfoState>({} as ColumnSizingInfoState);
   const [rowSelection, setRowSelection] = React.useState({});
   const [globalFilter, setGlobalFilter] = React.useState('');
   const [openFilterMenus, setOpenFilterMenus] = React.useState<Record<string, boolean>>({});
@@ -119,6 +127,11 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
   const [pageIndex, setPageIndex] = React.useState(0);
   const [pageSize, setPageSize] = React.useState(pagination.pageSize ?? 10);
   const pageSizeOptions = pagination.pageSizeOptions ?? [5, 10, 20, 50, 100];
+
+  const defaultColumn = React.useMemo(() => ({
+    size: 150,
+    minSize: 40,
+  }), []);
 
   React.useEffect(() => {
     onSortingChange?.(sorting);
@@ -131,14 +144,20 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
   const table = useReactTable({
     data,
     columns,
+    defaultColumn,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
       rowSelection,
       globalFilter,
+      columnSizing,
+      columnSizingInfo,
     },
     enableRowSelection: true,
+    columnResizeMode: 'onChange',
+    onColumnSizingChange: setColumnSizing,
+    onColumnSizingInfoChange: setColumnSizingInfo,
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
@@ -305,6 +324,10 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     pageSizeOptions,
     handlePageChange,
     handlePageSizeChange,
+    columnSizing,
+    columnSizingInfo,
+    setColumnSizing,
+    setColumnSizingInfo,
     title,
     description,
     toolbar,


### PR DESCRIPTION
## Summary
- add column sizing state to DataGrid context
- support column resize mode in react-table
- pass column widths to table header/body/footer
- add draggable resize handle in column header

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_e_68645485e488832689e51eb145fc6a8f