### PR TITLE
fix table overflow behavior

### DIFF
--- a/src/components/ui2/table.tsx
+++ b/src/components/ui2/table.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
+    <div className="relative w-full overflow-x-auto">
       <table ref={ref} className={cn('w-full caption-bottom text-sm dark:text-foreground', className)} {...props} />
     </div>
   )


### PR DESCRIPTION
## Summary
- change table wrapper to only scroll on x-axis

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669f87eaa08326b885f2ce9acdcf8c