### PR TITLE
Fix offerings batch entry link

### DIFF
--- a/src/pages/offerings/OfferingsDashboard.tsx
+++ b/src/pages/offerings/OfferingsDashboard.tsx
@@ -199,7 +199,7 @@ function OfferingsDashboard() {
                   <span className="text-xs font-normal">Individual entry form</span>
                 </Card>
               </Link>
-              <Link to="/finances/giving/import" className="w-full md:w-1/2">
+              <Link to="/finances/giving/add" className="w-full md:w-1/2">
                 <Card className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium py-5 px-6 rounded-lg flex flex-col items-center justify-center gap-1" hoverable>
                   <FileText className="text-xl text-gray-600 dark:text-gray-300" />
                   <span>Batch Entry</span>


### PR DESCRIPTION
## Summary
- fix link for Batch Entry from Offerings dashboard so it navigates to IncomeExpenseAddEdit

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686740fcdc648326954047e5d7ce697f