### PR TITLE
Fix finance_monthly_stats budget count type

### DIFF
--- a/supabase/migrations/20250721000000_finance_monthly_stats_function.sql
+++ b/supabase/migrations/20250721000000_finance_monthly_stats_function.sql
@@ -41,7 +41,7 @@ BEGIN
     SUM(CASE WHEN type = 'income' THEN total ELSE 0 END) AS monthly_income,
     SUM(CASE WHEN type = 'expense' THEN total ELSE 0 END) AS monthly_expenses,
     COALESCE(
-      (SELECT COUNT(*) FROM budgets b
+      (SELECT COUNT(*)::integer FROM budgets b
          WHERE b.tenant_id = tx.tenant_id
            AND p_end_date BETWEEN b.start_date AND b.end_date),
       0


### PR DESCRIPTION
## Summary
- ensure `finance_monthly_stats` casts the budget count to integer

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672ab0e0c08326b850ff3f2df6af9f