### PR TITLE
Fix DataGrid header spacing

### DIFF
--- a/src/components/ui2/data-grid-column-header.tsx
+++ b/src/components/ui2/data-grid-column-header.tsx
@@ -22,7 +22,7 @@ export function DataGridColumnHeader<TData, TValue>({ header }: DataGridColumnHe
       >
         {flexRender(column.columnDef.header, header.getContext())}
         {column.getCanSort() && (
-          <span>
+          <span className="ml-2">
             {{
               asc: <ArrowUp className="h-4 w-4 dark:text-gray-300" />,
               desc: <ArrowDown className="h-4 w-4 dark:text-gray-300" />,


### PR DESCRIPTION
## Summary
- add left margin on sort icon so there's more space between column name and the icon

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686460286ea0832696f5bea3a8e2fd00