### PR TITLE
Ensure transaction entries ordered by creation date

### DIFF
--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -261,7 +261,8 @@ export class FinancialTransactionHeaderAdapter
       `
       )
       .eq('tenant_id', tenantId)
-      .eq('header_id', headerId);
+      .eq('header_id', headerId)
+      .order('created_at', { ascending: true });
 
     if (error) throw error;
     return data || [];


### PR DESCRIPTION
## Summary
- order entries by creation time when fetching financial transactions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686786983b408326a0bfadd2f7181931