### PR TITLE
Colorize dashboard icons

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -2,14 +2,32 @@ import React from 'react';
 import { LucideIcon } from 'lucide-react';
 import { Card } from '../ui2/card';
 
+import { cn } from '@/lib/utils';
+
 interface MetricCardProps {
   label: string;
   value: React.ReactNode;
   icon?: LucideIcon;
+  /**
+   * Optional CSS classes for the icon element. Allows pages to
+   * colorize icons based on context.
+   */
+  iconClassName?: string;
   subtext?: string;
+  /**
+   * Optional CSS classes for the sub label element.
+   */
+  subtextClassName?: string;
 }
 
-export default function MetricCard({ label, value, icon: Icon, subtext }: MetricCardProps) {
+export default function MetricCard({
+  label,
+  value,
+  icon: Icon,
+  iconClassName,
+  subtext,
+  subtextClassName,
+}: MetricCardProps) {
   return (
     <Card
       hoverable
@@ -17,10 +35,19 @@ export default function MetricCard({ label, value, icon: Icon, subtext }: Metric
     >
       <p className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</p>
       {Icon && (
-        <Icon className="absolute top-4 right-4 text-blue-600 dark:text-blue-400 text-xl" />
+        <Icon
+          className={cn(
+            'absolute top-4 right-4 text-blue-600 dark:text-blue-400 text-xl',
+            iconClassName,
+          )}
+        />
       )}
       <p className="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
-      {subtext && <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtext}</p>}
+      {subtext && (
+        <p className={cn('mt-1 text-sm text-gray-500 dark:text-gray-400', subtextClassName)}>
+          {subtext}
+        </p>
+      )}
     </Card>
   );
 }

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -140,6 +140,10 @@ function FinancialOverviewDashboard() {
   const expenseRatio =
     totalIncome > 0 ? (totalExpenses / totalIncome) * 100 : 0;
 
+  const incomeChangeColor = incomeChange >= 0 ? 'text-success' : 'text-danger';
+  const expenseChangeColor = expenseChange <= 0 ? 'text-success' : 'text-danger';
+  const netChangeColor = netChange >= 0 ? 'text-success' : 'text-danger';
+
   const trendsChartData = React.useMemo(() => {
     return {
       series: [
@@ -255,25 +259,33 @@ function FinancialOverviewDashboard() {
           label="Total Income"
           value={formatCurrency(totalIncome, currency)}
           icon={TrendingUp}
+          iconClassName="text-success"
           subtext={`${incomeChange.toFixed(1)}% from last month`}
+          subtextClassName={incomeChangeColor}
         />
         <MetricCard
           label="Total Expenses"
           value={formatCurrency(totalExpenses, currency)}
           icon={TrendingDown}
+          iconClassName="text-destructive"
           subtext={`${expenseChange.toFixed(1)}% from last month`}
+          subtextClassName={expenseChangeColor}
         />
         <MetricCard
           label="Net Income"
           value={formatCurrency(netIncome, currency)}
           icon={Banknote}
+          iconClassName={netIncome >= 0 ? 'text-success' : 'text-destructive'}
           subtext={`${netChange.toFixed(1)}% from last month`}
+          subtextClassName={netChangeColor}
         />
         <MetricCard
           label="Expense Ratio"
           value={`${expenseRatio.toFixed(1)}%`}
           icon={Percent}
+          iconClassName="text-warning"
           subtext={getExpenseRating(expenseRatio)}
+          subtextClassName="text-warning/70"
         />
       </div>
 

--- a/src/pages/offerings/OfferingsDashboard.tsx
+++ b/src/pages/offerings/OfferingsDashboard.tsx
@@ -109,25 +109,33 @@ function OfferingsDashboard() {
       name: 'This Month',
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisMonthTotal.toFixed(2)}` : metrics.thisMonthTotal.toFixed(2),
       icon: DollarSign,
+      iconClassName: 'text-success',
       subtext: `${metrics.monthChange.toFixed(1)}% from last month`,
+      subtextClassName: 'text-success/70',
     },
     {
       name: 'Total Donors',
       value: metrics.donorCount,
       icon: Users,
+      iconClassName: 'text-primary',
       subtext: 'Active contributors',
+      subtextClassName: 'text-primary/70',
     },
     {
       name: 'This Week',
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisWeekTotal.toFixed(2)}` : metrics.thisWeekTotal.toFixed(2),
       icon: Calendar,
+      iconClassName: 'text-info',
       subtext: `From ${metrics.weekCount} donations`,
+      subtextClassName: 'text-info/70',
     },
     {
       name: 'Avg. Donation',
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.avgDonation.toFixed(2)}` : metrics.avgDonation.toFixed(2),
       icon: HandCoins,
+      iconClassName: 'text-warning',
       subtext: 'Per contribution',
+      subtextClassName: 'text-warning/70',
     },
   ];
 
@@ -159,7 +167,15 @@ function OfferingsDashboard() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {highlights.map((h) => (
-          <MetricCard key={h.name} label={h.name} value={h.value} icon={h.icon} subtext={h.subtext} />
+          <MetricCard
+            key={h.name}
+            label={h.name}
+            value={h.value}
+            icon={h.icon}
+            iconClassName={h.iconClassName}
+            subtext={h.subtext}
+            subtextClassName={h.subtextClassName}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- add style props for `MetricCard` icons and sublabels
- color metric icons on the Financial Overview Dashboard
- color metric icons on the Offerings Dashboard

## Testing
- `npx eslint src/components/dashboard/MetricCard.tsx --fix`
- `npx eslint src/pages/finances/FinancialOverviewDashboard.tsx --fix`
- `npx eslint src/pages/offerings/OfferingsDashboard.tsx --fix`
- `npm test`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68673c7102008326a38ee43edae6ee70