### PR TITLE
Unify pagination state key

### DIFF
--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -51,8 +51,10 @@ export interface DataGridProps<TData, TValue> {
   /** Whether the container should take the full width */
   fluid?: boolean;
   /**
-   * Optional key used to store column sizing in localStorage.
-   * Provide a unique value per page to scope the cache.
+   * Optional key used to persist column sizing and table state in localStorage.
+   * Provide a unique value per page to scope the cache. Stored state includes
+   * pagination (`page`, `pageSize`), sorting, filters, column visibility and
+   * global filter.
    */
   storageKey?: string;
 }
@@ -131,18 +133,24 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
 
   const exportOptions = { ...defaultExportOptions, ...providedExportOptions };
 
+  /**
+   * Shape of the state persisted in localStorage under `${storageKey}-state`.
+   * The `page` property stores the current zero-based page index.
+   */
   type PersistedState = {
     sorting: SortingState;
     columnFilters: ColumnFiltersState;
     columnVisibility: VisibilityState;
-    pageIndex: number;
+    page: number;
     pageSize: number;
     globalFilter: string;
   };
 
   const savedState = React.useMemo(() => {
     if (!storageKey) return undefined;
-    return getData(`${storageKey}-state`) as Partial<PersistedState> | undefined;
+    return getData(`${storageKey}-state`) as (Partial<PersistedState> & {
+      pageIndex?: number;
+    }) | undefined;
   }, [storageKey]);
 
   const [sorting, setSorting] = React.useState<SortingState>(savedState?.sorting ?? []);
@@ -158,7 +166,9 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
   const [globalFilter, setGlobalFilter] = React.useState(savedState?.globalFilter ?? '');
   const [openFilterMenus, setOpenFilterMenus] = React.useState<Record<string, boolean>>({});
   const [tempFilters, setTempFilters] = React.useState<Record<string, string>>({});
-  const [pageIndex, setPageIndex] = React.useState(savedState?.pageIndex ?? 0);
+  const [pageIndex, setPageIndex] = React.useState(
+    savedState?.page ?? savedState?.pageIndex ?? 0
+  );
   const [pageSize, setPageSize] = React.useState(savedState?.pageSize ?? pagination.pageSize ?? 10);
   const pageSizeOptions = pagination.pageSizeOptions ?? [5, 10, 20, 50, 100];
 
@@ -195,7 +205,7 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
       sorting,
       columnFilters,
       columnVisibility,
-      pageIndex,
+      page: pageIndex,
       pageSize,
       globalFilter,
     };

--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -31,7 +31,8 @@ export interface DataGridProps<T> extends Omit<MuiDataGridProps<T>, 'rows'> {
   paginationMode?: 'client' | 'server';
   showQuickFilter?: boolean;
   /**
-   * Optional key to persist pagination and sorting state in localStorage
+   * Optional key to persist pagination and sorting state in localStorage.
+   * Stored values include `page`, `pageSize`, `sortModel` and `filterModel`.
    */
   storageKey?: string;
 }
@@ -152,6 +153,9 @@ export function DataGrid<T>({
     []
   );
 
+  // Cached pagination, sorting and filtering state stored under
+  // `${storageKey}-state`. Supports the legacy `pageIndex` key for
+  // backward compatibility.
   const initialCache = React.useMemo(() => {
     if (!storageKey) return undefined;
     return getData(`${storageKey}-state`) as any;
@@ -178,8 +182,10 @@ export function DataGrid<T>({
   React.useEffect(() => {
     if (!initialCache) return;
     const saved = initialCache;
-    if (onPageChange && saved.page !== undefined && saved.page !== page) {
-      onPageChange(saved.page);
+    const savedPage =
+      saved.page !== undefined ? saved.page : saved.pageIndex;
+    if (onPageChange && savedPage !== undefined && savedPage !== page) {
+      onPageChange(savedPage);
     }
     if (onPageSizeChange && saved.pageSize !== undefined && saved.pageSize !== pageSize) {
       onPageSizeChange(saved.pageSize);
@@ -253,7 +259,12 @@ export function DataGrid<T>({
           ...(error ? { errorOverlay: { message: error } } : {}),
         }}
         initialState={initialCache ? {
-          pagination: { paginationModel: { page: initialCache.page ?? page, pageSize: initialCache.pageSize ?? pageSize } },
+          pagination: {
+            paginationModel: {
+              page: (initialCache.page ?? initialCache.pageIndex) ?? page,
+              pageSize: initialCache.pageSize ?? pageSize,
+            },
+          },
           sorting: { sortModel: initialCache.sortModel ?? [] },
           filter: initialCache.filterModel ? { filterModel: initialCache.filterModel } : undefined,
         } : undefined}


### PR DESCRIPTION
## Summary
- store pagination page index using `page`
- support legacy `pageIndex` when reading cached grid state
- document exact keys stored with `storageKey`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651d718b08832683407b00df453652