### PR TITLE
Parametrize finance stats query

### DIFF
--- a/src/adapters/financeDashboard.adapter.ts
+++ b/src/adapters/financeDashboard.adapter.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import { injectable } from 'inversify';
 import { supabase } from '../lib/supabase';
+import { tenantUtils } from '../utils/tenantUtils';
+import { format } from 'date-fns';
 
 @injectable()
 export class FinanceDashboardAdapter {
@@ -13,13 +15,17 @@ export class FinanceDashboardAdapter {
     return data || [];
   }
 
-  async fetchMonthlyStats() {
-    const { data, error } = await supabase
-      .from('finance_monthly_stats')
-      .select('*')
-      .maybeSingle();
+  async fetchMonthlyStats(startDate: Date, endDate: Date) {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) return null;
+
+    const { data, error } = await supabase.rpc('finance_monthly_stats', {
+      p_tenant_id: tenantId,
+      p_start_date: format(startDate, 'yyyy-MM-dd'),
+      p_end_date: format(endDate, 'yyyy-MM-dd'),
+    });
     if (error) throw error;
-    return data || null;
+    return data?.[0] || null;
   }
 
   async fetchFundBalances() {

--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -6,10 +6,14 @@ import type { IFinanceDashboardRepository } from '../repositories/financeDashboa
 import { useCurrencyStore } from '../stores/currencyStore';
 import { formatCurrency } from '../utils/currency';
 import { categoryUtils } from '../utils/categoryUtils';
+import { startOfMonth, endOfMonth } from 'date-fns';
 
-export function useFinanceDashboardData() {
+export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
   const { currency } = useCurrencyStore();
   const repository = container.get<IFinanceDashboardRepository>(TYPES.IFinanceDashboardRepository);
+
+  const start = dateRange?.from ?? startOfMonth(new Date());
+  const end = dateRange?.to ?? endOfMonth(new Date());
 
   const { data: monthlyTrends, isLoading: trendsLoading } = useQuery({
     queryKey: ['monthly-trends'],
@@ -17,8 +21,8 @@ export function useFinanceDashboardData() {
   });
 
   const { data: stats, isLoading: statsLoading } = useQuery({
-    queryKey: ['finance-stats'],
-    queryFn: () => repository.getMonthlyStats(),
+    queryKey: ['finance-stats', start, end],
+    queryFn: () => repository.getMonthlyStats(start, end),
   });
 
   const { data: incomeCategories, isLoading: incomeCatsLoading } = useQuery({

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -42,7 +42,7 @@ function FinancialOverviewDashboard() {
     incomeCategoryChartData,
     expenseCategoryChartData,
     isLoading,
-  } = useFinanceDashboardData();
+  } = useFinanceDashboardData(dateRange);
 
   const initialFrom = React.useMemo(() => {
     const d = new Date();

--- a/src/repositories/financeDashboard.repository.ts
+++ b/src/repositories/financeDashboard.repository.ts
@@ -5,7 +5,7 @@ import { MonthlyTrend, FinanceStats, FundBalance } from '../models/financeDashbo
 
 export interface IFinanceDashboardRepository {
   getMonthlyTrends(): Promise<MonthlyTrend[]>;
-  getMonthlyStats(): Promise<FinanceStats | null>;
+  getMonthlyStats(startDate: Date, endDate: Date): Promise<FinanceStats | null>;
   getFundBalances(): Promise<FundBalance[]>;
 }
 
@@ -29,8 +29,8 @@ export class FinanceDashboardRepository implements IFinanceDashboardRepository {
     }));
   }
 
-  async getMonthlyStats(): Promise<FinanceStats | null> {
-    const row = await this.adapter.fetchMonthlyStats();
+  async getMonthlyStats(startDate: Date, endDate: Date): Promise<FinanceStats | null> {
+    const row = await this.adapter.fetchMonthlyStats(startDate, endDate);
     if (!row) return null;
     return {
       monthlyIncome: Number(row.monthly_income),

--- a/supabase/migrations/20250721000000_finance_monthly_stats_function.sql
+++ b/supabase/migrations/20250721000000_finance_monthly_stats_function.sql
@@ -1,0 +1,59 @@
+-- Replace finance_monthly_stats view with a parameterized function
+DROP VIEW IF EXISTS finance_monthly_stats CASCADE;
+
+CREATE OR REPLACE FUNCTION finance_monthly_stats(
+  p_tenant_id uuid,
+  p_start_date date,
+  p_end_date date
+)
+RETURNS TABLE (
+  monthly_income numeric,
+  monthly_expenses numeric,
+  active_budgets integer,
+  income_by_category jsonb,
+  expenses_by_category jsonb
+)
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT check_tenant_access(p_tenant_id) THEN
+    RAISE EXCEPTION 'Permission denied';
+  END IF;
+
+  RETURN QUERY
+  WITH tx AS (
+    SELECT
+      h.tenant_id,
+      iet.transaction_type AS type,
+      COALESCE(c.name, 'Uncategorized') AS category_name,
+      SUM(iet.amount) AS total
+    FROM income_expense_transactions iet
+    JOIN income_expense_transaction_mappings m ON m.transaction_id = iet.id
+    JOIN financial_transaction_headers h ON h.id = m.transaction_header_id
+    LEFT JOIN categories c ON c.id = iet.category_id
+    WHERE h.transaction_date BETWEEN p_start_date AND p_end_date
+      AND iet.deleted_at IS NULL
+    GROUP BY h.tenant_id, iet.transaction_type, c.name
+  )
+  SELECT
+    SUM(CASE WHEN type = 'income' THEN total ELSE 0 END) AS monthly_income,
+    SUM(CASE WHEN type = 'expense' THEN total ELSE 0 END) AS monthly_expenses,
+    COALESCE(
+      (SELECT COUNT(*) FROM budgets b
+         WHERE b.tenant_id = tx.tenant_id
+           AND p_end_date BETWEEN b.start_date AND b.end_date),
+      0
+    ) AS active_budgets,
+    jsonb_object_agg(category_name, total) FILTER (WHERE type = 'income') AS income_by_category,
+    jsonb_object_agg(category_name, total) FILTER (WHERE type = 'expense') AS expenses_by_category
+  FROM tx
+  WHERE tenant_id = p_tenant_id
+  GROUP BY tenant_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION finance_monthly_stats(uuid, date, date) TO authenticated;
+COMMENT ON FUNCTION finance_monthly_stats(uuid, date, date) IS
+  'Aggregated financial statistics for a tenant within a date range';

--- a/tests/financeDashboardRepository.test.ts
+++ b/tests/financeDashboardRepository.test.ts
@@ -6,7 +6,7 @@ const adapter: IFinanceDashboardAdapter = {
   fetchMonthlyTrends: async () => [
     { month: '2025-06', income: '100', expenses: '50', percentage_change: '10' },
   ],
-  fetchMonthlyStats: async () => ({
+  fetchMonthlyStats: async (_start: Date, _end: Date) => ({
     monthly_income: '200',
     monthly_expenses: '75',
     active_budgets: 1,
@@ -32,7 +32,7 @@ describe('FinanceDashboardRepository mapping', () => {
   });
 
   it('maps monthly stats', async () => {
-    const stats = await repo.getMonthlyStats();
+    const stats = await repo.getMonthlyStats(new Date('2025-06-01'), new Date('2025-06-30'));
     expect(stats).toEqual({
       monthlyIncome: 200,
       monthlyExpenses: 75,


### PR DESCRIPTION
## Summary
- replace `finance_monthly_stats` view with function taking start/end dates
- fetch monthly stats through the new function
- allow `useFinanceDashboardData` to accept a date range
- apply date range in Financial Overview dashboard
- update repository and tests for new signature

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686719af9a9c83268a6f9ac909de3473