### PR TITLE
Add PDFKit export for financial reports

### DIFF
--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -128,6 +128,33 @@ function FinancialReportsPage() {
 
   const handlePrint = () => window.print();
 
+  const exportPdfWithPdfKit = async () => {
+    if (!data || !Array.isArray(data)) return;
+    try {
+      const response = await fetch('/functions/generate-financial-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: reportOptions.find(r => r.id === reportType)?.label,
+          transactions: data,
+        }),
+      });
+
+      if (!response.ok) throw new Error('Failed to generate PDF');
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${reportType}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Error exporting PDF:', error);
+    }
+  };
+
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8 space-y-6">
       <div className="flex justify-between items-center">
@@ -140,7 +167,7 @@ function FinancialReportsPage() {
             <Printer className="h-4 w-4 mr-2" />
             Print
           </Button>
-          <Button variant="outline" onClick={() => window.dispatchEvent(new Event('download-pdf'))} className="flex items-center">
+          <Button variant="outline" onClick={exportPdfWithPdfKit} className="flex items-center">
             <Download className="h-4 w-4 mr-2" />
             PDF
           </Button>
@@ -188,7 +215,7 @@ function FinancialReportsPage() {
               data={data}
               columns={columns}
               title={reportOptions.find(r => r.id === reportType)?.label}
-              exportOptions={{ enabled: true, excel: true, pdf: true, fileName: reportType }}
+              exportOptions={{ enabled: true, excel: true, pdf: false, fileName: reportType }}
             />
           ) : (
             <div className="py-8 text-center text-muted-foreground">No data available.</div>


### PR DESCRIPTION
## Summary
- enable PDF export with PDFKit for financial reports page
- disable built-in jsPDF export in DataGrid when using PDFKit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654d943354832681a3a90f370401ad