### PR TITLE
Fix weekly giving import matching

### DIFF
--- a/src/pages/finances/WeeklyGivingImport.tsx
+++ b/src/pages/finances/WeeklyGivingImport.tsx
@@ -154,9 +154,9 @@ function WeeklyGivingImport() {
     const parsed: ParsedRow[] = [];
     let idx = 0;
     for (const r of fileRows) {
-      const memberName = r.member || r.name || '';
-      const fundName = r.fund || '';
-      const sourceName = r.source || '';
+      const memberName = r['MEMBERS LIST'] || r.member || r.name || '';
+      const fundName = r.fund || 'Default Fund';
+      const sourceName = r.source || 'Offering Box';
 
       for (const cat of categoryHeaders) {
         const amt = parseFloat(r[cat]) || 0;


### PR DESCRIPTION
## Summary
- handle `MEMBERS LIST` column in weekly giving import
- default to `Default Fund` and `Offering Box` when fund or source are missing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c842d6108326a929d76407582e38