### PR TITLE
Add reusable metric card design

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+
+interface MetricCardProps {
+  label: string;
+  value: React.ReactNode;
+  icon?: LucideIcon;
+}
+
+export default function MetricCard({ label, value, icon: Icon }: MetricCardProps) {
+  return (
+    <div className="bg-white dark:bg-muted rounded-xl shadow-md p-5 flex justify-between items-start">
+      <div>
+        <p className="text-sm text-gray-500 dark:text-muted-foreground">{label}</p>
+        <p className="text-2xl font-semibold text-gray-900 dark:text-foreground">{value}</p>
+      </div>
+      {Icon && <Icon className="h-6 w-6 text-gray-400 dark:text-muted-foreground" />}
+    </div>
+  );
+}

--- a/src/pages/members/MembersDashboard.tsx
+++ b/src/pages/members/MembersDashboard.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from '../../components/ui2/card';
+import MetricCard from '../../components/dashboard/MetricCard';
 import { Button } from '../../components/ui2/button';
 import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui2/avatar';
 import {
@@ -170,19 +171,9 @@ function MembersDashboard() {
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {highlights.map((h) => (
-          <Card key={h.name}>
-            <CardContent className="p-4 flex items-center space-x-4">
-              <div className="p-2 rounded-md bg-primary/10">
-                <h.icon className="h-5 w-5 text-primary" />
-              </div>
-              <div>
-                <p className="text-2xl font-bold">{h.value}</p>
-                <p className="text-sm text-muted-foreground">{h.name}</p>
-              </div>
-            </CardContent>
-          </Card>
+          <MetricCard key={h.name} label={h.name} value={h.value} icon={h.icon} />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- implement new `MetricCard` component with standardized styling
- refactor Members dashboard to use `MetricCard` for summary metrics

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c78fe0e883269f01a10abe34e36d