### PR TITLE
Fix sticky table header/footer

### DIFF
--- a/src/components/ui2/data-table/data-table.tsx
+++ b/src/components/ui2/data-table/data-table.tsx
@@ -73,7 +73,12 @@ export function DataTable<TData, TValue>({
 
   return (
     <div
-      className={cn('space-y-4 w-full h-full overflow-y-auto', fluid ? '' : 'mx-auto', containerClassName, className)}
+      className={cn(
+        'space-y-4 w-full h-full',
+        fluid ? '' : 'mx-auto',
+        containerClassName,
+        className
+      )}
     >
       <DataTableToolbar
         table={table}
@@ -84,8 +89,9 @@ export function DataTable<TData, TValue>({
       />
 
       <div className="rounded-lg border border-border bg-card text-card-foreground shadow-sm">
-        <Table>
-          <TableHeader>
+        <div className="overflow-y-auto">
+          <Table>
+            <TableHeader className="sticky top-0 z-10 bg-card">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
@@ -97,13 +103,13 @@ export function DataTable<TData, TValue>({
                 ))}
               </TableRow>
             ))}
-          </TableHeader>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-96 text-center">
-                  <div className="flex items-center justify-center">
-                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-96 text-center">
+                    <div className="flex items-center justify-center">
+                      <Loader2 className="h-8 w-8 animate-spin text-primary" />
                   </div>
                 </TableCell>
               </TableRow>
@@ -125,22 +131,23 @@ export function DataTable<TData, TValue>({
               </TableRow>
             )}
           </TableBody>
-          {table.getFooterGroups().length > 0 && (
-            <TableFooter>
-              {table.getFooterGroups().map((footerGroup) => (
-                <TableRow key={footerGroup.id}>
-                  {footerGroup.headers.map((header) => (
-                    <TableCell key={header.id} style={{ width: header.column.getSize() }}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(header.column.columnDef.footer, header.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableFooter>
-          )}
-        </Table>
+            {table.getFooterGroups().length > 0 && (
+              <TableFooter className="sticky bottom-0 z-10 bg-card">
+                {table.getFooterGroups().map((footerGroup) => (
+                  <TableRow key={footerGroup.id}>
+                    {footerGroup.headers.map((header) => (
+                      <TableCell key={header.id} style={{ width: header.column.getSize() }}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.footer, header.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableFooter>
+            )}
+          </Table>
+        </div>
       </div>
 
       <DataTablePagination table={table} />


### PR DESCRIPTION
## Summary
- remove overflow-y-auto from top level DataTable wrapper
- add scrolling container around `<Table>`
- keep pagination visible by making header/footer sticky

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npx vitest run` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_68669da24cb48326a3609123c95b4b66