### PR TITLE
Update sidebar logo styling

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -371,11 +371,13 @@ function Sidebar() {
       >
         <SidebarHeader className="px-4">
           {/* Logo */}
-          <div className="flex-shrink-0 h-16 flex items-center justify-center px-4">
+          <div
+            className={`flex-shrink-0 h-16 flex items-center justify-center px-4 ${collapsed ? '' : 'pt-3'}`}
+          >
             <img
               src={collapsed ? '/logo_square.svg' : '/logo_long.svg'}
               alt="StewardTrack Logo"
-              className={collapsed ? 'h-20' : 'h-12'}
+              className={collapsed ? 'h-8' : 'h-10'}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- tweak sidebar logo container spacing
- size logos appropriately when sidebar is collapsed vs expanded

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f72a547483268ce403f71d334721