### PR TITLE
Enhance date range picker

### DIFF
--- a/src/components/ui2/date-range-picker-field.tsx
+++ b/src/components/ui2/date-range-picker-field.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import { format } from 'date-fns';
-import { Calendar as CalendarIcon, X } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { DateRange, DateRangePicker } from './date-range-picker';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { DateRange, DateRangePicker, DateRangePreset } from './date-range-picker';
 import { FormFieldProps } from './types';
 
 export interface DateRangePickerFieldProps extends FormFieldProps {
@@ -13,6 +11,7 @@ export interface DateRangePickerFieldProps extends FormFieldProps {
   disabled?: boolean;
   clearable?: boolean;
   showCompactInput?: boolean;
+  presets?: DateRangePreset[];
 }
 
 export function DateRangePickerField({
@@ -23,6 +22,7 @@ export function DateRangePickerField({
   disabled = false,
   clearable = true,
   showCompactInput = false,
+  presets,
   label,
   required,
   error,
@@ -37,6 +37,7 @@ export function DateRangePickerField({
       disabled={disabled}
       clearable={clearable}
       showCompactInput={showCompactInput}
+      presets={presets}
       icon={<CalendarIcon className="h-4 w-4" />}
       label={label}
       required={required}

--- a/src/components/ui2/date-range-picker.tsx
+++ b/src/components/ui2/date-range-picker.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { format, isValid, startOfDay, endOfDay, isBefore, isAfter, addDays } from 'date-fns';
+import {
+  format,
+  isValid,
+  startOfDay,
+  endOfDay,
+  isBefore,
+  isAfter,
+  addDays,
+} from 'date-fns';
 import { Calendar as CalendarIcon, ChevronDown, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from './button';
@@ -120,6 +128,28 @@ export function DateRangePicker({
         };
       },
     },
+    {
+      name: 'thisYear',
+      label: 'This Year',
+      range: () => {
+        const year = new Date().getFullYear();
+        return {
+          from: new Date(year, 0, 1),
+          to: new Date(year, 11, 31),
+        };
+      },
+    },
+    {
+      name: 'lastYear',
+      label: 'Last Year',
+      range: () => {
+        const year = new Date().getFullYear() - 1;
+        return {
+          from: new Date(year, 0, 1),
+          to: new Date(year, 11, 31),
+        };
+      },
+    },
   ];
 
   const finalPresets = presets || defaultPresets;
@@ -131,6 +161,7 @@ export function DateRangePicker({
 
   const handlePresetSelect = (preset: DateRangePreset) => {
     onChange(preset.range());
+    setOpen(false);
   };
 
   const handleSelect = (day: Date) => {
@@ -239,6 +270,9 @@ export function DateRangePicker({
             <div className="p-2 sm:p-3">
               <Calendar
                 mode="range"
+                captionLayout="dropdown-buttons"
+                fromYear={1900}
+                toYear={new Date().getFullYear() + 10}
                 selected={{
                   from: value.from,
                   to: value.to,


### PR DESCRIPTION
## Summary
- allow preset configuration in `DateRangePickerField`
- add year-based presets and improve preset behavior
- add month/year dropdown navigation to the calendar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686517ec59448326a793ec829b058247