### PR TITLE
Add settings table and service

### DIFF
--- a/src/adapters/setting.adapter.ts
+++ b/src/adapters/setting.adapter.ts
@@ -1,0 +1,33 @@
+import 'reflect-metadata';
+import { injectable, inject } from 'inversify';
+import { BaseAdapter } from './base.adapter';
+import { Setting } from '../models/setting.model';
+import { TYPES } from '../lib/types';
+import { AuditService } from '../services/AuditService';
+
+export interface ISettingAdapter extends BaseAdapter<Setting> {}
+
+@injectable()
+export class SettingAdapter
+  extends BaseAdapter<Setting>
+  implements ISettingAdapter
+{
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
+    super();
+  }
+
+  protected tableName = 'settings';
+
+  protected defaultSelect = `
+    id,
+    tenant_id,
+    user_id,
+    key,
+    value,
+    created_by,
+    updated_by,
+    created_at,
+    updated_at,
+    deleted_at
+  `;
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,3 +29,5 @@ export * from './useMembershipTypeRepository';
 export * from './useMembershipStatusRepository';
 export * from './useDonationImportService';
 export * from './useOfferingDashboardData';
+export * from './useSettingRepository';
+export * from './useSettingService';

--- a/src/hooks/useSettingRepository.ts
+++ b/src/hooks/useSettingRepository.ts
@@ -1,0 +1,9 @@
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { ISettingRepository } from '../repositories/setting.repository';
+import { useBaseRepository } from './useBaseRepository';
+
+export function useSettingRepository() {
+  const repository = container.get<ISettingRepository>(TYPES.ISettingRepository);
+  return useBaseRepository(repository, 'Setting', 'settings');
+}

--- a/src/hooks/useSettingService.ts
+++ b/src/hooks/useSettingService.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import { NotificationService } from '../services/NotificationService';
+import type { SettingService } from '../services/SettingService';
+
+export function useSettingService(key: string) {
+  const service = container.get<SettingService>(TYPES.SettingService);
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ['setting', key],
+    queryFn: () => service.getSetting(key),
+  });
+
+  const mutation = useMutation({
+    mutationFn: (value: string) => service.setSetting(key, value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['setting', key] });
+      NotificationService.showSuccess('Setting saved');
+    },
+    onError: (error: Error) => {
+      NotificationService.showError(error.message, 5000);
+    },
+  });
+
+  const updateSetting = async (value: string) => mutation.mutateAsync(value);
+
+  return { query, updateSetting, mutation };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -122,6 +122,9 @@ import {
 } from '../repositories/sourceRecentTransaction.repository';
 import { MessageThreadRepository, type IMessageThreadRepository } from '../repositories/messageThread.repository';
 import { MessageRepository, type IMessageRepository } from '../repositories/message.repository';
+import { SettingAdapter, type ISettingAdapter } from '../adapters/setting.adapter';
+import { SettingRepository, type ISettingRepository } from '../repositories/setting.repository';
+import { SupabaseSettingService, type SettingService } from '../services/SettingService';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { IncomeExpenseTransactionService } from '../services/IncomeExpenseTransactionService';
 import { DonationImportService } from '../services/DonationImportService';
@@ -235,6 +238,10 @@ container
   .bind<IMessageAdapter>(TYPES.IMessageAdapter)
   .to(MessageAdapter)
   .inSingletonScope();
+container
+  .bind<ISettingAdapter>(TYPES.ISettingAdapter)
+  .to(SettingAdapter)
+  .inSingletonScope();
 
 // Register services
 container
@@ -260,6 +267,10 @@ container
 container
   .bind<AnnouncementService>(TYPES.AnnouncementService)
   .to(SupabaseAnnouncementService)
+  .inSingletonScope();
+container
+  .bind<SettingService>(TYPES.SettingService)
+  .to(SupabaseSettingService)
   .inSingletonScope();
 
 // Register repositories
@@ -368,6 +379,10 @@ container
 container
   .bind<IMessageRepository>(TYPES.IMessageRepository)
   .to(MessageRepository)
+  .inSingletonScope();
+container
+  .bind<ISettingRepository>(TYPES.ISettingRepository)
+  .to(SettingRepository)
   .inSingletonScope();
 
 export { container };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,8 @@ export const TYPES = {
   IMessageAdapter: 'IMessageAdapter',
   IMessageThreadRepository: 'IMessageThreadRepository',
   IMessageRepository: 'IMessageRepository',
+  ISettingAdapter: 'ISettingAdapter',
+  ISettingRepository: 'ISettingRepository',
   IFinanceDashboardAdapter: 'IFinanceDashboardAdapter',
   IFinanceDashboardRepository: 'IFinanceDashboardRepository',
   ISourceRecentTransactionAdapter: 'ISourceRecentTransactionAdapter',
@@ -54,5 +56,6 @@ export const TYPES = {
   ActivityLogService: 'ActivityLogService',
   IncomeExpenseTransactionService: 'IncomeExpenseTransactionService',
   AnnouncementService: 'AnnouncementService',
-  DonationImportService: 'DonationImportService'
+  DonationImportService: 'DonationImportService',
+  SettingService: 'SettingService'
 };

--- a/src/models/setting.model.ts
+++ b/src/models/setting.model.ts
@@ -1,0 +1,9 @@
+import { BaseModel } from './base.model';
+
+export interface Setting extends BaseModel {
+  id: string;
+  tenant_id?: string | null;
+  user_id?: string | null;
+  key: string;
+  value: string;
+}

--- a/src/repositories/setting.repository.ts
+++ b/src/repositories/setting.repository.ts
@@ -1,0 +1,37 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { Setting } from '../models/setting.model';
+import type { ISettingAdapter } from '../adapters/setting.adapter';
+import { SettingValidator } from '../validators/setting.validator';
+
+export interface ISettingRepository extends BaseRepository<Setting> {
+  getByKey(key: string): Promise<Setting | null>;
+}
+
+@injectable()
+export class SettingRepository
+  extends BaseRepository<Setting>
+  implements ISettingRepository
+{
+  constructor(@inject('ISettingAdapter') adapter: ISettingAdapter) {
+    super(adapter);
+  }
+
+  async getByKey(key: string): Promise<Setting | null> {
+    const { data } = await this.find({
+      filters: { key: { operator: 'eq', value: key } },
+      pagination: { page: 1, pageSize: 1 },
+    });
+    return data?.[0] || null;
+  }
+
+  protected override async beforeCreate(data: Partial<Setting>): Promise<Partial<Setting>> {
+    SettingValidator.validate(data);
+    return data;
+  }
+
+  protected override async beforeUpdate(id: string, data: Partial<Setting>): Promise<Partial<Setting>> {
+    SettingValidator.validate(data);
+    return data;
+  }
+}

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -1,0 +1,66 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { ISettingRepository } from '../repositories/setting.repository';
+import type { Setting } from '../models/setting.model';
+import { tenantUtils } from '../utils/tenantUtils';
+import { supabase } from '../lib/supabase';
+
+export interface SettingService {
+  getSetting(key: string): Promise<Setting | null>;
+  setSetting(key: string, value: string, scope?: 'tenant' | 'user' | 'app'): Promise<Setting>;
+  getTenantCurrency(): Promise<string | null>;
+  setTenantCurrency(code: string): Promise<Setting>;
+  getUserWelcomeFlag(): Promise<boolean>;
+  setUserWelcomeFlag(value: boolean): Promise<Setting>;
+}
+
+@injectable()
+export class SupabaseSettingService implements SettingService {
+  constructor(
+    @inject(TYPES.ISettingRepository)
+    private repo: ISettingRepository,
+  ) {}
+
+  async getSetting(key: string): Promise<Setting | null> {
+    return this.repo.getByKey(key);
+  }
+
+  private async upsertSetting(key: string, value: string, scope: 'tenant' | 'user' | 'app' = 'tenant'): Promise<Setting> {
+    const existing = await this.repo.getByKey(key);
+    const { data: { user } } = await supabase.auth.getUser();
+    const tenantId = await tenantUtils.getTenantId();
+    const payload: Partial<Setting> = { key, value };
+    if (scope === 'tenant') {
+      payload.tenant_id = tenantId || undefined;
+    } else if (scope === 'user') {
+      payload.user_id = user?.id;
+      payload.tenant_id = tenantId || undefined;
+    }
+    if (existing) {
+      return this.repo.update(existing.id, { value });
+    }
+    return this.repo.create(payload as Partial<Setting>);
+  }
+
+  async setSetting(key: string, value: string, scope: 'tenant' | 'user' | 'app' = 'tenant'): Promise<Setting> {
+    return this.upsertSetting(key, value, scope);
+  }
+
+  async getTenantCurrency(): Promise<string | null> {
+    const setting = await this.getSetting('tenant.currency');
+    return setting?.value || null;
+  }
+
+  async setTenantCurrency(code: string): Promise<Setting> {
+    return this.upsertSetting('tenant.currency', code, 'tenant');
+  }
+
+  async getUserWelcomeFlag(): Promise<boolean> {
+    const setting = await this.getSetting('user.welcome_shown');
+    return setting?.value === 'true';
+  }
+
+  async setUserWelcomeFlag(value: boolean): Promise<Setting> {
+    return this.upsertSetting('user.welcome_shown', value.toString(), 'user');
+  }
+}

--- a/src/stores/currencyStore.ts
+++ b/src/stores/currencyStore.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { SettingService } from '../services/SettingService';
 
 export type Currency = {
   code: 'USD' | 'PHP' | 'MYR';
@@ -17,11 +20,16 @@ interface CurrencyState {
   setCurrency: (currency: Currency) => void;
 }
 
+const settingService = container.get<SettingService>(TYPES.SettingService);
+
 export const useCurrencyStore = create<CurrencyState>()(
   persist(
     (set) => ({
       currency: currencies.USD,
-      setCurrency: (currency) => set({ currency }),
+      setCurrency: (currency) => {
+        set({ currency });
+        settingService.setTenantCurrency(currency.code).catch(() => {});
+      },
     }),
     {
       name: 'currency-settings',
@@ -31,6 +39,11 @@ export const useCurrencyStore = create<CurrencyState>()(
         if (state?.currency && !currencies[state.currency.code]) {
           state.currency = currencies.USD;
         }
+        settingService.getTenantCurrency().then(code => {
+          if (code && currencies[code]) {
+            useCurrencyStore.setState({ currency: currencies[code] });
+          }
+        }).catch(() => {});
       },
     }
   )

--- a/src/stores/welcomeStore.ts
+++ b/src/stores/welcomeStore.ts
@@ -1,19 +1,32 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { SettingService } from '../services/SettingService';
 
 interface WelcomeState {
   hasSeenWelcome: boolean;
   setHasSeenWelcome: (value: boolean) => void;
 }
 
+const settingService = container.get<SettingService>(TYPES.SettingService);
+
 export const useWelcomeStore = create<WelcomeState>()(
   persist(
     (set) => ({
       hasSeenWelcome: false,
-      setHasSeenWelcome: (value) => set({ hasSeenWelcome: value }),
+      setHasSeenWelcome: (value) => {
+        set({ hasSeenWelcome: value });
+        settingService.setUserWelcomeFlag(value).catch(() => {});
+      },
     }),
     {
       name: 'welcome-settings',
+      onRehydrateStorage: () => () => {
+        settingService.getUserWelcomeFlag().then(flag => {
+          useWelcomeStore.setState({ hasSeenWelcome: flag });
+        }).catch(() => {});
+      }
     }
   )
 );

--- a/src/validators/setting.validator.ts
+++ b/src/validators/setting.validator.ts
@@ -1,0 +1,12 @@
+import { Setting } from '../models/setting.model';
+
+export class SettingValidator {
+  static validate(data: Partial<Setting>): void {
+    if (data.key !== undefined && !data.key.trim()) {
+      throw new Error('Setting key is required');
+    }
+    if (data.value === undefined || data.value === null) {
+      throw new Error('Setting value is required');
+    }
+  }
+}

--- a/supabase/migrations/20250722000000_settings_table.sql
+++ b/supabase/migrations/20250722000000_settings_table.sql
@@ -1,0 +1,76 @@
+-- Create settings table for tenant, user and global settings
+CREATE TABLE IF NOT EXISTS settings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid REFERENCES tenants(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  key text NOT NULL,
+  value text NOT NULL,
+  created_by uuid REFERENCES auth.users(id),
+  updated_by uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  deleted_at timestamptz
+);
+
+-- Unique key within scope
+CREATE UNIQUE INDEX IF NOT EXISTS settings_key_unique
+  ON settings(tenant_id, user_id, key);
+CREATE INDEX IF NOT EXISTS settings_tenant_id_idx ON settings(tenant_id);
+CREATE INDEX IF NOT EXISTS settings_user_id_idx ON settings(user_id);
+CREATE INDEX IF NOT EXISTS settings_deleted_at_idx ON settings(deleted_at);
+
+-- Enable RLS
+ALTER TABLE settings ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+DROP POLICY IF EXISTS "Settings are viewable" ON settings;
+CREATE POLICY "Settings are viewable" ON settings
+  FOR SELECT TO authenticated
+  USING (
+    (tenant_id IS NULL OR check_tenant_access(tenant_id)) AND
+    (user_id IS NULL OR user_id = auth.uid()) AND
+    deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS "Settings can be managed" ON settings;
+CREATE POLICY "Settings can be managed" ON settings
+  FOR ALL TO authenticated
+  USING (
+    (tenant_id IS NULL OR check_tenant_access(tenant_id)) AND
+    (user_id IS NULL OR user_id = auth.uid()) AND
+    deleted_at IS NULL
+  )
+  WITH CHECK (
+    (tenant_id IS NULL OR check_tenant_access(tenant_id)) AND
+    (user_id IS NULL OR user_id = auth.uid())
+  );
+
+-- updated_at trigger
+CREATE TRIGGER update_settings_updated_at
+BEFORE UPDATE ON settings
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- Auto assign tenant_id based on user if missing
+CREATE OR REPLACE FUNCTION set_setting_tenant_id()
+RETURNS TRIGGER AS $$
+DECLARE
+  user_tenant_id uuid;
+BEGIN
+  IF NEW.tenant_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT tenant_id INTO user_tenant_id
+  FROM tenant_users
+  WHERE user_id = NEW.user_id
+  LIMIT 1;
+
+  NEW.tenant_id := user_tenant_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_setting_tenant_id_trigger ON settings;
+CREATE TRIGGER set_setting_tenant_id_trigger
+BEFORE INSERT ON settings
+FOR EACH ROW EXECUTE FUNCTION set_setting_tenant_id();


### PR DESCRIPTION
## Summary
- add settings SQL migration with tenant/user flags
- implement Setting model, adapter, repository, validator and service
- expose hooks for settings repository/service
- update DI container and types for settings
- store tenant currency and welcome flag via new setting service

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678c65ce4883268a035072a3f05771