### PR TITLE
Fix hoverable card overlay

### DIFF
--- a/src/components/ui2/card.tsx
+++ b/src/components/ui2/card.tsx
@@ -90,7 +90,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         >
           {/* Gradient overlay for hover effect */}
           {hoverable && (
-            <div className="absolute inset-0 bg-gradient-to-t from-transparent via-primary-500/0 to-primary-500/0 opacity-0 group-hover:opacity-5 dark:group-hover:opacity-5 transition-opacity duration-200 rounded-2xl" />
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-transparent via-primary-500/0 to-primary-500/0 opacity-0 group-hover:opacity-5 dark:group-hover:opacity-5 transition-opacity duration-200 rounded-2xl" />
           )}
 
           {/* Loading overlay */}


### PR DESCRIPTION
## Summary
- ensure hover overlay doesn't block interactions on cards

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867344dda24832698f77fc9028b1e92