### PR TITLE
Add weekly giving import page

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -10,6 +10,7 @@ import {
   History,
   Wallet,
   Tag,
+  Upload,
   Shield,
   UserCog,
   Bell,
@@ -124,6 +125,11 @@ export const navigation: NavItem[] = [
             name: 'Donations',
             href: '/finances/giving',
             icon: Heart,
+          },
+          {
+            name: 'Import Weekly Giving',
+            href: '/finances/giving/import',
+            icon: Upload,
           },
           {
             name: 'Expenses',

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -23,6 +23,7 @@ const IncomeExpenseProfile = React.lazy(() => import('./incomeExpense/IncomeExpe
 const CategoryList = React.lazy(() => import('./configuration/CategoryList'));
 const CategoryAddEdit = React.lazy(() => import('./configuration/CategoryAddEdit'));
 const CategoryProfile = React.lazy(() => import('./configuration/CategoryProfile'));
+const WeeklyGivingImport = React.lazy(() => import('./WeeklyGivingImport'));
 
 function LoadingSpinner() {
   return (
@@ -137,6 +138,7 @@ function Finances() {
         <Route path="expenses/:id" element={<IncomeExpenseProfile transactionType="expense" />} />
         <Route path="giving" element={<IncomeExpenseList transactionType="income" />} />
         <Route path="giving/add" element={<IncomeExpenseAddEdit transactionType="income" />} />
+        <Route path="giving/import" element={<WeeklyGivingImport />} />
         <Route path="giving/:id/edit" element={<IncomeExpenseAddEdit transactionType="income" />} />
         <Route path="giving/:id" element={<IncomeExpenseProfile transactionType="income" />} />
         <Route path="reports" element={<Reports />} />

--- a/src/pages/finances/WeeklyGivingImport.tsx
+++ b/src/pages/finances/WeeklyGivingImport.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import * as XLSX from 'xlsx';
+import { Card, CardContent } from '../../components/ui2/card';
+import { Input } from '../../components/ui2/input';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '../../components/ui2/table';
+
+function WeeklyGivingImport() {
+  const [rows, setRows] = React.useState<Record<string, any>[]>([]);
+  const [headers, setHeaders] = React.useState<string[]>([]);
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const data = new Uint8Array(event.target?.result as ArrayBuffer);
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const json: Record<string, any>[] = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+      setRows(json);
+      if (json.length > 0) {
+        setHeaders(Object.keys(json[0]));
+      }
+    };
+    reader.readAsArrayBuffer(file);
+  };
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-foreground">Import Weekly Giving</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Upload an Excel file to import weekly giving records.
+          </p>
+        </div>
+      </div>
+
+      <Input type="file" accept=".xls,.xlsx" onChange={handleFileUpload} />
+
+      {rows.length > 0 && (
+        <Card>
+          <CardContent className="p-0 overflow-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {headers.map((h) => (
+                    <TableHead key={h}>{h}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row, idx) => (
+                  <TableRow key={idx}>
+                    {headers.map((h) => (
+                      <TableCell key={h}>{row[h]}</TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default WeeklyGivingImport;


### PR DESCRIPTION
## Summary
- add WeeklyGivingImport page to parse spreadsheets with xlsx
- wire new route in finances section
- include navigation link under Transaction Center

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68646a38e4bc8326a1585b3dd77d5de8