### PR TITLE
Implement persistent state for data grids

### DIFF
--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -280,25 +280,26 @@ function AccountList() {
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : (
-              <DataGrid<Account>
-                columns={columns}
-                data={filteredAccounts}
-                totalRows={filteredAccounts.length}
-                loading={isLoading}
-                error={error instanceof Error ? error.message : undefined}
-                onPageChange={handlePageChange}
-                onPageSizeChange={handlePageSizeChange}
-                getRowId={(row) => row.id}
-                onRowClick={(params) => handleRowClick(params)}
-                autoHeight
-                paginationMode="client"
-                disableColumnMenu={false}
-                disableColumnFilter={false}
-                disableColumnSelector={false}
-                disableDensitySelector={false}
-                page={page}
-                pageSize={pageSize}
-                slots={{
+                <DataGrid<Account>
+                  columns={columns}
+                  data={filteredAccounts}
+                  totalRows={filteredAccounts.length}
+                  loading={isLoading}
+                  error={error instanceof Error ? error.message : undefined}
+                  onPageChange={handlePageChange}
+                  onPageSizeChange={handlePageSizeChange}
+                  getRowId={(row) => row.id}
+                  onRowClick={(params) => handleRowClick(params)}
+                  autoHeight
+                  paginationMode="client"
+                  disableColumnMenu={false}
+                  disableColumnFilter={false}
+                  disableColumnSelector={false}
+                  disableDensitySelector={false}
+                  page={page}
+                  pageSize={pageSize}
+                  storageKey="account-list-grid"
+                  slots={{
                   toolbar: () => (
                     <div className="flex justify-between items-center p-4">
                       <h3 className="text-lg font-semibold">Accounts</h3>

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
@@ -562,6 +562,7 @@ function ChartOfAccountProfile() {
               fileName: `account_${account.code}_transactions`,
             }}
             paginationMode="client"
+            storageKey="chart-account-transactions"
             pageSize={10}
             page={0}
             pageSizeOptions={[5, 10, 25, 50, 100]}

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -231,6 +231,7 @@ function FinancialSourceList() {
                 page={page}
                 pageSize={pageSize}
                 showQuickFilter={false}
+                storageKey="financial-source-list-grid"
               />
             )}
           </CardContent>

--- a/src/pages/activity/ActivityList.tsx
+++ b/src/pages/activity/ActivityList.tsx
@@ -56,6 +56,7 @@ function ActivityList() {
             paginationMode="client"
             autoHeight
             getRowId={row => row.id}
+            storageKey="activity-list-grid"
           />
         </CardContent>
       </Card>

--- a/src/pages/admin/configuration/PermissionList.tsx
+++ b/src/pages/admin/configuration/PermissionList.tsx
@@ -97,6 +97,7 @@ function PermissionList() {
                 pageSize={pageSize}
                 autoHeight
                 getRowId={(row) => row.id}
+                storageKey="permission-list-grid"
               />
             )}
           </CardContent>

--- a/src/pages/finances/budgets/BudgetList.tsx
+++ b/src/pages/finances/budgets/BudgetList.tsx
@@ -375,6 +375,7 @@ function BudgetList() {
                 page={page}
                 pageSize={pageSize}
                 paginationMode="client"
+                storageKey="budget-list-grid"
               />
             )}
           </CardContent>

--- a/src/pages/finances/configuration/CategoryList.tsx
+++ b/src/pages/finances/configuration/CategoryList.tsx
@@ -166,6 +166,7 @@ function CategoryList({ categoryType, title, description }: CategoryListProps) {
                 onRowClick={(params) => navigate(`${params.row.id}`)}
                 autoHeight
                 paginationMode="client"
+                storageKey={`category-list-grid-${categoryType}`}
               />
             ) : (
               <div className="flex flex-col items-center justify-center py-8">

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -149,6 +149,7 @@ function FundList() {
                 page={page}
                 pageSize={pageSize}
                 showQuickFilter={false}
+                storageKey="fund-list-grid"
               />
             )}
           </CardContent>

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -151,6 +151,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
               showQuickFilter={false}
               page={page}
               pageSize={pageSize}
+              storageKey="income-expense-list-grid"
             />
           </CardContent>
         </Card>

--- a/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
@@ -143,6 +143,7 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
             }
             autoHeight
             paginationMode="client"
+            storageKey="income-expense-profile-entries"
           />
         </CardContent>
       </Card>

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -497,6 +497,7 @@ function TransactionList() {
             page={page}
             pageSize={pageSize}
             showQuickFilter
+            storageKey="transaction-list-grid"
           />
           </CardContent>
         </Card>

--- a/src/pages/members/configuration/MembershipStatusList.tsx
+++ b/src/pages/members/configuration/MembershipStatusList.tsx
@@ -126,6 +126,7 @@ function MembershipStatusList() {
                 onRowClick={params => navigate(`${params.row.id}`)}
                 autoHeight
                 paginationMode="client"
+                storageKey="membership-status-list-grid"
               />
             ) : (
               <div className="flex flex-col items-center justify-center py-8">

--- a/src/pages/members/configuration/MembershipTypeList.tsx
+++ b/src/pages/members/configuration/MembershipTypeList.tsx
@@ -126,6 +126,7 @@ function MembershipTypeList() {
                 onRowClick={params => navigate(`${params.row.id}`)}
                 autoHeight
                 paginationMode="client"
+                storageKey="membership-type-list-grid"
               />
             ) : (
               <div className="flex flex-col items-center justify-center py-8">

--- a/src/pages/members/family/FamilyRelationships.tsx
+++ b/src/pages/members/family/FamilyRelationships.tsx
@@ -277,6 +277,7 @@ function FamilyRelationships() {
           getRowId={(row) => row.id}
           autoHeight
           paginationMode="client"
+          storageKey="family-relationships-grid"
           disableColumnMenu={false}
           disableColumnFilter={false}
           disableColumnSelector={false}


### PR DESCRIPTION
## Summary
- persist filtering, sorting, and pagination in `DataGrid` via localStorage
- add similar persistence to `mui-datagrid`
- enable caching on various grid pages with unique storage keys

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651607add4832699f2bb2d32161927