### PR TITLE
fix double scrollbar in sidebar

### DIFF
--- a/src/components/ui2/sidebar.tsx
+++ b/src/components/ui2/sidebar.tsx
@@ -67,7 +67,11 @@ SidebarFooter.displayName = 'SidebarFooter';
 
 const SidebarContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex-1 overflow-y-auto', className)} {...props} />
+    <div
+      ref={ref}
+      className={cn('flex-1', className)}
+      {...props}
+    />
   )
 );
 SidebarContent.displayName = 'SidebarContent';


### PR DESCRIPTION
## Summary
- remove overflow from `SidebarContent` to avoid nested scrollbars

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866489aff348326a5117786b7df8b81