### PR TITLE
Refactor sidebar using shadcn-ui components

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './layout/Sidebar';
 import Topbar from './layout/Topbar';
 import Footer from './Footer';
+import { SidebarProvider, useSidebar } from './ui2/sidebar';
 
-function Layout() {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [sidebarPinned, setSidebarPinned] = useState(true);
+function LayoutContent() {
+  const { collapsed } = useSidebar();
   const location = useLocation();
   
   // Check if current page is settings
@@ -16,24 +15,14 @@ function Layout() {
   return (
     <div className="min-h-screen w-screen flex bg-gray-100 dark:bg-gray-900 overflow-x-hidden">
       {/* Sidebar */}
-      <Sidebar
-        sidebarOpen={sidebarOpen}
-        setSidebarOpen={setSidebarOpen}
-        collapsed={sidebarCollapsed}
-        setCollapsed={setSidebarCollapsed}
-        pinned={sidebarPinned}
-        setPinned={setSidebarPinned}
-      />
+      <Sidebar />
 
       {/* Main content wrapper */}
       <div
-        className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 pt-16 transition-all duration-300 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
+        className={`flex-1 w-screen overflow-x-hidden flex flex-col min-h-screen pb-24 pt-16 transition-all duration-300 ${collapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
       >
         {/* Top navigation */}
-        <Topbar
-          setSidebarOpen={setSidebarOpen}
-          sidebarCollapsed={sidebarCollapsed}
-        />
+        <Topbar />
 
         {/* Main content */}
         <main className={`flex-1 w-full ${isSettingsPage ? '' : 'bg-white dark:bg-gray-800'}`}>
@@ -47,10 +36,16 @@ function Layout() {
         </main>
 
         {/* Footer */}
-        <Footer sidebarCollapsed={sidebarCollapsed} />
+        <Footer sidebarCollapsed={collapsed} />
       </div>
     </div>
   );
 }
 
-export default Layout;
+export default function Layout() {
+  return (
+    <SidebarProvider>
+      <LayoutContent />
+    </SidebarProvider>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -9,6 +9,13 @@ import { Button } from '../ui2/button';
 import { Badge } from '../ui2/badge';
 import { Separator } from '../ui2/separator';
 import {
+  Sidebar as SidebarContainer,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarContent,
+  useSidebar,
+} from '../ui2/sidebar';
+import {
   Settings as SettingsIcon,
   Crown,
   Sparkles,
@@ -19,23 +26,15 @@ import {
 } from 'lucide-react';
 import { navigation as baseNavigation, NavItem } from '../../config/navigation';
 
-interface SidebarProps {
-  sidebarOpen: boolean;
-  setSidebarOpen: (open: boolean) => void;
-  collapsed: boolean;
-  setCollapsed: (collapsed: boolean) => void;
-  pinned: boolean;
-  setPinned: (pinned: boolean) => void;
-}
-
-function Sidebar({
-  sidebarOpen,
-  setSidebarOpen,
-  collapsed,
-  setCollapsed,
-  pinned,
-  setPinned,
-}: SidebarProps) {
+function Sidebar() {
+  const {
+    open: sidebarOpen,
+    setOpen: setSidebarOpen,
+    collapsed,
+    setCollapsed,
+    pinned,
+    setPinned,
+  } = useSidebar();
   const location = useLocation();
   const navigate = useNavigate();
   const { hasPermission } = usePermissions();
@@ -300,14 +299,14 @@ function Sidebar({
       />
 
       {/* Sidebar */}
-      <aside
+      <SidebarContainer
         className={`
-          fixed inset-y-0 left-0 z-50 bg-gray-900 flex flex-col
+          fixed inset-y-0 left-0 z-50 bg-gray-900
           transform transition-transform duration-300 ease-in-out
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
           lg:translate-x-0
           w-72 ${collapsed ? 'lg:w-20' : 'lg:w-72'}
-          transition-all
+          flex flex-col transition-all
         `}
         onMouseEnter={() => {
           if (!pinned) {
@@ -320,7 +319,7 @@ function Sidebar({
           }
         }}
       >
-        <div className="flex flex-col h-full px-2">
+        <SidebarHeader className="px-2">
           {/* Logo */}
           <div className="flex-shrink-0 h-16 flex items-center justify-center px-4">
             <img
@@ -353,9 +352,10 @@ function Sidebar({
           )}
 
           {!collapsed && <Separator className="bg-gray-800" />}
+        </SidebarHeader>
 
-          {/* Navigation - Scrollable Area */}
-          <Scrollable className={`flex-1 ${collapsed ? 'py-2' : 'py-4'}`} shadow={false}>
+        <SidebarContent>
+          <Scrollable className={`${collapsed ? 'py-2' : 'py-4'}`} shadow={false}>
             <nav className="space-y-1">
               {filteredNavigation.map((item) => renderItem(item))}
 
@@ -367,14 +367,14 @@ function Sidebar({
               )}
             </nav>
           </Scrollable>
+        </SidebarContent>
 
-          {/* Bottom Section - Fixed */}
-          <div className="flex-shrink-0 border-t border-gray-800 p-4 space-y-4">
-            {/* Subscribe Button */}
-            {!collapsed && (
-              <Link
-                to="/settings/subscription"
-                className="block"
+        <SidebarFooter className="border-t border-gray-800 p-4 space-y-4">
+          {/* Subscribe Button */}
+          {!collapsed && (
+            <Link
+              to="/settings/subscription"
+              className="block"
                 aria-label="Manage Subscription"
               >
                 <div className={`
@@ -434,9 +434,8 @@ function Sidebar({
               )}
             </Button>
 
-          </div>
-        </div>
-      </aside>
+          </SidebarFooter>
+      </SidebarContainer>
     </>
   );
 }

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -9,13 +9,10 @@ import { useAuthStore } from '../../stores/authStore';
 import { useNavigate } from 'react-router-dom';
 import ChurchBranding from '../ChurchBranding';
 import NotificationDropdown from './NotificationDropdown';
+import { SidebarTrigger, useSidebar } from '../ui2/sidebar';
 
-interface TopbarProps {
-  setSidebarOpen: (open: boolean) => void;
-  sidebarCollapsed: boolean;
-}
-
-function Topbar({ setSidebarOpen, sidebarCollapsed }: TopbarProps) {
+function Topbar() {
+  const { setOpen: setSidebarOpen, collapsed: sidebarCollapsed } = useSidebar();
   const { user, signOut } = useAuthStore();
   const navigate = useNavigate();
   const { settings, handleThemeToggle } = useThemeSwitcher();
@@ -30,14 +27,13 @@ function Topbar({ setSidebarOpen, sidebarCollapsed }: TopbarProps) {
       className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
     >
       {/* Sidebar toggle, only on mobile */}
-      <button
-        type="button"
+      <SidebarTrigger
+        action="open"
         className="-m-2.5 p-2.5 text-gray-700 dark:text-gray-300 lg:hidden"
-        onClick={() => setSidebarOpen(true)}
       >
         <span className="sr-only">Open sidebar</span>
         <Menu className="h-6 w-6" aria-hidden="true" />
-      </button>
+      </SidebarTrigger>
 
       {/* Separator */}
       <div className="h-6 w-px bg-gray-200 dark:bg-gray-700 lg:hidden" aria-hidden="true" />

--- a/src/components/ui2/sidebar.tsx
+++ b/src/components/ui2/sidebar.tsx
@@ -1,0 +1,110 @@
+// src/components/ui2/sidebar.tsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface SidebarContextValue {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  collapsed: boolean;
+  setCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  pinned: boolean;
+  setPinned: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | undefined>(undefined);
+
+export interface SidebarProviderProps {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  defaultCollapsed?: boolean;
+  defaultPinned?: boolean;
+}
+
+export function SidebarProvider({
+  children,
+  defaultOpen = false,
+  defaultCollapsed = false,
+  defaultPinned = true,
+}: SidebarProviderProps) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
+  const [pinned, setPinned] = React.useState(defaultPinned);
+
+  const value = React.useMemo(
+    () => ({ open, setOpen, collapsed, setCollapsed, pinned, setPinned }),
+    [open, collapsed, pinned]
+  );
+
+  return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
+}
+
+export function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) throw new Error('useSidebar must be used within a SidebarProvider');
+  return context;
+}
+
+const Sidebar = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col h-full', className)} {...props} />
+  )
+);
+Sidebar.displayName = 'Sidebar';
+
+const SidebarHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('sticky top-0 z-10', className)} {...props} />
+  )
+);
+SidebarHeader.displayName = 'SidebarHeader';
+
+const SidebarFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('mt-auto sticky bottom-0 z-10', className)} {...props} />
+  )
+);
+SidebarFooter.displayName = 'SidebarFooter';
+
+const SidebarContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex-1 overflow-y-auto', className)} {...props} />
+  )
+);
+SidebarContent.displayName = 'SidebarContent';
+
+const SidebarGroup = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('px-2 py-2', className)} {...props} />
+  )
+);
+SidebarGroup.displayName = 'SidebarGroup';
+
+export interface SidebarTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  action?: 'open' | 'close' | 'toggle';
+}
+
+const SidebarTrigger = React.forwardRef<HTMLButtonElement, SidebarTriggerProps>(
+  ({ action = 'toggle', onClick, className, ...props }, ref) => {
+    const { open, setOpen } = useSidebar();
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (action === 'open') setOpen(true);
+      else if (action === 'close') setOpen(false);
+      else setOpen(!open);
+      onClick?.(e);
+    };
+    return <button ref={ref} className={className} onClick={handleClick} {...props} />;
+  }
+);
+SidebarTrigger.displayName = 'SidebarTrigger';
+
+export {
+  Sidebar,
+  SidebarHeader,
+  SidebarFooter,
+  SidebarContent,
+  SidebarGroup,
+  SidebarTrigger,
+  SidebarProvider,
+  useSidebar,
+};


### PR DESCRIPTION
## Summary
- create shadcn-style sidebar primitives
- restructure main Sidebar component to use new primitives
- update Layout and Topbar to use SidebarProvider context

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664481d7d48326af38d2619fd8ee75