### PR TITLE
Set Card variant in RecentMemberItem

### DIFF
--- a/src/components/members/RecentMemberItem.tsx
+++ b/src/components/members/RecentMemberItem.tsx
@@ -30,7 +30,7 @@ export function RecentMemberItem({ member }: RecentMemberItemProps) {
   const variant = statusVariantMap[member.membership_status?.code || ''] || 'secondary';
   const joinedDate = member.membership_date || member.created_at;
   return (
-    <Card size="sm" hoverable>
+    <Card size="sm" hoverable variant="secondary">
       <CardContent className="flex justify-between gap-4 items-start py-3 px-4">
         <div className="flex items-start gap-3 flex-1">
           <Avatar size="md">


### PR DESCRIPTION
## Summary
- adjust RecentMemberItem card variant to use the `secondary` style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e9d63d4883269b7092dddb1ffe5a