### PR TITLE
Fix relationships for income expense mappings

### DIFF
--- a/src/adapters/incomeExpenseTransactionMapping.adapter.ts
+++ b/src/adapters/incomeExpenseTransactionMapping.adapter.ts
@@ -32,13 +32,15 @@ export class IncomeExpenseTransactionMappingAdapter
 
   protected defaultRelationships: QueryOptions['relationships'] = [
     {
-      table: 'debit_transaction',
+      table: 'financial_transactions',
       foreignKey: 'debit_transaction_id',
+      alias: 'debit_transaction',
       select: ['id', 'account_id', 'amount', 'debit', 'credit']
     },
     {
-      table: 'credit_transaction',
+      table: 'financial_transactions',
       foreignKey: 'credit_transaction_id',
+      alias: 'credit_transaction',
       select: ['id', 'account_id', 'amount', 'debit', 'credit']
     }
   ];


### PR DESCRIPTION
## Summary
- fix default relationships for `income_expense_transaction_mappings`
- allow aliasing table relationships to avoid duplicate joins

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68650d4af0c883268243ee1d39145a32