### PR TITLE
Implement clickable member directory items

### DIFF
--- a/src/components/members/DirectoryMemberItem.tsx
+++ b/src/components/members/DirectoryMemberItem.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import MemberCardItem, { MemberCardItemData } from './MemberCardItem';
+
+export interface DirectoryMember extends MemberCardItemData {
+  address: string | null;
+}
+
+interface DirectoryMemberItemProps {
+  member: DirectoryMember;
+}
+
+export function DirectoryMemberItem({ member }: DirectoryMemberItemProps) {
+  return <MemberCardItem member={member} showAddress />;
+}
+
+export default DirectoryMemberItem;

--- a/src/components/members/MemberCardItem.tsx
+++ b/src/components/members/MemberCardItem.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Card, CardContent } from '../ui2/card';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui2/avatar';
+import { Badge } from '../ui2/badge';
+import { Mail, Phone, MapPin } from 'lucide-react';
+
+export interface MemberCardItemData {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string | null;
+  contact_number: string | null;
+  membership_date: string | null;
+  membership_status: { name: string; code: string } | null;
+  profile_picture_url: string | null;
+  created_at: string | null;
+  address?: string | null;
+}
+
+interface MemberCardItemProps {
+  member: MemberCardItemData;
+  showAddress?: boolean;
+}
+
+const statusVariantMap: Record<string, 'success' | 'info' | 'secondary' | 'warning' | 'destructive'> = {
+  active: 'success',
+  visitor: 'info',
+  inactive: 'secondary',
+};
+
+export function MemberCardItem({ member, showAddress = false }: MemberCardItemProps) {
+  const variant = statusVariantMap[member.membership_status?.code || ''] || 'secondary';
+  const joinedDate = member.membership_date || member.created_at;
+
+  return (
+    <Link to={`/members/${member.id}`} className="block">
+      <Card size="sm" className="dark:bg-gray-600" hoverable>
+        <CardContent className="flex justify-between gap-4 items-start py-3 px-4">
+          <div className="flex items-start gap-3 flex-1">
+            <Avatar size="xl">
+              {member.profile_picture_url && (
+                <AvatarImage
+                  src={member.profile_picture_url}
+                  alt={`${member.first_name} ${member.last_name}`}
+                  crossOrigin="anonymous"
+                  onError={(e) => {
+                    (e.currentTarget as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+              )}
+              <AvatarFallback className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-100 font-semibold">
+                {member.first_name.charAt(0)}{member.last_name.charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col mt-1">
+              <span className="font-semibold text-gray-800 dark:text-gray-200">
+                {member.first_name} {member.last_name}
+              </span>
+              {member.email && (
+                <span className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+                  <Mail className="h-4 w-4 mr-1" />
+                  {member.email}
+                </span>
+              )}
+              {member.contact_number && (
+                <span className="flex items-center text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  <Phone className="h-4 w-4 mr-1" />
+                  {member.contact_number}
+                </span>
+              )}
+              {showAddress && member.address && (
+                <span className="flex items-center text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  <MapPin className="h-4 w-4 mr-1" />
+                  {member.address}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col items-end">
+            {member.membership_status?.name && (
+              <Badge variant={variant} className="text-sm font-medium">
+                {member.membership_status.name}
+              </Badge>
+            )}
+            <span className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+              Member since{' '}
+              {joinedDate
+                ? new Date(joinedDate).toLocaleDateString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                  })
+                : ''}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+export default MemberCardItem;

--- a/src/components/members/RecentMemberItem.tsx
+++ b/src/components/members/RecentMemberItem.tsx
@@ -1,91 +1,14 @@
 import React from 'react';
-import { Card, CardContent } from '../ui2/card';
-import { Avatar, AvatarImage, AvatarFallback } from '../ui2/avatar';
-import { Badge } from '../ui2/badge';
-import { Mail, Phone } from 'lucide-react';
+import MemberCardItem, { MemberCardItemData } from './MemberCardItem';
 
-export interface RecentMember {
-  id: string;
-  first_name: string;
-  last_name: string;
-  email: string | null;
-  contact_number: string | null;
-  membership_date: string | null;
-  membership_status: { name: string; code: string } | null;
-  profile_picture_url: string | null;
-  created_at: string | null;
-}
+export interface RecentMember extends MemberCardItemData {}
 
 interface RecentMemberItemProps {
   member: RecentMember;
 }
 
-const statusVariantMap: Record<string, 'success' | 'info' | 'secondary' | 'warning' | 'destructive'> = {
-  active: 'success',
-  visitor: 'info',
-  inactive: 'secondary',
-};
-
 export function RecentMemberItem({ member }: RecentMemberItemProps) {
-  const variant = statusVariantMap[member.membership_status?.code || ''] || 'secondary';
-  const joinedDate = member.membership_date || member.created_at;
-  return (
-    <Card size="sm" className="dark:bg-gray-600" hoverable>
-      <CardContent className="flex justify-between gap-4 items-start py-3 px-4">
-        <div className="flex items-start gap-3 flex-1">
-          <Avatar size="xl">
-            {member.profile_picture_url && (
-              <AvatarImage
-                src={member.profile_picture_url}
-                alt={`${member.first_name} ${member.last_name}`}
-                crossOrigin="anonymous"
-                onError={(e) => {
-                  (e.currentTarget as HTMLImageElement).style.display = 'none';
-                }}
-              />
-            )}
-            <AvatarFallback className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-100 font-semibold">
-              {member.first_name.charAt(0)}{member.last_name.charAt(0)}
-            </AvatarFallback>
-          </Avatar>
-          <div className="flex flex-col mt-1">
-            <span className="font-semibold text-gray-800 dark:text-gray-200">
-              {member.first_name} {member.last_name}
-            </span>
-            {member.email && (
-              <span className="flex items-center text-md text-gray-500 dark:text-gray-400">
-                <Mail className="h-4 w-4 mr-1" />
-                {member.email}
-              </span>
-            )}
-            {member.contact_number && (
-              <span className="flex items-center text-md text-gray-500 dark:text-gray-400 mt-1">
-                <Phone className="h-4 w-4 mr-1" />
-                {member.contact_number}
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="flex flex-col items-end">
-          {member.membership_status?.name && (
-            <Badge variant={variant} className="text-md font-medium">
-              {member.membership_status.name}
-            </Badge>
-          )}
-          <span className="text-md text-gray-400 dark:text-gray-500 mt-1">
-            Joined{' '}
-            {joinedDate
-            ? new Date(joinedDate).toLocaleDateString(undefined, {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric'
-            })
-            : ''}
-          </span>
-        </div>
-      </CardContent>
-    </Card>
-  );
+  return <MemberCardItem member={member} />;
 }
 
 export default RecentMemberItem;

--- a/src/components/members/index.ts
+++ b/src/components/members/index.ts
@@ -1,1 +1,3 @@
 export * from './RecentMemberItem';
+export * from './DirectoryMemberItem';
+export * from './MemberCardItem';

--- a/src/pages/members/MembersDashboard.tsx
+++ b/src/pages/members/MembersDashboard.tsx
@@ -14,11 +14,6 @@ import {
 } from "../../components/ui2/card";
 import MetricCard from "../../components/dashboard/MetricCard";
 import {
-  Avatar,
-  AvatarImage,
-  AvatarFallback,
-} from "../../components/ui2/avatar";
-import {
   Users,
   UserPlus,
   UserCheck,
@@ -26,8 +21,6 @@ import {
   ChevronRight,
   FileText,
   Search,
-  Mail,
-  Phone,
 } from "lucide-react";
 import { Container } from "../../components/ui2/container";
 import {
@@ -37,7 +30,7 @@ import {
   TabsContent,
 } from "../../components/ui2/tabs";
 import { Input } from "../../components/ui2/input";
-import { RecentMemberItem } from "../../components/members";
+import { RecentMemberItem, DirectoryMemberItem } from "../../components/members";
 
 interface MemberSummary {
   id: string;
@@ -49,6 +42,7 @@ interface MemberSummary {
   membership_status: { name: string; code: string } | null;
   profile_picture_url: string | null;
   created_at: string | null;
+  address?: string | null;
 }
 
 function MembersDashboard() {
@@ -163,11 +157,13 @@ function MembersDashboard() {
       const search = directorySearch.trim();
       let query = supabase
         .from("members")
-        .select("id, first_name, last_name, profile_picture_url")
+        .select(
+          "id, first_name, last_name, email, contact_number, address, membership_date, profile_picture_url, created_at, membership_status(name, code)"
+        )
         .eq("tenant_id", tenant.id)
         .is("deleted_at", null)
         .order("last_name", { ascending: true })
-        .limit(3);
+        .limit(5);
       if (search) {
         query = query.or(
           `first_name.ilike.%${search}%,last_name.ilike.%${search}%,preferred_name.ilike.%${search}%`
@@ -314,48 +310,27 @@ function MembersDashboard() {
 
         <TabsContent value="directory" className="mt-4">
           <Card>
-            <CardContent className="space-y-4">
+            <CardHeader className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <CardTitle>Member Directory</CardTitle>
+                <CardDescription>Search and manage all members</CardDescription>
+              </div>
               <Input
                 value={directorySearch}
                 onChange={(e) => setDirectorySearch(e.target.value)}
                 placeholder="Search members..."
                 icon={<Search className="h-4 w-4" />}
+                className="md:w-64"
               />
-              <div className="space-y-4">
-                {directoryMembers && directoryMembers.length > 0 ? (
-                  directoryMembers.map((member) => (
-                    <Link
-                      key={member.id}
-                      to={`/members/${member.id}`}
-                      className="flex items-center space-x-3 hover:underline"
-                    >
-                      <Avatar size="sm">
-                        {member.profile_picture_url && (
-                          <AvatarImage
-                            src={member.profile_picture_url}
-                            alt={`${member.first_name} ${member.last_name}`}
-                            crossOrigin="anonymous"
-                            onError={(e) => {
-                              e.currentTarget.style.display = "none";
-                            }}
-                          />
-                        )}
-                        <AvatarFallback>
-                          {member.first_name.charAt(0)}
-                          {member.last_name.charAt(0)}
-                        </AvatarFallback>
-                      </Avatar>
-                      <span className="font-medium text-foreground">
-                        {member.first_name} {member.last_name}
-                      </span>
-                    </Link>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No members found.
-                  </p>
-                )}
-              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {directoryMembers && directoryMembers.length > 0 ? (
+                directoryMembers.map((member) => (
+                  <DirectoryMemberItem key={member.id} member={member} />
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">No members found.</p>
+              )}
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
## Summary
- add shared `MemberCardItem` component
- make `RecentMemberItem` and new `DirectoryMemberItem` use shared component
- show member directory in dashboard with address, member since date and search box
- query top 5 members and display clickable items

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f24a286c8326abadf3617867b416