### PR TITLE
Fix CORS for Supabase functions

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -4,7 +4,8 @@ import Stripe from 'https://esm.sh/stripe@13.10.0';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type, x-application-name',
 };
 
 interface RequestBody {

--- a/supabase/functions/email-service/index.ts
+++ b/supabase/functions/email-service/index.ts
@@ -2,7 +2,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type, x-application-name',
 };
 
 interface EmailRequest {

--- a/supabase/functions/generate-financial-report/index.ts
+++ b/supabase/functions/generate-financial-report/index.ts
@@ -4,7 +4,8 @@ import { Buffer } from 'node:buffer';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type, x-application-name',
 };
 
 interface Transaction {


### PR DESCRIPTION
## Summary
- allow custom `x-application-name` header when calling Supabase Edge Functions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655c8c4e448326b0c6c552dee59470