### PR TITLE
Update PDF export workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The JSON file should contain a `title` and a `transactions` array with `date`,
 `description` and `amount` fields. The generated PDF will list each transaction
 and show the total amount at the bottom.
 
+The `FinancialReportsPage` component now posts report data to a serverless
+function at `/functions/generate-financial-report` when you click the **PDF**
+button. The function generates the PDF using PDFKit and returns it for download.
+
 ## Changelog
 
 - Dates are now stored and parsed using local `yyyy-MM-dd` format instead of ISO strings.

--- a/src/components/ui2/data-grid/index.tsx
+++ b/src/components/ui2/data-grid/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button } from '../button';
 import { Input } from '../input';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuCheckboxItem } from '../dropdown-menu';
-import { Settings2, FileText, FileSpreadsheet } from 'lucide-react';
+import { Settings2, FileSpreadsheet } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DataGridProvider, DataGridProps, useDataGrid } from './context';
 import { DataGridTable } from '../data-grid-table';
@@ -15,7 +15,6 @@ function DataGridContent() {
     toolbar,
     exportOptions,
     handleExportExcel,
-    handleExportPDF,
     quickFilterPlaceholder,
     globalFilter,
     setGlobalFilter,
@@ -68,12 +67,6 @@ function DataGridContent() {
                   <Button variant="outline" size="sm" onClick={handleExportExcel} className="flex items-center space-x-2">
                     <FileSpreadsheet className="h-4 w-4" />
                     <span>Excel</span>
-                  </Button>
-                )}
-                {exportOptions.pdf && (
-                  <Button variant="outline" size="sm" onClick={handleExportPDF} className="flex items-center space-x-2">
-                    <FileText className="h-4 w-4" />
-                    <span>PDF</span>
                   </Button>
                 )}
               </div>

--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -215,7 +215,7 @@ function FinancialReportsPage() {
               data={data}
               columns={columns}
               title={reportOptions.find(r => r.id === reportType)?.label}
-              exportOptions={{ enabled: true, excel: true, pdf: false, fileName: reportType }}
+              exportOptions={{ enabled: true, excel: true, fileName: reportType }}
             />
           ) : (
             <div className="py-8 text-center text-muted-foreground">No data available.</div>


### PR DESCRIPTION
## Summary
- document FinancialReportsPage changes in README
- remove DataGrid PDF export implementation
- drop PDF export button
- update export options in FinancialReportsPage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68654ecd2490832696c4d5ad82f7a789