### PR TITLE
Add Handlebars + Puppeteer report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ dependencies run:
 npm install && npm run test
 ```
 
+## Generating PDF reports
+
+The project includes a small utility for rendering financial reports using
+[Handlebars](https://handlebarsjs.com/) templates and
+[Puppeteer](https://pptr.dev/) to generate a PDF.
+
+Create a data file in JSON format and run:
+
+```bash
+npm run generate-report -- <data.json> <output.pdf>
+```
+
+This will compile `templates/financial-report.hbs` with your data and save the
+resulting PDF to the specified location.
+
 ## Changelog
 
 - Dates are now stored and parsed using local `yyyy-MM-dd` format instead of ISO strings.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "generate-report": "node scripts/generate-report.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -68,7 +69,9 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7",
     "xlsx": "^0.18.5",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "handlebars": "^4.7.8",
+    "puppeteer": "^21.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/scripts/generate-report.js
+++ b/scripts/generate-report.js
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import handlebars from 'handlebars';
+import puppeteer from 'puppeteer';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+handlebars.registerHelper('sum', (items) => {
+  return items.reduce((acc, cur) => acc + (Number(cur.amount) || 0), 0);
+});
+
+async function main() {
+  const [dataFile, outputFile] = process.argv.slice(2);
+  if (!dataFile || !outputFile) {
+    console.error('Usage: ts-node generate-report.ts <data.json> <output.pdf>');
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(dataFile, 'utf-8'));
+  const templatePath = path.join(__dirname, '../templates/financial-report.hbs');
+  const template = handlebars.compile(fs.readFileSync(templatePath, 'utf-8'));
+  const html = template(data);
+
+  const browser = await puppeteer.launch({
+    headless: 'new',
+  });
+  const page = await browser.newPage();
+  await page.setContent(html, { waitUntil: 'networkidle0' });
+  await page.pdf({ path: outputFile, format: 'A4' });
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/templates/financial-report.hbs
+++ b/templates/financial-report.hbs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{title}}</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+    th { background: #f0f0f0; }
+    tfoot td { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>{{title}}</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Description</th>
+        <th>Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each transactions}}
+      <tr>
+        <td>{{this.date}}</td>
+        <td>{{this.description}}</td>
+        <td>{{this.amount}}</td>
+      </tr>
+      {{/each}}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="2">Total</td>
+        <td>{{sum transactions}}</td>
+      </tr>
+    </tfoot>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate Handlebars and Puppeteer dependencies
- add a simple script to generate PDF reports
- provide default Handlebars template
- document PDF report generation in README

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865432d34648326a8fb8f2e621ad3c1