### PR TITLE
Add shadcn-style pagination for data table

### DIFF
--- a/src/components/ui2/data-table/data-table-pagination.tsx
+++ b/src/components/ui2/data-table/data-table-pagination.tsx
@@ -1,0 +1,96 @@
+import { Table } from "@tanstack/react-table"
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react"
+
+import { Button } from "../button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select"
+
+interface DataTablePaginationProps<TData> {
+  table: Table<TData>
+}
+
+export function DataTablePagination<TData>({ table }: DataTablePaginationProps<TData>) {
+  return (
+    <div className="flex items-center justify-between px-2">
+      <div className="flex-1 text-sm text-muted-foreground">
+        {table.getFilteredSelectedRowModel().rows.length} of{" "}
+        {table.getFilteredRowModel().rows.length} row(s) selected.
+      </div>
+      <div className="flex items-center space-x-6 lg:space-x-8">
+        <div className="flex items-center space-x-2">
+          <p className="text-sm font-medium">Rows per page</p>
+          <Select
+            value={`${table.getState().pagination.pageSize}`}
+            onValueChange={(value) => table.setPageSize(Number(value))}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue placeholder={table.getState().pagination.pageSize} />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {[10, 20, 25, 30, 40, 50].map((pageSize) => (
+                <SelectItem key={pageSize} value={`${pageSize}`}>
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+        </div>
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="outline"
+            size="icon"
+            className="hidden size-8 lg:flex"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to first page</span>
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <span className="sr-only">Go to previous page</span>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to next page</span>
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="hidden size-8 lg:flex"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <span className="sr-only">Go to last page</span>
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui2/data-table/data-table.tsx
+++ b/src/components/ui2/data-table/data-table.tsx
@@ -15,7 +15,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableFoo
 import { Loader2 } from 'lucide-react';
 import { DataTableToolbar } from './data-table-toolbar';
 import { DataTableColumnHeader } from './data-table-column-header';
-import { Pagination } from '../pagination';
+import { DataTablePagination } from './data-table-pagination';
 import { cn } from '@/lib/utils';
 
 export interface DataTableProps<TData, TValue> {
@@ -143,17 +143,7 @@ export function DataTable<TData, TValue>({
         </Table>
       </div>
 
-      <Pagination
-        currentPage={pageIndex + 1}
-        totalPages={Math.max(1, table.getPageCount())}
-        onPageChange={(p) => table.setPageIndex(p - 1)}
-        itemsPerPage={pageSize}
-        totalItems={table.getFilteredRowModel().rows.length}
-        onItemsPerPageChange={(size) => table.setPageSize(size)}
-        showItemsPerPage
-        className="border-t sticky bottom-0 bg-background z-10"
-        size="sm"
-      />
+      <DataTablePagination table={table} />
     </div>
   );
 }

--- a/src/components/ui2/data-table/index.tsx
+++ b/src/components/ui2/data-table/index.tsx
@@ -1,4 +1,5 @@
 export { DataTable } from './data-table';
 export { DataTableToolbar } from './data-table-toolbar';
 export { DataTableColumnHeader } from './data-table-column-header';
+export { DataTablePagination } from './data-table-pagination';
 export type { DataTableProps } from './data-table';


### PR DESCRIPTION
## Summary
- add `DataTablePagination` component to match shadcn data table style
- export new pagination component
- use `DataTablePagination` within `DataTable`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669ac568408326b014fd7c111319a1