### PR TITLE
Remove fund_id from fund summary report

### DIFF
--- a/src/hooks/useFinancialReports.ts
+++ b/src/hooks/useFinancialReports.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../lib/supabase';
 import { useMessageStore } from '../components/MessageHandler';
+import { FundSummary } from '../models/financialReport.model';
 
 interface QueryOptions {
   enabled?: boolean;
@@ -105,14 +106,14 @@ export function useFinancialReports(tenantId: string | null) {
     });
 
   const useFundSummary = (startDate: string, endDate: string, options?: QueryOptions) =>
-    useQuery({
+    useQuery<FundSummary[]>({
       queryKey: ['fund-summary', tenantId, startDate, endDate],
       queryFn: () =>
         fetchReport('report_fund_summary', {
           p_tenant_id: tenantId,
           p_start_date: startDate,
           p_end_date: endDate,
-        }),
+        }) as Promise<FundSummary[]>,
       enabled: !!tenantId && (options?.enabled ?? true),
       staleTime: 5 * 60 * 1000,
     });

--- a/src/models/financialReport.model.ts
+++ b/src/models/financialReport.model.ts
@@ -1,0 +1,6 @@
+export interface FundSummary {
+  fund_name: string;
+  income: number;
+  expenses: number;
+  net_change: number;
+}

--- a/src/pages/finances/financialReports/FundSummaryReport.tsx
+++ b/src/pages/finances/financialReports/FundSummaryReport.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../../components/ui2/button';
 import { Printer, Download } from 'lucide-react';
 import { useFinancialReports } from '../../../hooks/useFinancialReports';
 import { exportReportPdf } from '../../../utils';
+import { FundSummary } from '../../../models/financialReport.model';
 
 interface Props {
   tenantId: string | null;
@@ -19,7 +20,7 @@ export default function FundSummaryReport({ tenantId, dateRange }: Props) {
     format(dateRange.to, 'yyyy-MM-dd'),
   );
 
-  const columns = React.useMemo<ColumnDef<any>[]>(
+  const columns = React.useMemo<ColumnDef<FundSummary>[]>(
     () => [
       { accessorKey: 'fund_name', header: 'Fund' },
       { accessorKey: 'income', header: 'Income' },
@@ -43,7 +44,7 @@ export default function FundSummaryReport({ tenantId, dateRange }: Props) {
         <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
         <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
       </div>
-      <DataGrid
+      <DataGrid<FundSummary>
         data={data || []}
         columns={columns}
         loading={isLoading}

--- a/supabase/migrations/20250716010000_update_fund_summary.sql
+++ b/supabase/migrations/20250716010000_update_fund_summary.sql
@@ -1,0 +1,40 @@
+-- Update fund summary report to remove fund_id column
+
+CREATE OR REPLACE FUNCTION report_fund_summary(
+  p_tenant_id uuid,
+  p_start_date date,
+  p_end_date date
+)
+RETURNS TABLE (
+  fund_name text,
+  income numeric,
+  expenses numeric,
+  net_change numeric
+)
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT check_tenant_access(p_tenant_id) THEN
+    RAISE EXCEPTION 'Permission denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    f.name,
+    COALESCE(SUM(CASE WHEN ft.type = 'income' THEN ft.credit END),0) AS income,
+    COALESCE(SUM(CASE WHEN ft.type = 'expense' THEN ft.debit END),0) AS expenses,
+    COALESCE(SUM(CASE WHEN ft.type = 'income' THEN ft.credit ELSE -ft.debit END),0) AS net_change
+  FROM funds f
+  LEFT JOIN financial_transactions ft ON ft.fund_id = f.id
+    AND ft.date BETWEEN p_start_date AND p_end_date
+  WHERE f.tenant_id = p_tenant_id
+  GROUP BY f.name
+  ORDER BY f.name;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION report_fund_summary(uuid, date, date) TO authenticated;
+COMMENT ON FUNCTION report_fund_summary(uuid, date, date) IS
+  'Summary of income and expenses by fund for a tenant';


### PR DESCRIPTION
## Summary
- update report_fund_summary to only return fund_name
- provide FundSummary type for frontend
- type useFundSummary hook
- type FundSummaryReport data grid

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a4d7c1b08326baca73e9e66b4f27