### PR TITLE
Add subtext to MetricCard and update dashboard

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -5,16 +5,18 @@ interface MetricCardProps {
   label: string;
   value: React.ReactNode;
   icon?: LucideIcon;
+  subtext?: string;
 }
 
-export default function MetricCard({ label, value, icon: Icon }: MetricCardProps) {
+export default function MetricCard({ label, value, icon: Icon, subtext }: MetricCardProps) {
   return (
-    <div className="bg-white dark:bg-muted rounded-xl shadow-md p-5 flex justify-between items-start">
-      <div>
-        <p className="text-sm text-gray-500 dark:text-muted-foreground">{label}</p>
-        <p className="text-2xl font-semibold text-gray-900 dark:text-foreground">{value}</p>
-      </div>
-      {Icon && <Icon className="h-6 w-6 text-gray-400 dark:text-muted-foreground" />}
+    <div className="relative min-w-[240px] h-auto p-5 rounded-xl bg-white dark:bg-gray-800 shadow-md flex flex-col justify-between gap-2">
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</p>
+      {Icon && (
+        <Icon className="absolute top-4 right-4 text-blue-600 dark:text-blue-400 text-xl" />
+      )}
+      <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
+      {subtext && <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtext}</p>}
     </div>
   );
 }

--- a/src/pages/members/MembersDashboard.tsx
+++ b/src/pages/members/MembersDashboard.tsx
@@ -136,10 +136,30 @@ function MembersDashboard() {
   });
 
   const highlights = [
-    { name: 'Total Members', value: totalMembers || 0, icon: Users },
-    { name: 'New This Month', value: newMembers || 0, icon: UserPlus },
-    { name: 'Visitors', value: visitorCount || 0, icon: UserCheck },
-    { name: 'Families', value: familyCount || 0, icon: Heart },
+    {
+      name: 'Total Members',
+      value: totalMembers || 0,
+      icon: Users,
+      subtext: 'Active members',
+    },
+    {
+      name: 'New This Month',
+      value: newMembers || 0,
+      icon: UserPlus,
+      subtext: 'Joined this month',
+    },
+    {
+      name: 'Visitors',
+      value: visitorCount || 0,
+      icon: UserCheck,
+      subtext: 'Current visitors',
+    },
+    {
+      name: 'Families',
+      value: familyCount || 0,
+      icon: Heart,
+      subtext: 'Family groups',
+    },
   ];
 
   const actions = [
@@ -173,7 +193,13 @@ function MembersDashboard() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {highlights.map((h) => (
-          <MetricCard key={h.name} label={h.name} value={h.value} icon={h.icon} />
+          <MetricCard
+            key={h.name}
+            label={h.name}
+            value={h.value}
+            icon={h.icon}
+            subtext={h.subtext}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- support an optional `subtext` prop in `MetricCard`
- restyle the card container
- show optional icon, value, and subtext
- update member dashboard highlights to use new prop
- add dark mode styles for `MetricCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866cabbd1a0832685df900678ae24e9