### PR TITLE
Add modular financial reports page

### DIFF
--- a/src/hooks/useFinancialReports.ts
+++ b/src/hooks/useFinancialReports.ts
@@ -1,0 +1,204 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabase';
+import { useMessageStore } from '../components/MessageHandler';
+
+interface QueryOptions {
+  enabled?: boolean;
+}
+
+export function useFinancialReports(tenantId: string | null) {
+  const { addMessage } = useMessageStore();
+
+  const fetchReport = async (
+    rpc: string,
+    params: Record<string, any>
+  ) => {
+    const { data, error } = await supabase.rpc(rpc, params);
+    if (error) {
+      console.error(`Error fetching ${rpc}:`, error);
+      addMessage({ type: 'error', text: `Failed to generate ${rpc.replace(/_/g,' ')}`, duration: 5000 });
+      throw error;
+    }
+    return data || [];
+  };
+
+  const useTrialBalance = (endDate: string, options?: QueryOptions) =>
+    useQuery({
+      queryKey: ['trial-balance', tenantId, endDate],
+      queryFn: () => fetchReport('report_trial_balance', { tenant_id: tenantId, end_date: endDate }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useGeneralLedger = (
+    startDate: string,
+    endDate: string,
+    accountId?: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['general-ledger', tenantId, startDate, endDate, accountId],
+      queryFn: () =>
+        fetchReport('report_general_ledger', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+          account_id: accountId,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useJournalReport = (
+    startDate: string,
+    endDate: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['journal-report', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_journal', { tenant_id: tenantId, start_date: startDate, end_date: endDate }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useIncomeStatement = (
+    startDate: string,
+    endDate: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['income-statement', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_income_statement', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useBudgetVsActual = (
+    startDate: string,
+    endDate: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['budget-vs-actual', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_budget_vs_actual', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useFundSummary = (startDate: string, endDate: string, options?: QueryOptions) =>
+    useQuery({
+      queryKey: ['fund-summary', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_fund_summary', { tenant_id: tenantId, start_date: startDate, end_date: endDate }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useMemberGivingSummary = (
+    startDate: string,
+    endDate: string,
+    memberId?: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['member-giving-summary', tenantId, startDate, endDate, memberId],
+      queryFn: () =>
+        fetchReport('report_member_giving_summary', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+          member_id: memberId,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useGivingStatement = (
+    startDate: string,
+    endDate: string,
+    memberId: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['giving-statement', tenantId, startDate, endDate, memberId],
+      queryFn: () =>
+        fetchReport('report_giving_statement', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+          member_id: memberId,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useOfferingSummary = (startDate: string, endDate: string, options?: QueryOptions) =>
+    useQuery({
+      queryKey: ['offering-summary', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_offering_summary', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useCategoryFinancialReport = (
+    startDate: string,
+    endDate: string,
+    categoryId?: string,
+    options?: QueryOptions
+  ) =>
+    useQuery({
+      queryKey: ['category-financial-report', tenantId, startDate, endDate, categoryId],
+      queryFn: () =>
+        fetchReport('report_category_financial', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+          category_id: categoryId,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  const useCashFlowSummary = (startDate: string, endDate: string, options?: QueryOptions) =>
+    useQuery({
+      queryKey: ['cash-flow-summary', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_cash_flow_summary', {
+          tenant_id: tenantId,
+          start_date: startDate,
+          end_date: endDate,
+        }),
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
+  return {
+    useTrialBalance,
+    useGeneralLedger,
+    useJournalReport,
+    useIncomeStatement,
+    useBudgetVsActual,
+    useFundSummary,
+    useMemberGivingSummary,
+    useGivingStatement,
+    useOfferingSummary,
+    useCategoryFinancialReport,
+    useCashFlowSummary,
+  };
+}

--- a/src/pages/finances/Finances.tsx
+++ b/src/pages/finances/Finances.tsx
@@ -16,6 +16,7 @@ const FundList = React.lazy(() => import('./funds/FundList'));
 const FundAddEdit = React.lazy(() => import('./funds/FundAddEdit'));
 const FundProfile = React.lazy(() => import('./funds/FundProfile'));
 const Reports = React.lazy(() => import('./Reports'));
+const FinancialReportsPage = React.lazy(() => import('./FinancialReportsPage'));
 const Statements = React.lazy(() => import('./Statements'));
 const IncomeExpenseList = React.lazy(() => import('./incomeExpense/IncomeExpenseList'));
 const IncomeExpenseAddEdit = React.lazy(() => import('./incomeExpense/IncomeExpenseAddEdit'));
@@ -142,6 +143,7 @@ function Finances() {
         <Route path="giving/:id/edit" element={<IncomeExpenseAddEdit transactionType="income" />} />
         <Route path="giving/:id" element={<IncomeExpenseProfile transactionType="income" />} />
         <Route path="reports" element={<Reports />} />
+        <Route path="financial-reports" element={<FinancialReportsPage />} />
         <Route path="statements" element={<Statements />} />
       </Routes>
     </Suspense>

--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -1,0 +1,202 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { startCase } from 'lodash-es';
+import { format } from 'date-fns';
+import { Card, CardContent, CardHeader } from '../../components/ui2/card';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '../../components/ui2/select';
+import { DateRangePickerField } from '../../components/ui2/date-range-picker-field';
+import { Input } from '../../components/ui2/input';
+import { DataGrid } from '../../components/ui2/data-grid';
+import { Button } from '../../components/ui2/button';
+import { Loader2, Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../hooks/useFinancialReports';
+import { tenantUtils } from '../../utils/tenantUtils';
+import { usePermissions } from '../../hooks/usePermissions';
+
+interface RecordData {
+  [key: string]: any;
+}
+
+const reportOptions = [
+  { id: 'trial-balance', label: 'Trial Balance' },
+  { id: 'general-ledger', label: 'General Ledger' },
+  { id: 'journal', label: 'Journal Report' },
+  { id: 'income-statement', label: 'Income Statement' },
+  { id: 'budget-vs-actual', label: 'Budget vs Actual' },
+  { id: 'fund-summary', label: 'Fund Summary' },
+  { id: 'member-giving', label: 'Member Giving Summary' },
+  { id: 'giving-statement', label: 'Giving Statement' },
+  { id: 'offering-summary', label: 'Offering Summary' },
+  { id: 'category-financial', label: 'Category Based Report' },
+  { id: 'cash-flow', label: 'Cash Flow Summary' }
+];
+
+function FinancialReportsPage() {
+  const [tenantId, setTenantId] = useState<string | null>(null);
+  const [reportType, setReportType] = useState('trial-balance');
+  const [dateRange, setDateRange] = useState({ from: new Date(), to: new Date() });
+  const [memberId, setMemberId] = useState('');
+  const [fundId, setFundId] = useState('');
+  const [accountId, setAccountId] = useState('');
+  const [categoryId, setCategoryId] = useState('');
+
+  const { isAdmin } = usePermissions();
+
+  useEffect(() => {
+    tenantUtils.getTenantId().then(id => setTenantId(id));
+  }, []);
+
+  const {
+    useTrialBalance,
+    useGeneralLedger,
+    useJournalReport,
+    useIncomeStatement,
+    useBudgetVsActual,
+    useFundSummary,
+    useMemberGivingSummary,
+    useGivingStatement,
+    useOfferingSummary,
+    useCategoryFinancialReport,
+    useCashFlowSummary,
+  } = useFinancialReports(tenantId);
+
+  const trialBalanceQuery = useTrialBalance(format(dateRange.to, 'yyyy-MM-dd'), { enabled: reportType === 'trial-balance' });
+  const generalLedgerQuery = useGeneralLedger(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    accountId || undefined,
+    { enabled: reportType === 'general-ledger' }
+  );
+  const journalQuery = useJournalReport(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'journal' }
+  );
+  const incomeStatementQuery = useIncomeStatement(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'income-statement' }
+  );
+  const budgetQuery = useBudgetVsActual(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'budget-vs-actual' }
+  );
+  const fundSummaryQuery = useFundSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'fund-summary' }
+  );
+  const memberGivingQuery = useMemberGivingSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    memberId || undefined,
+    { enabled: reportType === 'member-giving' }
+  );
+  const givingStatementQuery = useGivingStatement(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    memberId,
+    { enabled: reportType === 'giving-statement' }
+  );
+  const offeringSummaryQuery = useOfferingSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'offering-summary' }
+  );
+  const categoryReportQuery = useCategoryFinancialReport(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    categoryId || undefined,
+    { enabled: reportType === 'category-financial' }
+  );
+  const cashFlowQuery = useCashFlowSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    { enabled: reportType === 'cash-flow' }
+  );
+
+  const activeQuery =
+    trialBalanceQuery ?? generalLedgerQuery ?? journalQuery ?? incomeStatementQuery ?? budgetQuery ?? fundSummaryQuery ?? memberGivingQuery ?? givingStatementQuery ?? offeringSummaryQuery ?? categoryReportQuery ?? cashFlowQuery;
+
+  const { data, isLoading } = activeQuery;
+
+  const columns = useMemo(() => {
+    if (!data || !Array.isArray(data) || data.length === 0) return [];
+    const keys = Object.keys(data[0] as RecordData);
+    return keys.map(key => ({ accessorKey: key, header: startCase(key) }));
+  }, [data]);
+
+  const handlePrint = () => window.print();
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Financial Reports</h1>
+          <p className="text-muted-foreground">Generate and export financial reports.</p>
+        </div>
+        <div className="flex space-x-2">
+          <Button variant="outline" onClick={handlePrint} className="flex items-center">
+            <Printer className="h-4 w-4 mr-2" />
+            Print
+          </Button>
+          <Button variant="outline" onClick={() => window.dispatchEvent(new Event('download-pdf'))} className="flex items-center">
+            <Download className="h-4 w-4 mr-2" />
+            PDF
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col sm:flex-row sm:items-end gap-4">
+          <Select value={reportType} onValueChange={setReportType}>
+            <SelectTrigger label="Report Type" className="max-w-xs">
+              <SelectValue placeholder="Select report" />
+            </SelectTrigger>
+            <SelectContent>
+              {reportOptions.map(opt => (
+                <SelectItem key={opt.id} value={opt.id}>{opt.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DateRangePickerField
+            value={dateRange}
+            onChange={setDateRange}
+            label="Date Range"
+            showCompactInput
+          />
+          {['general-ledger'].includes(reportType) && (
+            <Input value={accountId} onChange={e => setAccountId(e.target.value)} label="Account ID" className="max-w-xs" />
+          )}
+          {['member-giving', 'giving-statement'].includes(reportType) && (
+            <Input value={memberId} onChange={e => setMemberId(e.target.value)} label="Member ID" className="max-w-xs" />
+          )}
+          {['fund-summary'].includes(reportType) && (
+            <Input value={fundId} onChange={e => setFundId(e.target.value)} label="Fund ID" className="max-w-xs" />
+          )}
+          {['category-financial'].includes(reportType) && (
+            <Input value={categoryId} onChange={e => setCategoryId(e.target.value)} label="Category" className="max-w-xs" />
+          )}
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+          ) : data && Array.isArray(data) && data.length > 0 ? (
+            <DataGrid
+              data={data}
+              columns={columns}
+              title={reportOptions.find(r => r.id === reportType)?.label}
+              exportOptions={{ enabled: true, excel: true, pdf: true, fileName: reportType }}
+            />
+          ) : (
+            <div className="py-8 text-center text-muted-foreground">No data available.</div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default FinancialReportsPage;


### PR DESCRIPTION
## Summary
- add hook for requesting various financial reports
- implement `FinancialReportsPage` with dynamic filters and exports
- register route in Finances module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686532411a9c8326bbfdc4ed8ac513b3