### PR TITLE
Fix table initialization order

### DIFF
--- a/src/components/ui2/data-grid/context.tsx
+++ b/src/components/ui2/data-grid/context.tsx
@@ -202,14 +202,6 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     setData(`${storageKey}-state`, state);
   }, [storageKey, sorting, columnFilters, columnVisibility, pageIndex, pageSize, globalFilter]);
 
-  React.useEffect(() => {
-    table.setPageIndex(pageIndex);
-  }, [table, pageIndex]);
-
-  React.useEffect(() => {
-    table.setPageSize(pageSize);
-  }, [table, pageSize]);
-
   const table = useReactTable({
     data,
     columns,
@@ -239,6 +231,14 @@ export function DataGridProvider<TData, TValue>({ children, ...props }: DataGrid
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
+
+  React.useEffect(() => {
+    table.setPageIndex(pageIndex);
+  }, [table, pageIndex]);
+
+  React.useEffect(() => {
+    table.setPageSize(pageSize);
+  }, [table, pageSize]);
 
   const handleApplyFilter = (columnId: string) => {
     const filterValue = tempFilters[columnId];


### PR DESCRIPTION
## Summary
- fix initialization order so `table` is defined before using it

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686529f4f7848326ab687ca045009608