### PR TITLE
Sync DataGrid pagination state on mount

### DIFF
--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -169,6 +169,17 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
 
   React.useEffect(() => {
     if (!storageKey) return;
+    if (savedState?.pageIndex !== undefined) {
+      onPageChange?.(savedState.pageIndex);
+    }
+    if (savedState?.pageSize !== undefined) {
+      onPageSizeChange?.(savedState.pageSize);
+    }
+    // run once on mount to sync pagination state
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => {
+    if (!storageKey) return;
     const saved = getData(`${storageKey}-columnSizing`);
     if (saved && typeof saved === 'object') {
       setColumnSizing(saved as ColumnSizingState);


### PR DESCRIPTION
## Summary
- ensure DataGridProvider notifies pagination handlers when restoring from cache

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68651d6d6f5883269075793cd3bf036d