### PR TITLE
Add date range filtering for income/expense list

### DIFF
--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -33,7 +33,15 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
     isLoading: entriesLoading,
     error: entriesError,
   } = useEntryQuery({
-    filters: { transaction_type: { operator: 'eq', value: transactionType } },
+    filters: {
+      transaction_type: { operator: 'eq', value: transactionType },
+      transaction_date: {
+        operator: 'between',
+        value: format(dateRange.from, 'yyyy-MM-dd'),
+        valueTo: format(dateRange.to, 'yyyy-MM-dd'),
+      },
+    },
+    order: { column: 'transaction_date', ascending: false },
   });
 
   const headerIds = React.useMemo(


### PR DESCRIPTION
## Summary
- filter income/expense entries by selected date range
- order entries by newest transaction date

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_6866a8b5623c83269d22013c5a5839df