### PR TITLE
Add DonationImportService

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -27,3 +27,4 @@ export * from './useMessageThreadRepository';
 export * from './useMessageRepository';
 export * from './useMembershipTypeRepository';
 export * from './useMembershipStatusRepository';
+export * from './useDonationImportService';

--- a/src/hooks/useDonationImportService.ts
+++ b/src/hooks/useDonationImportService.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import { DonationImportService, DonationImportRow } from '../services/DonationImportService';
+import { NotificationService } from '../services/NotificationService';
+
+export function useDonationImportService() {
+  const service = container.get<DonationImportService>(TYPES.DonationImportService);
+
+  const mutation = useMutation({
+    mutationFn: (rows: DonationImportRow[]) => service.import(rows),
+    onSuccess: () => {
+      NotificationService.showSuccess('Donations imported successfully');
+    },
+    onError: (error: Error) => {
+      NotificationService.showError(error.message, 5000);
+    },
+  });
+
+  const importDonations = async (rows: DonationImportRow[]) => mutation.mutateAsync(rows);
+
+  return { importDonations, mutation };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -124,6 +124,7 @@ import { MessageThreadRepository, type IMessageThreadRepository } from '../repos
 import { MessageRepository, type IMessageRepository } from '../repositories/message.repository';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { IncomeExpenseTransactionService } from '../services/IncomeExpenseTransactionService';
+import { DonationImportService } from '../services/DonationImportService';
 import { SupabaseErrorLogService, type ErrorLogService } from '../services/ErrorLogService';
 import { SupabaseAnnouncementService, type AnnouncementService } from '../services/AnnouncementService';
 import { SupabaseActivityLogService, type ActivityLogService } from '../services/ActivityLogService';
@@ -243,6 +244,10 @@ container
 container
   .bind<IncomeExpenseTransactionService>(TYPES.IncomeExpenseTransactionService)
   .to(IncomeExpenseTransactionService)
+  .inSingletonScope();
+container
+  .bind<DonationImportService>(TYPES.DonationImportService)
+  .to(DonationImportService)
   .inSingletonScope();
 container
   .bind<ErrorLogService>(TYPES.ErrorLogService)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,5 +53,6 @@ export const TYPES = {
   ErrorLogService: 'ErrorLogService',
   ActivityLogService: 'ActivityLogService',
   IncomeExpenseTransactionService: 'IncomeExpenseTransactionService',
-  AnnouncementService: 'AnnouncementService'
+  AnnouncementService: 'AnnouncementService',
+  DonationImportService: 'DonationImportService'
 };

--- a/src/services/DonationImportService.ts
+++ b/src/services/DonationImportService.ts
@@ -1,0 +1,88 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { ICategoryRepository } from '../repositories/category.repository';
+import type { IFundRepository } from '../repositories/fund.repository';
+import { IncomeExpenseTransactionService, IncomeExpenseEntry } from './IncomeExpenseTransactionService';
+import type { FinancialTransactionHeader } from '../models/financialTransactionHeader.model';
+
+export interface DonationImportRow {
+  tenant_id: string;
+  member_id: string | null;
+  giving_date: string;
+  categories: Record<string, number>;
+}
+
+@injectable()
+export class DonationImportService {
+  constructor(
+    @inject(TYPES.IncomeExpenseTransactionService)
+    private ieService: IncomeExpenseTransactionService,
+    @inject(TYPES.ICategoryRepository)
+    private categoryRepo: ICategoryRepository,
+    @inject(TYPES.IFundRepository)
+    private fundRepo: IFundRepository,
+  ) {}
+
+  private categoryFundMap: Record<string, string> = {
+    tithe: 'TITHES_OFFERINGS',
+    first_fruit_offering: 'TITHES_OFFERINGS',
+    love_offering: 'TITHES_OFFERINGS',
+    mission_offering: 'MISSIONS',
+    mission_pledge: 'MISSIONS',
+    building_offering: 'BUILDING',
+    lot_offering: 'LOT',
+    other_income: 'GENERAL',
+  };
+
+  private async getCategory(tenantId: string, code: string) {
+    const { data } = await this.categoryRepo.find({
+      filters: {
+        type: { operator: 'eq', value: 'income_transaction' },
+        code: { operator: 'eq', value: code },
+        tenant_id: { operator: 'eq', value: tenantId },
+      },
+    });
+    return data?.[0] || null;
+  }
+
+  private async getFund(tenantId: string, code: string) {
+    const { data } = await this.fundRepo.find({
+      filters: { code: { operator: 'eq', value: code }, tenant_id: { operator: 'eq', value: tenantId } },
+    });
+    return data?.[0] || null;
+  }
+
+  public async import(rows: DonationImportRow[]) {
+    for (const row of rows) {
+      for (const [code, amt] of Object.entries(row.categories)) {
+        const amount = Number(amt);
+        if (!amount) continue;
+
+        const category = await this.getCategory(row.tenant_id, code);
+        if (!category) continue;
+
+        const fundCode = this.categoryFundMap[code] || 'GENERAL';
+        const fund = await this.getFund(row.tenant_id, fundCode);
+
+        const header: Partial<FinancialTransactionHeader> = {
+          transaction_date: row.giving_date,
+          description: 'Weekly Giving Import',
+        };
+
+        const entry: IncomeExpenseEntry = {
+          transaction_type: 'income',
+          member_id: row.member_id ?? null,
+          accounts_account_id: null,
+          fund_id: fund?.id ?? null,
+          category_id: category.id,
+          source_id: null,
+          amount,
+          source_account_id: null,
+          category_account_id: category.chart_of_account_id ?? null,
+        };
+
+        await this.ieService.create(header, [entry]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `DonationImportService` to turn imported donations into income transactions
- register the new service in the DI container
- expose `useDonationImportService` hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646cd38ff483269f2bda4285e5459f