### PR TITLE
Fix report query selection

### DIFF
--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -116,8 +116,44 @@ function FinancialReportsPage() {
     { enabled: reportType === 'cash-flow' }
   );
 
-  const activeQuery =
-    trialBalanceQuery ?? generalLedgerQuery ?? journalQuery ?? incomeStatementQuery ?? budgetQuery ?? fundSummaryQuery ?? memberGivingQuery ?? givingStatementQuery ?? offeringSummaryQuery ?? categoryReportQuery ?? cashFlowQuery;
+  let activeQuery;
+  switch (reportType) {
+    case 'trial-balance':
+      activeQuery = trialBalanceQuery;
+      break;
+    case 'general-ledger':
+      activeQuery = generalLedgerQuery;
+      break;
+    case 'journal':
+      activeQuery = journalQuery;
+      break;
+    case 'income-statement':
+      activeQuery = incomeStatementQuery;
+      break;
+    case 'budget-vs-actual':
+      activeQuery = budgetQuery;
+      break;
+    case 'fund-summary':
+      activeQuery = fundSummaryQuery;
+      break;
+    case 'member-giving':
+      activeQuery = memberGivingQuery;
+      break;
+    case 'giving-statement':
+      activeQuery = givingStatementQuery;
+      break;
+    case 'offering-summary':
+      activeQuery = offeringSummaryQuery;
+      break;
+    case 'category-financial':
+      activeQuery = categoryReportQuery;
+      break;
+    case 'cash-flow':
+      activeQuery = cashFlowQuery;
+      break;
+    default:
+      activeQuery = trialBalanceQuery;
+  }
 
   const { data, isLoading } = activeQuery;
 


### PR DESCRIPTION
## Summary
- use switch block to choose query for each financial report

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657a5e8b6c8326a2a4940ab678d2c7