### PR TITLE
Use ui2 Card in MetricCard

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LucideIcon } from 'lucide-react';
+import { Card } from '../ui2/card';
 
 interface MetricCardProps {
   label: string;
@@ -10,13 +11,13 @@ interface MetricCardProps {
 
 export default function MetricCard({ label, value, icon: Icon, subtext }: MetricCardProps) {
   return (
-    <div className="relative min-w-[240px] h-auto p-5 rounded-xl bg-white dark:bg-gray-800 shadow-md flex flex-col justify-between gap-2">
+    <Card className="relative min-w-[240px] h-auto p-5 shadow-md flex flex-col justify-between gap-2">
       <p className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</p>
       {Icon && (
         <Icon className="absolute top-4 right-4 text-blue-600 dark:text-blue-400 text-xl" />
       )}
       <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
       {subtext && <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtext}</p>}
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- refactor MetricCard to leverage the shared `Card` component from `ui2`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3f2e9e88326bc5822a7eb10d1f7