### PR TITLE
Add audit info columns to select lists

### DIFF
--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { format } from 'date-fns';
 import { Link, useNavigate } from "react-router-dom";
 import { useAccountRepository } from "../../../hooks/useAccountRepository";
 import { Account } from "../../../models/account.model";
@@ -53,7 +54,12 @@ function AccountList() {
   const { useQuery: useAccountsQuery, useDelete } = useAccountRepository();
 
   // Get accounts
-  const { data: result, isLoading, error } = useAccountsQuery();
+  const { data: result, isLoading, error } = useAccountsQuery({
+    relationships: [
+      { table: 'auth.users', foreignKey: 'created_by', alias: 'created_by_user', select: ['email'] },
+      { table: 'auth.users', foreignKey: 'updated_by', alias: 'updated_by_user', select: ['email'] },
+    ],
+  });
   const accounts = result?.data || [];
   const deleteAccountMutation = useDelete();
 
@@ -142,6 +148,22 @@ function AccountList() {
             <span>{params.value}</span>
           </div>
         ) : null,
+    },
+    { field: 'created_by_user', headerName: 'Created By', flex: 1.5, minWidth: 150, valueGetter: params => params.row.created_by_user?.email },
+    { field: 'updated_by_user', headerName: 'Modified By', flex: 1.5, minWidth: 150, valueGetter: params => params.row.updated_by_user?.email },
+    {
+      field: 'created_at',
+      headerName: 'Created Date',
+      flex: 1,
+      minWidth: 150,
+      valueFormatter: params => params.value ? format(new Date(params.value as string), 'MMM d, yyyy') : '',
+    },
+    {
+      field: 'updated_at',
+      headerName: 'Modified Date',
+      flex: 1,
+      minWidth: 150,
+      valueFormatter: params => params.value ? format(new Date(params.value as string), 'MMM d, yyyy') : '',
     },
     {
       field: "is_active",

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { format } from 'date-fns';
 import { Link, useNavigate } from 'react-router-dom';
 import { useFinancialSourceRepository } from '../../../hooks/useFinancialSourceRepository';
 import { FinancialSource } from '../../../models/financialSource.model';
@@ -22,7 +23,12 @@ function FinancialSourceList() {
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
   
   // Get sources
-  const { data: result, isLoading, error } = useSourcesQuery();
+  const { data: result, isLoading, error } = useSourcesQuery({
+    relationships: [
+      { table: 'auth.users', foreignKey: 'created_by', alias: 'created_by_user', select: ['email'] },
+      { table: 'auth.users', foreignKey: 'updated_by', alias: 'updated_by_user', select: ['email'] },
+    ],
+  });
   const sources = result?.data || [];
   
   // Filter sources
@@ -102,7 +108,7 @@ function FinancialSourceList() {
       flex: 1,
       minWidth: 120,
       renderCell: (params) => (
-        <Badge 
+        <Badge
           variant={params.value ? 'success' : 'secondary'}
           className="flex items-center"
         >
@@ -119,6 +125,22 @@ function FinancialSourceList() {
           )}
         </Badge>
       ),
+    },
+    { field: 'created_by_user', headerName: 'Created By', flex: 1.5, minWidth: 150, valueGetter: params => params.row.created_by_user?.email },
+    { field: 'updated_by_user', headerName: 'Modified By', flex: 1.5, minWidth: 150, valueGetter: params => params.row.updated_by_user?.email },
+    {
+      field: 'created_at',
+      headerName: 'Created Date',
+      flex: 1,
+      minWidth: 150,
+      valueFormatter: params => params.value ? format(new Date(params.value as string), 'MMM d, yyyy') : '',
+    },
+    {
+      field: 'updated_at',
+      headerName: 'Modified Date',
+      flex: 1,
+      minWidth: 150,
+      valueFormatter: params => params.value ? format(new Date(params.value as string), 'MMM d, yyyy') : '',
     },
   ];
 

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
+import { format } from 'date-fns';
 import { Link, useNavigate } from 'react-router-dom';
 import { ColumnDef, ColumnFiltersState, SortingState } from '@tanstack/react-table';
 import { useQuery as useReactQuery } from '@tanstack/react-query';
@@ -98,6 +99,20 @@ function MemberList() {
       ascending: !sorting[0].desc,
     } : undefined,
     filters,
+    relationships: [
+      {
+        table: 'auth.users',
+        foreignKey: 'created_by',
+        alias: 'created_by_user',
+        select: ['email'],
+      },
+      {
+        table: 'auth.users',
+        foreignKey: 'updated_by',
+        alias: 'updated_by_user',
+        select: ['email'],
+      },
+    ],
   });
 
   const deleteMemberMutation = useDelete();
@@ -205,6 +220,32 @@ function MemberList() {
             {value ? new Date(value).toLocaleDateString() : ''}
           </div>
         );
+      },
+    },
+    {
+      id: 'created_by_user',
+      header: 'Created By',
+      accessorFn: row => row.created_by_user?.email,
+    },
+    {
+      id: 'updated_by_user',
+      header: 'Modified By',
+      accessorFn: row => row.updated_by_user?.email,
+    },
+    {
+      accessorKey: 'created_at',
+      header: 'Created Date',
+      cell: ({ getValue }) => {
+        const value = getValue<string | null>();
+        return value ? format(new Date(value), 'MMM d, yyyy') : '';
+      },
+    },
+    {
+      accessorKey: 'updated_at',
+      header: 'Modified Date',
+      cell: ({ getValue }) => {
+        const value = getValue<string | null>();
+        return value ? format(new Date(value), 'MMM d, yyyy') : '';
       },
     },
   ];


### PR DESCRIPTION
## Summary
- extend queries to fetch created/updated user
- show audit columns in MemberList, AccountList and FinancialSourceList

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68678ee9f0a88326a53f47287b84529a