### PR TITLE
Align topbar content

### DIFF
--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -24,7 +24,7 @@ function Topbar() {
 
   return (
     <header
-      className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
+      className={`fixed top-0 inset-x-0 w-full z-30 flex h-16 shrink-0 items-center justify-end gap-x-4 border-b border-gray-200 bg-primary-gradient dark:bg-gray-800 dark:border-gray-700 px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:pr-8 ${sidebarCollapsed ? 'lg:pl-16' : 'lg:pl-72'}`}
     >
       {/* Sidebar toggle, only on mobile */}
       <SidebarTrigger


### PR DESCRIPTION
## Summary
- apply `bg-primary-gradient` to the header
- right-align header items using `justify-end`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664c3e80ac83268ad285dfe1e575bb