### PR TITLE
Add donation status actions

### DIFF
--- a/src/models/incomeExpenseTransaction.model.ts
+++ b/src/models/incomeExpenseTransaction.model.ts
@@ -4,6 +4,7 @@ import { Fund } from './fund.model';
 import { FinancialSource } from './financialSource.model';
 import { Account } from './account.model';
 import type { TransactionType } from './financialTransaction.model';
+import type { FinancialTransactionHeader } from './financialTransactionHeader.model';
 
 export interface IncomeExpenseTransaction extends BaseModel {
   id: string;
@@ -27,4 +28,5 @@ export interface IncomeExpenseTransaction extends BaseModel {
   account_id: string | null;
   account?: Account;
   header_id: string | null;
+  header?: FinancialTransactionHeader;
 }

--- a/src/pages/offerings/OfferingsDashboard.tsx
+++ b/src/pages/offerings/OfferingsDashboard.tsx
@@ -51,6 +51,13 @@ function OfferingsDashboard() {
     filters: { transaction_type: { operator: 'eq', value: 'income' } },
     order: { column: 'transaction_date', ascending: false },
     pagination: { page: 1, pageSize: 5 },
+    relationships: [
+      {
+        table: 'financial_transaction_headers',
+        foreignKey: 'header_id',
+        select: ['id', 'status'],
+      },
+    ],
     enabled: !!tenant?.id,
   });
   const recentDonations = (recentResult?.data || []) as DonationItem[];
@@ -67,6 +74,13 @@ function OfferingsDashboard() {
     },
     order: { column: 'transaction_date', ascending: false },
     pagination: { page: 1, pageSize: 5 },
+    relationships: [
+      {
+        table: 'financial_transaction_headers',
+        foreignKey: 'header_id',
+        select: ['id', 'status'],
+      },
+    ],
     enabled: !!tenant?.id,
   });
   const historyDonations = (historyResult?.data || []) as DonationItem[];


### PR DESCRIPTION
## Summary
- expose `FinancialTransactionHeader` on `IncomeExpenseTransaction`
- pull donation header status on offering dashboard queries
- extend DonationItem with header fields
- add contextual action menu for donations

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686729e6e1648326a0027a39c7f0a630