### PR TITLE
Match members dashboard background

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,9 +8,11 @@ import { SidebarProvider, useSidebar } from './ui2/sidebar';
 function LayoutContent() {
   const { collapsed } = useSidebar();
   const location = useLocation();
-  
+
   // Check if current page is settings
   const isSettingsPage = location.pathname.startsWith('/settings');
+  const isMembersDashboard =
+    location.pathname === '/members' || location.pathname === '/members/';
 
   return (
     <div className="min-h-screen w-screen flex bg-gray-100 dark:bg-gray-900 overflow-x-hidden">
@@ -25,7 +27,9 @@ function LayoutContent() {
         <Topbar />
 
         {/* Main content */}
-        <main className={`flex-1 w-full ${isSettingsPage ? '' : 'bg-white dark:bg-gray-800'}`}>
+        <main
+          className={`flex-1 w-full ${isSettingsPage ? '' : isMembersDashboard ? 'bg-gray-50 dark:bg-gray-800' : 'bg-white dark:bg-gray-800'}`}
+        >
           {isSettingsPage ? (
             <Outlet />
           ) : (


### PR DESCRIPTION
## Summary
- highlight the members dashboard path in the layout
- use the same background color as the topbar when viewing the members dashboard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866dbb4328883269978882cb4b173d7