### PR TITLE
Update general ledger view

### DIFF
--- a/src/pages/finances/financialReports/GeneralLedgerReport.tsx
+++ b/src/pages/finances/financialReports/GeneralLedgerReport.tsx
@@ -24,7 +24,8 @@ export default function GeneralLedgerReport({ tenantId, dateRange, accountId }: 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
       { accessorKey: 'entry_date', header: 'Date' },
-      { accessorKey: 'account_id', header: 'Account' },
+      { accessorKey: 'account_code', header: 'Account Code' },
+      { accessorKey: 'account_name', header: 'Account Name' },
       { accessorKey: 'description', header: 'Description' },
       { accessorKey: 'debit', header: 'Debit' },
       { accessorKey: 'credit', header: 'Credit' },

--- a/supabase/migrations/20250716000000_update_general_ledger.sql
+++ b/supabase/migrations/20250716000000_update_general_ledger.sql
@@ -1,0 +1,47 @@
+-- Update general ledger report to return account details
+
+CREATE OR REPLACE FUNCTION report_general_ledger(
+  p_tenant_id uuid,
+  p_start_date date,
+  p_end_date date,
+  p_account_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  entry_date date,
+  account_code text,
+  account_name text,
+  description text,
+  debit numeric,
+  credit numeric,
+  running_balance numeric
+)
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT check_tenant_access(p_tenant_id) THEN
+    RAISE EXCEPTION 'Permission denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    ft.date,
+    coa.code,
+    coa.name,
+    ft.description,
+    ft.debit,
+    ft.credit,
+    SUM(ft.debit - ft.credit) OVER (ORDER BY ft.date, ft.id) AS running_balance
+  FROM financial_transactions ft
+  JOIN chart_of_accounts coa ON ft.account_id = coa.id
+  WHERE ft.tenant_id = p_tenant_id
+    AND ft.date BETWEEN p_start_date AND p_end_date
+    AND (p_account_id IS NULL OR ft.account_id = p_account_id)
+  ORDER BY ft.date, ft.id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION report_general_ledger(uuid, date, date, uuid) TO authenticated;
+COMMENT ON FUNCTION report_general_ledger(uuid, date, date, uuid) IS
+  'Detailed ledger entries for a tenant within a date range';


### PR DESCRIPTION
## Summary
- update `report_general_ledger` to join chart of accounts
- expose code and name instead of account UUID
- show account code and name in GeneralLedgerReport

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659e368950832688ad81cad8b3f6f2