### PR TITLE
Refactor financial reports into modular components

### DIFF
--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -1,21 +1,21 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { startCase } from 'lodash-es';
-import { format } from 'date-fns';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader } from '../../components/ui2/card';
-import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '../../components/ui2/select';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from ../../components/ui2/select';
 import { DateRangePickerField } from '../../components/ui2/date-range-picker-field';
 import { Input } from '../../components/ui2/input';
-import { DataGrid } from '../../components/ui2/data-grid';
-import { Button } from '../../components/ui2/button';
-import { Loader2, Printer, Download } from 'lucide-react';
-import { useFinancialReports } from '../../hooks/useFinancialReports';
 import { tenantUtils } from '../../utils/tenantUtils';
-import { usePermissions } from '../../hooks/usePermissions';
-import { PDFDocument, StandardFonts } from 'pdf-lib';
 
-interface RecordData {
-  [key: string]: any;
-}
+import TrialBalanceReport from './financialReports/TrialBalanceReport';
+import GeneralLedgerReport from './financialReports/GeneralLedgerReport';
+import JournalReport from './financialReports/JournalReport';
+import IncomeStatementReport from './financialReports/IncomeStatementReport';
+import BudgetVsActualReport from './financialReports/BudgetVsActualReport';
+import FundSummaryReport from './financialReports/FundSummaryReport';
+import MemberGivingSummaryReport from './financialReports/MemberGivingSummaryReport';
+import GivingStatementReport from './financialReports/GivingStatementReport';
+import OfferingSummaryReport from './financialReports/OfferingSummaryReport';
+import CategoryFinancialReport from './financialReports/CategoryFinancialReport';
+import CashFlowSummaryReport from './financialReports/CashFlowSummaryReport';
 
 const reportOptions = [
   { id: 'trial-balance', label: 'Trial Balance' },
@@ -28,219 +28,28 @@ const reportOptions = [
   { id: 'giving-statement', label: 'Giving Statement' },
   { id: 'offering-summary', label: 'Offering Summary' },
   { id: 'category-financial', label: 'Category Based Report' },
-  { id: 'cash-flow', label: 'Cash Flow Summary' }
+  { id: 'cash-flow', label: 'Cash Flow Summary' },
 ];
 
 function FinancialReportsPage() {
   const [tenantId, setTenantId] = useState<string | null>(null);
-  const [reportType, setReportType] = useState('trial-balance');
+  const [reportType, setReportType] = useState(reportOptions[0].id);
   const [dateRange, setDateRange] = useState({ from: new Date(), to: new Date() });
   const [memberId, setMemberId] = useState('');
   const [fundId, setFundId] = useState('');
   const [accountId, setAccountId] = useState('');
   const [categoryId, setCategoryId] = useState('');
 
-  const { isAdmin } = usePermissions();
 
   useEffect(() => {
     tenantUtils.getTenantId().then(id => setTenantId(id));
   }, []);
 
-  const {
-    useTrialBalance,
-    useGeneralLedger,
-    useJournalReport,
-    useIncomeStatement,
-    useBudgetVsActual,
-    useFundSummary,
-    useMemberGivingSummary,
-    useGivingStatement,
-    useOfferingSummary,
-    useCategoryFinancialReport,
-    useCashFlowSummary,
-  } = useFinancialReports(tenantId);
-
-  const trialBalanceQuery = useTrialBalance(format(dateRange.to, 'yyyy-MM-dd'), { enabled: reportType === 'trial-balance' });
-  const generalLedgerQuery = useGeneralLedger(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    accountId || undefined,
-    { enabled: reportType === 'general-ledger' }
-  );
-  const journalQuery = useJournalReport(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'journal' }
-  );
-  const incomeStatementQuery = useIncomeStatement(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'income-statement' }
-  );
-  const budgetQuery = useBudgetVsActual(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'budget-vs-actual' }
-  );
-  const fundSummaryQuery = useFundSummary(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'fund-summary' }
-  );
-  const memberGivingQuery = useMemberGivingSummary(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    memberId || undefined,
-    { enabled: reportType === 'member-giving' }
-  );
-  const givingStatementQuery = useGivingStatement(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    memberId,
-    { enabled: reportType === 'giving-statement' }
-  );
-  const offeringSummaryQuery = useOfferingSummary(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'offering-summary' }
-  );
-  const categoryReportQuery = useCategoryFinancialReport(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    categoryId || undefined,
-    { enabled: reportType === 'category-financial' }
-  );
-  const cashFlowQuery = useCashFlowSummary(
-    format(dateRange.from, 'yyyy-MM-dd'),
-    format(dateRange.to, 'yyyy-MM-dd'),
-    { enabled: reportType === 'cash-flow' }
-  );
-
-  let activeQuery;
-  switch (reportType) {
-    case 'trial-balance':
-      activeQuery = trialBalanceQuery;
-      break;
-    case 'general-ledger':
-      activeQuery = generalLedgerQuery;
-      break;
-    case 'journal':
-      activeQuery = journalQuery;
-      break;
-    case 'income-statement':
-      activeQuery = incomeStatementQuery;
-      break;
-    case 'budget-vs-actual':
-      activeQuery = budgetQuery;
-      break;
-    case 'fund-summary':
-      activeQuery = fundSummaryQuery;
-      break;
-    case 'member-giving':
-      activeQuery = memberGivingQuery;
-      break;
-    case 'giving-statement':
-      activeQuery = givingStatementQuery;
-      break;
-    case 'offering-summary':
-      activeQuery = offeringSummaryQuery;
-      break;
-    case 'category-financial':
-      activeQuery = categoryReportQuery;
-      break;
-    case 'cash-flow':
-      activeQuery = cashFlowQuery;
-      break;
-    default:
-      activeQuery = trialBalanceQuery;
-  }
-
-  const { data, isLoading } = activeQuery;
-
-  const columns = useMemo(() => {
-    if (!data || !Array.isArray(data) || data.length === 0) return [];
-    const keys = Object.keys(data[0] as RecordData);
-    return keys.map(key => ({ accessorKey: key, header: startCase(key) }));
-  }, [data]);
-
-  const handlePrint = () => window.print();
-
-  const exportPdfWithPdfLib = async () => {
-    if (!data || !Array.isArray(data) || data.length === 0) return;
-
-    const pdfDoc = await PDFDocument.create();
-    const page = pdfDoc.addPage();
-    const { width, height } = page.getSize();
-    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
-
-    const title = reportOptions.find(r => r.id === reportType)?.label || 'Financial Report';
-
-    let y = height - 40;
-    page.drawText(title, { x: 40, y, size: 18, font });
-    y -= 24;
-
-    const keys = Object.keys(data[0] as RecordData);
-    const columnWidth = (width - 80) / keys.length;
-
-    keys.forEach((key, index) => {
-      page.drawText(startCase(key), { x: 40 + index * columnWidth, y, size: 12, font });
-    });
-    y -= 16;
-
-    (data as RecordData[]).forEach(rec => {
-      keys.forEach((key, index) => {
-        page.drawText(String(rec[key] ?? ''), {
-          x: 40 + index * columnWidth,
-          y,
-          font,
-          size: 12,
-        });
-      });
-      y -= 16;
-    });
-
-    if (keys.includes('amount')) {
-      const total = (data as RecordData[]).reduce(
-        (acc, cur) => acc + (Number(cur.amount) || 0),
-        0,
-      );
-      y -= 8;
-      const amountIndex = keys.indexOf('amount');
-      page.drawText(`Total: ${total}`, {
-        x: 40 + amountIndex * columnWidth,
-        y,
-        size: 12,
-        font,
-      });
-    }
-
-    const pdfBytes = await pdfDoc.save();
-    const blob = new Blob([pdfBytes], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${reportType}.pdf`;
-    link.click();
-    URL.revokeObjectURL(url);
-  };
-
   return (
     <div className="w-full px-4 sm:px-6 lg:px-8 space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-semibold text-foreground">Financial Reports</h1>
-          <p className="text-muted-foreground">Generate and export financial reports.</p>
-        </div>
-        <div className="flex space-x-2">
-          <Button variant="outline" onClick={handlePrint} className="flex items-center">
-            <Printer className="h-4 w-4 mr-2" />
-            Print
-          </Button>
-          <Button variant="outline" onClick={exportPdfWithPdfLib} className="flex items-center">
-            <Download className="h-4 w-4 mr-2" />
-            PDF
-          </Button>
-        </div>
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">Financial Reports</h1>
+        <p className="text-muted-foreground">Generate and export financial reports.</p>
       </div>
 
       <Card>
@@ -275,19 +84,38 @@ function FinancialReportsPage() {
           )}
         </CardHeader>
         <CardContent>
-          {isLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-8 w-8 animate-spin text-primary" />
-            </div>
-          ) : data && Array.isArray(data) && data.length > 0 ? (
-            <DataGrid
-              data={data}
-              columns={columns}
-              title={reportOptions.find(r => r.id === reportType)?.label}
-              exportOptions={{ enabled: true, excel: true, pdf: false, fileName: reportType }}
-            />
-          ) : (
-            <div className="py-8 text-center text-muted-foreground">No data available.</div>
+          {reportType === 'trial-balance' && (
+            <TrialBalanceReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'general-ledger' && (
+            <GeneralLedgerReport tenantId={tenantId} dateRange={dateRange} accountId={accountId} />
+          )}
+          {reportType === 'journal' && (
+            <JournalReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'income-statement' && (
+            <IncomeStatementReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'budget-vs-actual' && (
+            <BudgetVsActualReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'fund-summary' && (
+            <FundSummaryReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'member-giving' && (
+            <MemberGivingSummaryReport tenantId={tenantId} dateRange={dateRange} memberId={memberId} />
+          )}
+          {reportType === 'giving-statement' && (
+            <GivingStatementReport tenantId={tenantId} dateRange={dateRange} memberId={memberId} />
+          )}
+          {reportType === 'offering-summary' && (
+            <OfferingSummaryReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'category-financial' && (
+            <CategoryFinancialReport tenantId={tenantId} dateRange={dateRange} categoryId={categoryId} />
+          )}
+          {reportType === 'cash-flow' && (
+            <CashFlowSummaryReport tenantId={tenantId} dateRange={dateRange} />
           )}
         </CardContent>
       </Card>

--- a/src/pages/finances/financialReports/BudgetVsActualReport.tsx
+++ b/src/pages/finances/financialReports/BudgetVsActualReport.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function BudgetVsActualReport({ tenantId, dateRange }: Props) {
+  const { useBudgetVsActual } = useFinancialReports(tenantId);
+  const { data, isLoading } = useBudgetVsActual(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'budget_name', header: 'Budget' },
+      { accessorKey: 'budget_amount', header: 'Budgeted' },
+      { accessorKey: 'actual_amount', header: 'Actual' },
+      { accessorKey: 'variance', header: 'Variance' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Budget vs Actual', fileName: 'budget-vs-actual' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'budget-vs-actual' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/CashFlowSummaryReport.tsx
+++ b/src/pages/finances/financialReports/CashFlowSummaryReport.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function CashFlowSummaryReport({ tenantId, dateRange }: Props) {
+  const { useCashFlowSummary } = useFinancialReports(tenantId);
+  const { data, isLoading } = useCashFlowSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'month', header: 'Month' },
+      { accessorKey: 'inflow', header: 'Inflow' },
+      { accessorKey: 'outflow', header: 'Outflow' },
+      { accessorKey: 'net_change', header: 'Net Change' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Cash Flow Summary', fileName: 'cash-flow' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'cash-flow' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/CategoryFinancialReport.tsx
+++ b/src/pages/finances/financialReports/CategoryFinancialReport.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+  categoryId?: string;
+}
+
+export default function CategoryFinancialReport({ tenantId, dateRange, categoryId }: Props) {
+  const { useCategoryFinancialReport } = useFinancialReports(tenantId);
+  const { data, isLoading } = useCategoryFinancialReport(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    categoryId || undefined,
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'category_name', header: 'Category' },
+      { accessorKey: 'income', header: 'Income' },
+      { accessorKey: 'expenses', header: 'Expenses' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Category Financial', fileName: 'category-financial' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'category-financial' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/FundSummaryReport.tsx
+++ b/src/pages/finances/financialReports/FundSummaryReport.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function FundSummaryReport({ tenantId, dateRange }: Props) {
+  const { useFundSummary } = useFinancialReports(tenantId);
+  const { data, isLoading } = useFundSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'fund_name', header: 'Fund' },
+      { accessorKey: 'income', header: 'Income' },
+      { accessorKey: 'expenses', header: 'Expenses' },
+      { accessorKey: 'net_change', header: 'Net Change' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Fund Summary', fileName: 'fund-summary' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'fund-summary' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/GeneralLedgerReport.tsx
+++ b/src/pages/finances/financialReports/GeneralLedgerReport.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+  accountId?: string;
+}
+
+export default function GeneralLedgerReport({ tenantId, dateRange, accountId }: Props) {
+  const { useGeneralLedger } = useFinancialReports(tenantId);
+  const { data, isLoading } = useGeneralLedger(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    accountId || undefined,
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'entry_date', header: 'Date' },
+      { accessorKey: 'account_id', header: 'Account' },
+      { accessorKey: 'description', header: 'Description' },
+      { accessorKey: 'debit', header: 'Debit' },
+      { accessorKey: 'credit', header: 'Credit' },
+      { accessorKey: 'running_balance', header: 'Balance' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'General Ledger', fileName: 'general-ledger' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'general-ledger' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/GivingStatementReport.tsx
+++ b/src/pages/finances/financialReports/GivingStatementReport.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+  memberId: string;
+}
+
+export default function GivingStatementReport({ tenantId, dateRange, memberId }: Props) {
+  const { useGivingStatement } = useFinancialReports(tenantId);
+  const { data, isLoading } = useGivingStatement(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    memberId,
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'entry_date', header: 'Date' },
+      { accessorKey: 'fund_name', header: 'Fund' },
+      { accessorKey: 'amount', header: 'Amount' },
+      { accessorKey: 'description', header: 'Description' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Giving Statement', fileName: 'giving-statement' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'giving-statement' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/IncomeStatementReport.tsx
+++ b/src/pages/finances/financialReports/IncomeStatementReport.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function IncomeStatementReport({ tenantId, dateRange }: Props) {
+  const { useIncomeStatement } = useFinancialReports(tenantId);
+  const { data, isLoading } = useIncomeStatement(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'account_code', header: 'Account Code' },
+      { accessorKey: 'account_name', header: 'Account Name' },
+      { accessorKey: 'account_type', header: 'Account Type' },
+      { accessorKey: 'amount', header: 'Amount' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Income Statement', fileName: 'income-statement' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'income-statement' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/JournalReport.tsx
+++ b/src/pages/finances/financialReports/JournalReport.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function JournalReport({ tenantId, dateRange }: Props) {
+  const { useJournalReport } = useFinancialReports(tenantId);
+  const { data, isLoading } = useJournalReport(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'entry_date', header: 'Date' },
+      { accessorKey: 'account_code', header: 'Account Code' },
+      { accessorKey: 'account_name', header: 'Account Name' },
+      { accessorKey: 'description', header: 'Description' },
+      { accessorKey: 'debit', header: 'Debit' },
+      { accessorKey: 'credit', header: 'Credit' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Journal Report', fileName: 'journal' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'journal' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/MemberGivingSummaryReport.tsx
+++ b/src/pages/finances/financialReports/MemberGivingSummaryReport.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+  memberId?: string;
+}
+
+export default function MemberGivingSummaryReport({ tenantId, dateRange, memberId }: Props) {
+  const { useMemberGivingSummary } = useFinancialReports(tenantId);
+  const { data, isLoading } = useMemberGivingSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+    memberId || undefined,
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'first_name', header: 'First Name' },
+      { accessorKey: 'last_name', header: 'Last Name' },
+      { accessorKey: 'total_amount', header: 'Total Amount' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Member Giving Summary', fileName: 'member-giving' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'member-giving' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/OfferingSummaryReport.tsx
+++ b/src/pages/finances/financialReports/OfferingSummaryReport.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function OfferingSummaryReport({ tenantId, dateRange }: Props) {
+  const { useOfferingSummary } = useFinancialReports(tenantId);
+  const { data, isLoading } = useOfferingSummary(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'category_name', header: 'Category' },
+      { accessorKey: 'total_amount', header: 'Total Amount' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Offering Summary', fileName: 'offering-summary' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'offering-summary' }}
+      />
+    </div>
+  );
+}

--- a/src/pages/finances/financialReports/TrialBalanceReport.tsx
+++ b/src/pages/finances/financialReports/TrialBalanceReport.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { exportReportPdf } from '../../../utils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function TrialBalanceReport({ tenantId, dateRange }: Props) {
+  const { useTrialBalance } = useFinancialReports(tenantId);
+  const { data, isLoading } = useTrialBalance(format(dateRange.to, 'yyyy-MM-dd'));
+
+  const columns = React.useMemo<ColumnDef<any>[]>(
+    () => [
+      { accessorKey: 'account_code', header: 'Account Code' },
+      { accessorKey: 'account_name', header: 'Account Name' },
+      { accessorKey: 'account_type', header: 'Account Type' },
+      { accessorKey: 'debit_balance', header: 'Debit' },
+      { accessorKey: 'credit_balance', header: 'Credit' },
+    ],
+    [],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = () =>
+    exportReportPdf(data, { title: 'Trial Balance', fileName: 'trial-balance' });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid
+        data={data || []}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'trial-balance' }}
+      />
+    </div>
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './queryErrorHandler';
 export * from './storage';
 export * from './supabaseErrorHandler';
 export * from './accounting';
+export * from './reportPdf';

--- a/src/utils/reportPdf.ts
+++ b/src/utils/reportPdf.ts
@@ -1,0 +1,64 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { startCase } from 'lodash-es';
+
+export interface PdfOptions {
+  title: string;
+  fileName: string;
+}
+
+export async function exportReportPdf(
+  data: Record<string, any>[] | undefined,
+  { title, fileName }: PdfOptions,
+) {
+  if (!data || data.length === 0) return;
+
+  const pdfDoc = await PDFDocument.create();
+  const page = pdfDoc.addPage();
+  const { width, height } = page.getSize();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  let y = height - 40;
+  page.drawText(title, { x: 40, y, size: 18, font });
+  y -= 24;
+
+  const keys = Object.keys(data[0]);
+  const columnWidth = (width - 80) / keys.length;
+
+  keys.forEach((key, index) => {
+    page.drawText(startCase(key), { x: 40 + index * columnWidth, y, size: 12, font });
+  });
+  y -= 16;
+
+  data.forEach(rec => {
+    keys.forEach((key, index) => {
+      page.drawText(String(rec[key] ?? ''), {
+        x: 40 + index * columnWidth,
+        y,
+        font,
+        size: 12,
+      });
+    });
+    y -= 16;
+  });
+
+  if (keys.includes('amount')) {
+    const total = data.reduce((acc, cur) => acc + (Number(cur.amount) || 0), 0);
+    y -= 8;
+    const amountIndex = keys.indexOf('amount');
+    page.drawText(`Total: ${total}`, {
+      x: 40 + amountIndex * columnWidth,
+      y,
+      size: 12,
+      font,
+    });
+  }
+
+  const pdfBytes = await pdfDoc.save();
+  const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${fileName}.pdf`;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add `exportReportPdf` helper for generating PDFs
- split financial reports into individual components under `financialReports/`
- refactor `FinancialReportsPage` to render selected report component
- export `reportPdf` util in `utils/index.ts`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657b399bc8832690720469c280c548