### PR TITLE
Update search visibility in sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -101,6 +101,18 @@ function Sidebar() {
     [hasPermission]
   );
 
+  const menuItemCount = useMemo(() => {
+    let count = 0;
+    const walk = (items: NavItem[]) => {
+      items.forEach((it) => {
+        count += 1;
+        if (it.submenu) walk(it.submenu);
+      });
+    };
+    walk(navigation);
+    return count;
+  }, [navigation]);
+
 
   const itemLevels = useMemo(() => {
     const levels = new Map<string, number>();
@@ -115,6 +127,14 @@ function Sidebar() {
     walk(navigation);
     return levels;
   }, [navigation]);
+
+  const showSearch = menuItemCount > 10;
+
+  React.useEffect(() => {
+    if (!showSearch && searchTerm) {
+      setSearchTerm('');
+    }
+  }, [showSearch, searchTerm]);
 
   const renderItem = (item: NavItem, level = 0) => {
     const hasChildren = item.submenu && item.submenu.length > 0;
@@ -365,7 +385,7 @@ function Sidebar() {
               collapsed ? 'p-2 justify-center' : 'px-4 py-4'
             } flex items-center space-x-2`}
           >
-            {!collapsed && (
+            {!collapsed && showSearch && (
               <Input
                 placeholder="Search menu..."
                 value={searchTerm}


### PR DESCRIPTION
## Summary
- hide sidebar search unless menu has more than 10 items

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd2de2bc83268b9323fa81d3a757