### PR TITLE
Fix repository query key

### DIFF
--- a/src/lib/repository/repository.ts
+++ b/src/lib/repository/repository.ts
@@ -123,10 +123,11 @@ export class Repository<T extends Entity> {
   }
 
   public useQuery(options: QueryOptions = {}) {
-    const queryClient = useQueryClient();
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
 
     return useQuery({
-      queryKey: [this.config.tableName, options],
+      queryKey: [this.config.tableName, serializedOptions],
       queryFn: async (): Promise<QueryResult<T>> => {
         try {
           // Use queryUtils to fetch data
@@ -136,7 +137,7 @@ export class Repository<T extends Entity> {
               select: this.config.defaultSelect,
               relationships: this.config.defaultRelationships,
               order: this.config.defaultOrder,
-              ...options
+              ...rest
             }
           );
 
@@ -153,7 +154,7 @@ export class Repository<T extends Entity> {
       },
       staleTime: this.options.staleTime,
       cacheTime: this.options.cacheTime,
-      enabled: options.enabled !== false,
+      enabled: enabled !== false,
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure Repository `useQuery` uses a stable query key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651d487a0083268d930b7bd2610aec