### PR TITLE
Implement sticky pagination for data grid

### DIFF
--- a/src/components/ui2/data-grid-pagination.tsx
+++ b/src/components/ui2/data-grid-pagination.tsx
@@ -14,7 +14,7 @@ export function DataGridPagination() {
       totalItems={recordCount}
       onItemsPerPageChange={handlePageSizeChange}
       showItemsPerPage
-      className="border-t"
+      className="border-t sticky bottom-0 bg-background z-10"
       size="sm"
     />
   );

--- a/src/components/ui2/data-grid/index.tsx
+++ b/src/components/ui2/data-grid/index.tsx
@@ -28,7 +28,7 @@ function DataGridContent() {
   return (
     <div
       className={cn(
-        'space-y-4 w-full',
+        'space-y-4 w-full h-full overflow-y-auto',
         fluid ? '' : 'mx-auto',
         containerClassName,
         className


### PR DESCRIPTION
## Summary
- keep pagination visible by making it sticky
- allow vertical scrolling within `DataGridContent`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e2edd9b48326b66b81e8bb660cc9