### PR TITLE
Fix DataGrid props re-export

### DIFF
--- a/src/components/ui2/data-grid/index.tsx
+++ b/src/components/ui2/data-grid/index.tsx
@@ -1,2 +1,2 @@
 export { DataTable as DataGrid } from '../data-table';
-export type { DataTableProps as DataGridProps } from '../data-table';
+export type { DataTableProps as DataGridProps } from '../data-table/data-table';


### PR DESCRIPTION
## Summary
- re-export `DataTableProps` directly from `data-table` implementation so `DataGridProps` consumers get updated typing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866bbfebe3c8326be8ace35159e1fdd