### PR TITLE
Update sidebar toggle icons

### DIFF
--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,13 @@
 import React, { useMemo } from 'react';
-import { Menu, User, Search, Sun, Moon, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import {
+  Menu,
+  User,
+  Search,
+  Sun,
+  Moon,
+  PanelLeft,
+  PanelLeftClose
+} from 'lucide-react';
 import { Button } from '../ui2/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '../ui2/dropdown-menu';
 import { Input } from '../ui2/input';
@@ -64,9 +72,9 @@ function Topbar() {
           className="hidden lg:inline-flex"
         >
           {collapsed ? (
-            <ChevronsRight className="h-5 w-5" />
+            <PanelLeftClose className="h-5 w-5" />
           ) : (
-            <ChevronsLeft className="h-5 w-5" />
+            <PanelLeft className="h-5 w-5" />
           )}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- use `PanelLeft` and `PanelLeftClose` icons in Topbar sidebar toggle

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e773934083268d658d1522f22852