### PR TITLE
Combine profile picture and name columns

### DIFF
--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -91,37 +91,33 @@ function MemberList() {
 
   const columns: ColumnDef<Member>[] = [
     {
-      id: 'profile_picture_url',
-      accessorKey: 'profile_picture_url',
-      header: '',
-      cell: ({ row }) => (
-        <Avatar size="md">
-          {row.original.profile_picture_url && (
-            <AvatarImage
-              src={row.original.profile_picture_url}
-              alt={`${row.original.first_name} ${row.original.last_name}`}
-              crossOrigin="anonymous"
-              onError={(e) => {
-                e.currentTarget.style.display = 'none';
-              }}
-            />
-          )}
-          <AvatarFallback>
-            {row.original.first_name?.charAt(0)}
-            {row.original.last_name?.charAt(0)}
-          </AvatarFallback>
-        </Avatar>
-      ),
-      enableSorting: false,
-      enableColumnFilter: false,
-    },
-    {
+      id: 'first_name',
       accessorKey: 'first_name',
-      header: 'First Name',
-    },
-    {
-      accessorKey: 'last_name',
-      header: 'Last Name',
+      header: 'Name',
+      cell: ({ row }) => (
+        <div className="flex items-center">
+          <Avatar size="md">
+            {row.original.profile_picture_url && (
+              <AvatarImage
+                src={row.original.profile_picture_url}
+                alt={`${row.original.first_name} ${row.original.last_name}`}
+                crossOrigin="anonymous"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none';
+                }}
+              />
+            )}
+            <AvatarFallback>
+              {row.original.first_name?.charAt(0)}
+              {row.original.last_name?.charAt(0)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="ml-2">
+            {row.original.first_name} {row.original.last_name}
+          </span>
+        </div>
+      ),
+      // sorting/filtering behave as before via accessorKey 'first_name'
     },
     {
       accessorKey: 'preferred_name',


### PR DESCRIPTION
## Summary
- streamline member list columns by replacing separate profile picture and name columns with single composite column showing avatar and full name

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645b7890808326a8e423884914e6e9