### PR TITLE
Add dark mode styles to members dashboard

### DIFF
--- a/src/components/members/RecentMemberItem.tsx
+++ b/src/components/members/RecentMemberItem.tsx
@@ -44,22 +44,22 @@ export function RecentMemberItem({ member }: RecentMemberItemProps) {
                 }}
               />
             )}
-            <AvatarFallback className="bg-blue-100 text-blue-700 font-semibold">
+            <AvatarFallback className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-100 font-semibold">
               {member.first_name.charAt(0)}{member.last_name.charAt(0)}
             </AvatarFallback>
           </Avatar>
           <div className="flex flex-col">
-            <span className="font-semibold text-gray-800">
+            <span className="font-semibold text-gray-800 dark:text-gray-200">
               {member.first_name} {member.last_name}
             </span>
             {member.email && (
-              <span className="flex items-center text-md text-gray-500">
+              <span className="flex items-center text-md text-gray-500 dark:text-gray-400">
                 <Mail className="h-4 w-4 mr-1" />
                 {member.email}
               </span>
             )}
             {member.contact_number && (
-              <span className="flex items-center text-md text-gray-500">
+              <span className="flex items-center text-md text-gray-500 dark:text-gray-400">
                 <Phone className="h-4 w-4 mr-1" />
                 {member.contact_number}
               </span>
@@ -72,7 +72,7 @@ export function RecentMemberItem({ member }: RecentMemberItemProps) {
               {member.membership_status.name}
             </Badge>
           )}
-          <span className="text-md text-gray-400 mt-1">
+          <span className="text-md text-gray-400 dark:text-gray-500 mt-1">
             Joined{' '}
             {joinedDate
             ? new Date(joinedDate).toLocaleDateString(undefined, {

--- a/src/pages/members/MembersDashboard.tsx
+++ b/src/pages/members/MembersDashboard.tsx
@@ -234,13 +234,13 @@ function MembersDashboard() {
         <TabsList className="w-full grid grid-cols-2 bg-muted p-1 rounded-full">
           <TabsTrigger
             value="overview"
-            className="flex-1 text-sm font-medium text-gray-700 px-6 py-2 rounded-full transition-colors duration-200 ease-in-out data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-sm hover:text-black"
+            className="flex-1 text-sm font-medium text-gray-700 dark:text-gray-300 px-6 py-2 rounded-full transition-colors duration-200 ease-in-out data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm hover:text-black dark:hover:text-foreground"
           >
             Overview
           </TabsTrigger>
           <TabsTrigger
             value="directory"
-            className="flex-1 text-sm font-medium text-gray-700 px-6 py-2 rounded-full transition-colors duration-200 ease-in-out data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:shadow-sm hover:text-black"
+            className="flex-1 text-sm font-medium text-gray-700 dark:text-gray-300 px-6 py-2 rounded-full transition-colors duration-200 ease-in-out data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm hover:text-black dark:hover:text-foreground"
           >
             Directory
           </TabsTrigger>
@@ -269,12 +269,12 @@ function MembersDashboard() {
               </Link>
               <Link to="/members/batch" className="w-full md:w-1/2">
                 <Card
-                  className="bg-gray-50 border border-gray-200 text-gray-700 text-sm font-medium py-5 px-6 rounded-lg flex flex-col items-center justify-center gap-1"
+                  className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium py-5 px-6 rounded-lg flex flex-col items-center justify-center gap-1"
                   hoverable
                 >
-                  <FileText className="text-xl text-gray-600" />
+                  <FileText className="text-xl text-gray-600 dark:text-gray-300" />
                   <span>Batch Entry</span>
-                  <span className="text-xs text-gray-500">
+                  <span className="text-xs text-gray-500 dark:text-gray-400">
                     Spreadsheet-style entry
                   </span>
                 </Card>
@@ -283,10 +283,10 @@ function MembersDashboard() {
           </Card>
           <Card className="mt-4">
             <CardContent className="space-y-4">
-              <h3 className="font-semibold text-lg text-gray-900">
+              <h3 className="font-semibold text-lg text-gray-900 dark:text-gray-100">
                 Recent Additions
               </h3>
-              <p className="text-sm text-gray-500 mb-4">
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
                 Latest member entries
               </p>
               <div className="flex flex-col space-y-2">


### PR DESCRIPTION
## Summary
- ensure MembersDashboard text elements have dark mode variants
- add dark style variants to RecentMemberItem

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6866e62541e883268ede06880fdb9054