### PR TITLE
Fix localStorage access when window is undefined

### DIFF
--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,6 +1,10 @@
 const getData = (key: string): unknown | undefined => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return undefined;
+  }
+
   try {
-    const data = localStorage.getItem(key);
+    const data = window.localStorage.getItem(key);
 
     if (data) {
       return JSON.parse(data);
@@ -11,8 +15,12 @@ const getData = (key: string): unknown | undefined => {
 };
 
 const setData = (key: string, value: unknown): void => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    window.localStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
     console.error('Save in local storage', error);
   }


### PR DESCRIPTION
## Summary
- guard `getData` and `setData` against missing `window.localStorage`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651d8bc2e08326b1538fb285eebdea