### PR TITLE
Fix PDF export currency formatting

### DIFF
--- a/src/utils/reportPdf.ts
+++ b/src/utils/reportPdf.ts
@@ -98,7 +98,12 @@ export async function exportReportPdf(
   for (const rec of data) {
     const cellLines = columns.map(col => {
       let value = rec[col.key];
-      if (['debit', 'credit', 'amount'].includes(col.key)) {
+      const key = col.key.toLowerCase();
+      const header = col.header.toLowerCase();
+      if (
+        ['debit', 'credit', 'amount'].includes(key) ||
+        ['debit', 'credit', 'amount'].includes(header)
+      ) {
         value = formatCurrency(Number(value) || 0, currency);
       }
       return splitTextIntoLines(String(value ?? ''), font, 12, columnWidth - 2);


### PR DESCRIPTION
## Summary
- improve `exportReportPdf` currency detection logic so headers labeled **Amount**, **Debit**, or **Credit** are formatted with `formatCurrency`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865847c0f008326bd071af817bda55f