### PR TITLE
Add expenses dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const Settings = React.lazy(() => import('./pages/Settings'));
 const Members = React.lazy(() => import('./pages/members/Members'));
 const Finances = React.lazy(() => import('./pages/finances/Finances'));
 const Offerings = React.lazy(() => import('./pages/offerings/Offerings'));
+const Expenses = React.lazy(() => import('./pages/expenses/Expenses'));
 const Accounts = React.lazy(() => import('./pages/accounts/Accounts'));
 const Administration = React.lazy(() => import('./pages/admin/Administration'));
 const AnnouncementList = React.lazy(() => import('./pages/announcements/AnnouncementList'));
@@ -146,6 +147,7 @@ function App() {
                   <Route path="/dashboard/*" element={<Dashboard />} />
                   <Route path="/members/*" element={<Members />} />
                   <Route path="/finances/*" element={<Finances />} />
+                  <Route path="/expenses/*" element={<Expenses />} />
                   <Route path="/offerings/*" element={<Offerings />} />
                   <Route path="/accounts/*" element={<Accounts />} />
                   <Route path="/announcements" element={<AnnouncementList />} />

--- a/src/components/finances/ExpenseActions.tsx
+++ b/src/components/finances/ExpenseActions.tsx
@@ -1,0 +1,334 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../ui2/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui2/alert-dialog';
+import { Button } from '../ui2/button';
+import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
+import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useCurrencyStore } from '../../stores/currencyStore';
+import { formatCurrency } from '../../utils/currency';
+import type { ExpenseItem } from './RecentExpenseItem';
+import {
+  Eye,
+  Edit,
+  MoreHorizontal,
+  FileText,
+  Check,
+  X,
+  Trash2,
+  Loader2,
+  AlertTriangle,
+} from 'lucide-react';
+import { format } from 'date-fns';
+
+interface ExpenseActionsProps {
+  expense: ExpenseItem;
+}
+
+export default function ExpenseActions({ expense }: ExpenseActionsProps) {
+  const navigate = useNavigate();
+  const { currency } = useCurrencyStore();
+  const {
+    submitTransaction,
+    approveTransaction,
+    postTransaction,
+    useUpdate,
+  } = useFinancialTransactionHeaderRepository();
+  const updateMutation = useUpdate();
+  const { deleteTransaction } = useIncomeExpenseService('expense');
+  const { hasPermission } = usePermissions();
+
+  const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [showSubmitDialog, setShowSubmitDialog] = React.useState(false);
+  const [showApproveDialog, setShowApproveDialog] = React.useState(false);
+  const [showPostDialog, setShowPostDialog] = React.useState(false);
+  const [showEditDialog, setShowEditDialog] = React.useState(false);
+  const [actionInProgress, setActionInProgress] = React.useState(false);
+  const [actionError, setActionError] = React.useState<string | null>(null);
+
+  const canEdit = expense.header?.status === 'draft';
+
+  const displayName = expense.accounts?.name ||
+    (expense.member ? `${expense.member.first_name} ${expense.member.last_name}` : 'Anonymous');
+
+  const info = (
+    <div className="mt-4 border rounded-md p-3 text-left space-y-1">
+      <p className="font-medium">{displayName}</p>
+      <p className="text-sm text-muted-foreground">{expense.categories?.name || 'Uncategorized'}</p>
+      <p className="text-sm text-muted-foreground">{format(new Date(expense.transaction_date), 'MMM d, yyyy')}</p>
+      <p className="text-sm text-muted-foreground">{formatCurrency(expense.amount, currency)}</p>
+    </div>
+  );
+
+  const handleDelete = async () => {
+    try {
+      setActionInProgress(true);
+      setActionError(null);
+      await deleteTransaction(expense.id);
+      setShowDeleteDialog(false);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete expense');
+      console.error('Failed to delete expense', err);
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!expense.header_id) return;
+    try {
+      setActionInProgress(true);
+      setActionError(null);
+      await submitTransaction(expense.header_id);
+      setShowSubmitDialog(false);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to submit expense');
+      console.error('Failed to submit expense', err);
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handleApprove = async () => {
+    if (!expense.header_id) return;
+    try {
+      setActionInProgress(true);
+      setActionError(null);
+      await approveTransaction(expense.header_id);
+      setShowApproveDialog(false);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to approve expense');
+      console.error('Failed to approve expense', err);
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!expense.header_id) return;
+    try {
+      setActionInProgress(true);
+      setActionError(null);
+      await updateMutation.mutateAsync({ id: expense.header_id, data: { status: 'draft' } });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to reject expense');
+      console.error('Failed to reject expense', err);
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handlePost = async () => {
+    if (!expense.header_id) return;
+    try {
+      setActionInProgress(true);
+      setActionError(null);
+      await postTransaction(expense.header_id);
+      setShowPostDialog(false);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to post expense');
+      console.error('Failed to post expense', err);
+    } finally {
+      setActionInProgress(false);
+    }
+  };
+
+  const handleEdit = () => {
+    if (!expense.header_id) return;
+    navigate(`/finances/expenses/${expense.header_id}/edit`);
+  };
+
+  const handleView = () => {
+    if (!expense.header_id) return;
+    navigate(`/finances/expenses/${expense.header_id}`);
+  };
+
+  return (
+    <>
+      <div className="flex items-center space-x-1">
+        <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={handleView}>
+          <Eye className="h-4 w-4" />
+        </Button>
+        {canEdit && (
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0" onClick={() => setShowEditDialog(true)}>
+            <Edit className="h-4 w-4" />
+          </Button>
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={handleView} className="flex items-center">
+              <Eye className="h-4 w-4 mr-2" /> View
+            </DropdownMenuItem>
+            {canEdit && (
+              <DropdownMenuItem onClick={() => setShowEditDialog(true)} className="flex items-center">
+                <Edit className="h-4 w-4 mr-2" /> Edit
+              </DropdownMenuItem>
+            )}
+            {expense.header?.status === 'draft' && (
+              <DropdownMenuItem onClick={() => setShowSubmitDialog(true)} className="flex items-center">
+                <FileText className="h-4 w-4 mr-2" /> Submit
+              </DropdownMenuItem>
+            )}
+            {expense.header?.status === 'submitted' && hasPermission('finance.approve') && (
+              <DropdownMenuItem onClick={() => setShowApproveDialog(true)} className="flex items-center">
+                <Check className="h-4 w-4 mr-2" /> Approve
+              </DropdownMenuItem>
+            )}
+            {expense.header?.status === 'submitted' && hasPermission('finance.approve') && (
+              <DropdownMenuItem onClick={handleReject} className="flex items-center">
+                <X className="h-4 w-4 mr-2" /> Reject
+              </DropdownMenuItem>
+            )}
+            {expense.header?.status === 'approved' && hasPermission('finance.approve') && (
+              <DropdownMenuItem onClick={() => setShowPostDialog(true)} className="flex items-center">
+                <Check className="h-4 w-4 mr-2" /> Post
+              </DropdownMenuItem>
+            )}
+            {canEdit && (
+              <DropdownMenuItem onClick={() => setShowDeleteDialog(true)} className="flex items-center text-destructive">
+                <Trash2 className="h-4 w-4 mr-2" /> Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Edit Confirmation Dialog */}
+      <AlertDialog open={showEditDialog} onOpenChange={setShowEditDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="default">Edit Expense</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to edit this expense?
+              {info}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setShowEditDialog(false)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleEdit}>Edit</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="danger">Delete Expense</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete this expense?
+              {info}
+              {actionError && (
+                <div className="mt-2 p-2 bg-destructive/10 border border-destructive/20 rounded-md text-destructive flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{actionError}</span>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => { setShowDeleteDialog(false); setActionError(null); }} disabled={actionInProgress}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" onClick={handleDelete} disabled={actionInProgress}>
+              {actionInProgress ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Deleting...</>) : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Submit Confirmation Dialog */}
+      <AlertDialog open={showSubmitDialog} onOpenChange={setShowSubmitDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="default">Submit Expense</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to submit this expense for approval?
+              {info}
+              {actionError && (
+                <div className="mt-2 p-2 bg-destructive/10 border border-destructive/20 rounded-md text-destructive flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{actionError}</span>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => { setShowSubmitDialog(false); setActionError(null); }} disabled={actionInProgress}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleSubmit} disabled={actionInProgress}>
+              {actionInProgress ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Submitting...</>) : 'Submit'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Approve Confirmation Dialog */}
+      <AlertDialog open={showApproveDialog} onOpenChange={setShowApproveDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="success">Approve Expense</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to approve this expense?
+              {info}
+              {actionError && (
+                <div className="mt-2 p-2 bg-destructive/10 border border-destructive/20 rounded-md text-destructive flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{actionError}</span>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => { setShowApproveDialog(false); setActionError(null); }} disabled={actionInProgress}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleApprove} disabled={actionInProgress}>
+              {actionInProgress ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Approving...</>) : 'Approve'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Post Confirmation Dialog */}
+      <AlertDialog open={showPostDialog} onOpenChange={setShowPostDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle variant="success">Post Expense</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to post this expense? Once posted, it cannot be edited or deleted.
+              {info}
+              {actionError && (
+                <div className="mt-2 p-2 bg-destructive/10 border border-destructive/20 rounded-md text-destructive flex items-start">
+                  <AlertTriangle className="h-5 w-5 mr-2 flex-shrink-0 mt-0.5" />
+                  <span>{actionError}</span>
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => { setShowPostDialog(false); setActionError(null); }} disabled={actionInProgress}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handlePost} disabled={actionInProgress}>
+              {actionInProgress ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Posting...</>) : 'Post'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/finances/RecentExpenseItem.tsx
+++ b/src/components/finances/RecentExpenseItem.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Card, CardContent } from '../ui2/card';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui2/avatar';
+import { useCurrencyStore } from '../../stores/currencyStore';
+import { formatCurrency } from '../../utils/currency';
+import ExpenseActions from './ExpenseActions';
+
+export interface ExpenseItem {
+  id: string;
+  transaction_date: string;
+  amount: number;
+  header_id: string | null;
+  header?: { status: string } | null;
+  member?: {
+    first_name: string;
+    last_name: string;
+    profile_picture_url: string | null;
+  } | null;
+  accounts?: {
+    name: string;
+  } | null;
+  categories?: {
+    name: string;
+  } | null;
+}
+
+interface Props {
+  expense: ExpenseItem;
+}
+
+export default function RecentExpenseItem({ expense }: Props) {
+  const { currency } = useCurrencyStore();
+  const name = expense.member
+    ? `${expense.member.first_name} ${expense.member.last_name}`
+    : "Anonymous";
+  const displayName = expense.accounts?.name || name;
+
+  return (
+    <Card size="sm" hoverable className="dark:bg-gray-600">
+      <CardContent className="flex justify-between items-center gap-4 py-3 px-4">
+        <div className="flex items-center gap-3">
+          <Avatar size="md">
+            {expense.member?.profile_picture_url && (
+              <AvatarImage
+                src={expense.member.profile_picture_url}
+                alt={name}
+                crossOrigin="anonymous"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.display = "none";
+                }}
+              />
+            )}
+            <AvatarFallback className="bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-100 font-semibold">
+              {expense.accounts?.name
+                ? expense.accounts.name
+                    .split(" ")
+                    .map((word) => word.charAt(0))
+                    .join("")
+                    .slice(0, 2)
+                    .toUpperCase()
+                : "?"}
+            </AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="font-medium text-foreground">{displayName}</p>
+            <p className="text-sm text-muted-foreground">
+              {new Date(expense.transaction_date).toLocaleDateString(
+                undefined,
+                {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                }
+              )}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-right">
+            <p className="font-semibold text-foreground">
+              {formatCurrency(expense.amount, currency)}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {expense.categories?.name || 'Uncategorized'}
+            </p>
+          </div>
+          <ExpenseActions expense={expense} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,5 +29,6 @@ export * from './useMembershipTypeRepository';
 export * from './useMembershipStatusRepository';
 export * from './useDonationImportService';
 export * from './useOfferingDashboardData';
+export * from './useExpenseDashboardData';
 export * from './useSettingRepository';
 export * from './useSettingService';

--- a/src/hooks/useExpenseDashboardData.ts
+++ b/src/hooks/useExpenseDashboardData.ts
@@ -1,0 +1,110 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../lib/supabase';
+import { tenantUtils } from '../utils/tenantUtils';
+import { format, startOfMonth, endOfMonth, subMonths, startOfWeek, endOfWeek } from 'date-fns';
+import { useCurrencyStore } from '../stores/currencyStore';
+
+export function useExpenseDashboardData(dateRange: { from: Date; to: Date }) {
+  const { currency } = useCurrencyStore();
+
+  const fetchTotals = async (from: Date, to: Date) => {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) return [] as any[];
+    const { data, error } = await supabase
+      .from('income_expense_transactions')
+      .select('amount')
+      .eq('tenant_id', tenantId)
+      .eq('transaction_type', 'expense')
+      .gte('transaction_date', format(from, 'yyyy-MM-dd'))
+      .lte('transaction_date', format(to, 'yyyy-MM-dd'));
+    if (error) throw error;
+    return data || [];
+  };
+
+  const fetchCount = async (from: Date, to: Date) => {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) return 0;
+    const { count, error } = await supabase
+      .from('income_expense_transactions')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .eq('transaction_type', 'expense')
+      .gte('transaction_date', format(from, 'yyyy-MM-dd'))
+      .lte('transaction_date', format(to, 'yyyy-MM-dd'));
+    if (error) throw error;
+    return count || 0;
+  };
+
+  const fetchPayees = async () => {
+    const tenantId = await tenantUtils.getTenantId();
+    if (!tenantId) return 0;
+    const { data, error } = await supabase
+      .from('income_expense_transactions')
+      .select('account_id')
+      .eq('tenant_id', tenantId)
+      .eq('transaction_type', 'expense')
+      .not('account_id', 'is', null);
+    if (error) throw error;
+    const unique = new Set((data || []).map(r => r.account_id as string));
+    return unique.size;
+  };
+
+  const monthStart = startOfMonth(dateRange.from);
+  const monthEnd = endOfMonth(dateRange.to);
+  const prevMonthStart = startOfMonth(subMonths(monthStart, 1));
+  const prevMonthEnd = endOfMonth(subMonths(monthStart, 1));
+  const weekStart = startOfWeek(dateRange.to, { weekStartsOn: 0 });
+  const weekEnd = endOfWeek(dateRange.to, { weekStartsOn: 0 });
+
+  const { data: monthTotals } = useQuery({
+    queryKey: ['expense-summary', monthStart, monthEnd],
+    queryFn: () => fetchTotals(monthStart, monthEnd),
+  });
+
+  const { data: prevMonthTotals } = useQuery({
+    queryKey: ['expense-summary-prev', prevMonthStart, prevMonthEnd],
+    queryFn: () => fetchTotals(prevMonthStart, prevMonthEnd),
+  });
+
+  const { data: weekTotals } = useQuery({
+    queryKey: ['expense-summary-week', weekStart, weekEnd],
+    queryFn: () => fetchTotals(weekStart, weekEnd),
+  });
+
+  const { data: monthCount } = useQuery({
+    queryKey: ['expense-count', monthStart, monthEnd],
+    queryFn: () => fetchCount(monthStart, monthEnd),
+  });
+
+  const { data: weekCount } = useQuery({
+    queryKey: ['expense-count-week', weekStart, weekEnd],
+    queryFn: () => fetchCount(weekStart, weekEnd),
+  });
+
+  const { data: payeeCount } = useQuery({
+    queryKey: ['expense-payees'],
+    queryFn: fetchPayees,
+  });
+
+  const sumAmount = (rows: any[] | undefined) =>
+    rows?.reduce((sum, r) => sum + Number(r.amount), 0) || 0;
+
+  const thisMonthTotal = sumAmount(monthTotals);
+  const lastMonthTotal = sumAmount(prevMonthTotals);
+  const thisWeekTotal = sumAmount(weekTotals);
+
+  const monthChange =
+    lastMonthTotal > 0 ? ((thisMonthTotal - lastMonthTotal) / lastMonthTotal) * 100 : 0;
+
+  const avgExpense = monthCount && monthCount > 0 ? thisMonthTotal / monthCount : 0;
+
+  return {
+    currency,
+    thisMonthTotal,
+    monthChange,
+    payeeCount: payeeCount || 0,
+    thisWeekTotal,
+    weekCount: weekCount || 0,
+    avgExpense,
+  };
+}

--- a/src/pages/expenses/Expenses.tsx
+++ b/src/pages/expenses/Expenses.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+const ExpensesDashboard = React.lazy(() => import('./ExpensesDashboard'));
+
+function Expenses() {
+  return (
+    <Routes>
+      <Route index element={<ExpensesDashboard />} />
+    </Routes>
+  );
+}
+
+export default Expenses;

--- a/src/pages/expenses/ExpensesDashboard.tsx
+++ b/src/pages/expenses/ExpensesDashboard.tsx
@@ -1,0 +1,394 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { startOfMonth } from 'date-fns';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '../../components/ui2/card';
+import MetricCard from '../../components/dashboard/MetricCard';
+import { Container } from '../../components/ui2/container';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../components/ui2/tabs';
+import { Input } from '../../components/ui2/input';
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '../../components/ui2/dropdown-menu';
+import { Button } from '../../components/ui2/button';
+import SingleExpenseDialog from './SingleExpenseDialog';
+import {
+  Users,
+  Calendar,
+  HandCoins,
+  DollarSign,
+  Settings,
+  ChevronRight,
+  FileText,
+  Search,
+} from 'lucide-react';
+import ExpenseActions from '../../components/finances/ExpenseActions';
+import { ExpenseItem } from '../../components/finances/RecentExpenseItem';
+import { DataGrid } from '../../components/ui2/mui-datagrid';
+import { GridColDef } from '@mui/x-data-grid';
+import { Badge } from '../../components/ui2/badge';
+import { useCurrencyStore } from '../../stores/currencyStore';
+import { formatCurrency } from '../../utils/currency';
+import { format } from 'date-fns';
+import { useIncomeExpenseTransactionRepository } from '../../hooks/useIncomeExpenseTransactionRepository';
+import { useExpenseDashboardData } from '../../hooks/useExpenseDashboardData';
+import { tenantUtils } from '../../utils/tenantUtils';
+
+function ExpensesDashboard() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = React.useState('overview');
+  const [showExpenseDialog, setShowExpenseDialog] = React.useState(false);
+  const dateRange = React.useMemo(
+    () => ({ from: startOfMonth(new Date()), to: new Date() }),
+    []
+  );
+
+  const { data: tenant } = useQuery({
+    queryKey: ['current-tenant'],
+    queryFn: () => tenantUtils.getCurrentTenant(),
+  });
+
+  const metrics = useExpenseDashboardData(dateRange);
+  const { currency } = useCurrencyStore();
+
+  const [recentPage, setRecentPage] = React.useState(0);
+  const [recentPageSize, setRecentPageSize] = React.useState(5);
+  const [historyPage, setHistoryPage] = React.useState(0);
+  const [historyPageSize, setHistoryPageSize] = React.useState(5);
+
+  const statusVariantMap: Record<string, 'success' | 'warning' | 'info' | 'secondary' | 'destructive'> = {
+    posted: 'success',
+    approved: 'warning',
+    submitted: 'info',
+    draft: 'secondary',
+    voided: 'destructive',
+  };
+
+  const columns: GridColDef<ExpenseItem>[] = [
+    {
+      field: 'transaction_date',
+      headerName: 'Date',
+      flex: 1,
+      minWidth: 120,
+      renderCell: params => format(new Date(params.row.transaction_date), 'MMM d, yyyy'),
+    },
+    {
+      field: 'display_name',
+      headerName: 'Payee/Account',
+      flex: 1.5,
+      minWidth: 160,
+      valueGetter: params =>
+        params.row.accounts?.name ||
+        (params.row.member ? `${params.row.member.first_name} ${params.row.member.last_name}` : 'Anonymous'),
+    },
+    {
+      field: 'category',
+      headerName: 'Category',
+      flex: 1,
+      minWidth: 150,
+      valueGetter: params => params.row.categories?.name || 'Uncategorized',
+    },
+    {
+      field: 'amount',
+      headerName: 'Amount',
+      flex: 1,
+      minWidth: 120,
+      renderCell: params => formatCurrency(params.row.amount, currency),
+    },
+    {
+      field: 'status',
+      headerName: 'Status',
+      flex: 1,
+      minWidth: 120,
+      valueGetter: params => params.row.header?.status || 'draft',
+      renderCell: params => (
+        <Badge variant={statusVariantMap[params.value] || 'secondary'} className="capitalize">
+          {params.value}
+        </Badge>
+      ),
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      flex: 1,
+      minWidth: 120,
+      sortable: false,
+      filterable: false,
+      renderCell: params => <ExpenseActions expense={params.row} />,
+    },
+  ];
+
+  const { useQuery: useTxQuery } = useIncomeExpenseTransactionRepository();
+  const { data: recentResult } = useTxQuery({
+    filters: { transaction_type: { operator: 'eq', value: 'expense' } },
+    order: { column: 'transaction_date', ascending: false },
+    pagination: { page: 1, pageSize: 5 },
+    relationships: [
+      {
+        table: 'financial_transaction_headers',
+        foreignKey: 'header_id',
+        select: ['id', 'status'],
+      },
+      {
+        table: 'accounts',
+        foreignKey: 'account_id',
+        select: ['id', 'name'],
+      },
+      {
+        table: 'categories',
+        foreignKey: 'category_id',
+        select: ['id','code', 'name'],
+      },
+    ],
+    enabled: !!tenant?.id,
+  });
+  const recentExpenses = (recentResult?.data || []) as ExpenseItem[];
+
+  const [historySearch, setHistorySearch] = React.useState('');
+  const { data: historyResult } = useTxQuery({
+    filters: {
+      transaction_type: { operator: 'eq', value: 'expense' },
+      ...(historySearch.trim()
+        ? {
+            or: `description.ilike.*${historySearch.trim()}*,members.first_name.ilike.*${historySearch.trim()}*,members.last_name.ilike.*${historySearch.trim()}*`,
+          }
+        : {}),
+    },
+    order: { column: 'transaction_date', ascending: false },
+    pagination: { page: 1, pageSize: 5 },
+    relationships: [
+      {
+        table: 'financial_transaction_headers',
+        foreignKey: 'header_id',
+        select: ['id', 'status'],
+      },
+      {
+        table: 'accounts',
+        foreignKey: 'account_id',
+        select: ['id', 'name'],
+      },
+      {
+        table: 'categories',
+        foreignKey: 'category_id',
+        select: ['id','code', 'name'],
+      },
+    ],
+    enabled: !!tenant?.id,
+  });
+  const historyExpenses = (historyResult?.data || []) as ExpenseItem[];
+
+  const highlights = [
+    {
+      name: 'This Month',
+      value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisMonthTotal.toFixed(2)}` : metrics.thisMonthTotal.toFixed(2),
+      icon: DollarSign,
+      iconClassName: 'text-success',
+      subtext: `${metrics.monthChange.toFixed(1)}% from last month`,
+      subtextClassName: 'text-success/70',
+    },
+    {
+      name: 'Total Payees',
+      value: metrics.payeeCount,
+      icon: Users,
+      iconClassName: 'text-primary',
+      subtext: 'Active payees',
+      subtextClassName: 'text-primary/70',
+    },
+    {
+      name: 'This Week',
+      value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisWeekTotal.toFixed(2)}` : metrics.thisWeekTotal.toFixed(2),
+      icon: Calendar,
+      iconClassName: 'text-info',
+      subtext: `From ${metrics.weekCount} expenses`,
+      subtextClassName: 'text-info/70',
+    },
+    {
+      name: 'Avg. Expense',
+      value: metrics.currency ? `${metrics.currency.symbol}${metrics.avgExpense.toFixed(2)}` : metrics.avgExpense.toFixed(2),
+      icon: HandCoins,
+      iconClassName: 'text-warning',
+      subtext: 'Per transaction',
+      subtextClassName: 'text-warning/70',
+    },
+  ];
+
+  return (
+    <Container className="space-y-6 max-w-[1200px]" size="xl">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-foreground">Expenses</h1>
+          <p className="mt-2 text-sm text-muted-foreground">Track and manage church expenses</p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none flex gap-2 items-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon">
+                <Settings className="h-5 w-5" />
+                <span className="sr-only">Settings</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => navigate('/finances/funds')}>Setup funds</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate('/accounts/sources')}>Setup financial sources</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate('/accounts/chart-of-accounts')}>Setup chart of accounts</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate('/finances/configuration/donation-categories')}>Setup income categories</DropdownMenuItem>
+              <DropdownMenuItem onClick={() => navigate('/finances/configuration/expense-categories')}>Setup expense categories</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {highlights.map((h) => (
+          <MetricCard
+            key={h.name}
+            label={h.name}
+            value={h.value}
+            icon={h.icon}
+            iconClassName={h.iconClassName}
+            subtext={h.subtext}
+            subtextClassName={h.subtextClassName}
+          />
+        ))}
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="w-full grid grid-cols-2 bg-muted p-1 rounded-full">
+          <TabsTrigger value="overview" className="flex-1 text-sm font-medium px-6 py-2 rounded-full data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm">Overview</TabsTrigger>
+          <TabsTrigger value="history" className="flex-1 text-sm font-medium px-6 py-2 rounded-full data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm">History</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick Actions</CardTitle>
+              <CardDescription>Choose how you’d like to record expenses</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col md:flex-row gap-4">
+              <div className="w-full md:w-1/2">
+                <Card
+                  className="bg-gradient-to-r from-green-500 to-green-600 text-white font-semibold text-sm py-5 px-6 rounded-lg shadow-md flex flex-col items-center justify-center gap-1"
+                  hoverable
+                  onClick={() => setShowExpenseDialog(true)}
+                >
+                  <HandCoins className="text-white text-xl" />
+                  <span>Record Single Expense</span>
+                  <span className="text-xs font-normal">Individual entry form</span>
+                </Card>
+              </div>
+              <Link to="/finances/expenses/add" className="w-full md:w-1/2">
+                <Card className="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium py-5 px-6 rounded-lg flex flex-col items-center justify-center gap-1" hoverable>
+                  <FileText className="text-xl text-gray-600 dark:text-gray-300" />
+                  <span>Batch Entry</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">Spreadsheet-style entry</span>
+                </Card>
+              </Link>
+            </CardContent>
+          </Card>
+          <Card className="mt-4">
+            <CardContent className="space-y-4">
+              <div className="text-gray-900 dark:text-gray-100 mt-4">
+                <CardTitle>Recent Expenses</CardTitle>
+                <CardDescription>Latest donation entries</CardDescription>
+              </div>
+              {recentExpenses && recentExpenses.length > 0 ? (
+                <DataGrid<ExpenseItem>
+                  columns={columns}
+                  data={recentExpenses}
+                  totalRows={recentExpenses.length}
+                  paginationMode="client"
+                  page={recentPage}
+                  pageSize={recentPageSize}
+                  onPageChange={setRecentPage}
+                  onPageSizeChange={setRecentPageSize}
+                  getRowId={(row) => row.id}
+                  autoHeight
+                  showQuickFilter={false}
+                  onRowClick={(params) =>
+                    navigate(
+                      params.row.header?.status === 'draft'
+                        ? `/finances/expenses/${params.row.header_id}/edit`
+                        : `/finances/expenses/${params.row.header_id}`
+                    )
+                  }
+                  storageKey="recent-expenses-grid"
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">No recent expenses.</p>
+              )}
+              <div className="pt-4">
+                <Link to="/finances/expenses" className="text-sm text-primary font-medium flex items-center hover:underline">
+                  View all expenses <ChevronRight className="h-4 w-4 ml-1" />
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="history" className="mt-4">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between w-full space-y-4 md:space-y-0">
+                <div className="text-gray-900 dark:text-gray-100">
+                  <CardTitle>Expense Records</CardTitle>
+                  <CardDescription>Search and review expenses</CardDescription>
+                </div>
+                <div className="w-full md:w-auto">
+                  <Input
+                    value={historySearch}
+                    onChange={(e) => setHistorySearch(e.target.value)}
+                    placeholder="Search expenses..."
+                    icon={<Search className="h-4 w-4" />}
+                    className="w-full md:w-64"
+                  />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {historyExpenses && historyExpenses.length > 0 ? (
+                <DataGrid<ExpenseItem>
+                  columns={columns}
+                  data={historyExpenses}
+                  totalRows={historyExpenses.length}
+                  paginationMode="client"
+                  page={historyPage}
+                  pageSize={historyPageSize}
+                  onPageChange={setHistoryPage}
+                  onPageSizeChange={setHistoryPageSize}
+                  getRowId={(row) => row.id}
+                  autoHeight
+                  showQuickFilter={false}
+                  onRowClick={(params) =>
+                    navigate(
+                      params.row.header?.status === 'draft'
+                        ? `/finances/expenses/${params.row.header_id}/edit`
+                        : `/finances/expenses/${params.row.header_id}`
+                    )
+                  }
+                  storageKey="expense-records-grid"
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">No expenses found.</p>
+              )}
+              <div className="pt-4">
+                <Link to="/finances/expenses" className="text-sm text-primary font-medium flex items-center hover:underline">
+                  View all expenses <ChevronRight className="h-4 w-4 ml-1" />
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+      <SingleExpenseDialog
+        open={showExpenseDialog}
+        onOpenChange={setShowExpenseDialog}
+      />
+    </Container>
+  );
+}
+
+export default ExpensesDashboard;

--- a/src/pages/expenses/SingleExpenseDialog.tsx
+++ b/src/pages/expenses/SingleExpenseDialog.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { format } from 'date-fns';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '../../components/ui2/dialog';
+import { Button } from '../../components/ui2/button';
+import { Input } from '../../components/ui2/input';
+import { Combobox } from '../../components/ui2/combobox';
+import { DatePickerInput } from '../../components/ui2/date-picker';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '../../components/ui2/form';
+import { useAccountRepository } from '../../hooks/useAccountRepository';
+import { useFundRepository } from '../../hooks/useFundRepository';
+import { useCategoryRepository } from '../../hooks/useCategoryRepository';
+import { useFinancialSourceRepository } from '../../hooks/useFinancialSourceRepository';
+import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
+
+interface SingleExpenseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface FormValues {
+  transaction_date: Date;
+  description: string;
+  account_id: string;
+  fund_id: string;
+  category_id: string;
+  source_id: string;
+  amount: string;
+}
+
+export default function SingleExpenseDialog({ open, onOpenChange }: SingleExpenseDialogProps) {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      transaction_date: new Date(),
+      description: '',
+      account_id: '',
+      fund_id: '',
+      category_id: '',
+      source_id: '',
+      amount: '',
+    },
+  });
+
+  const { useQuery: useAccountsQuery } = useAccountRepository();
+  const { useQuery: useFundsQuery } = useFundRepository();
+  const { useQuery: useCategoriesQuery } = useCategoryRepository();
+  const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
+  const svc = useIncomeExpenseService('expense');
+
+  const accountsRes = useAccountsQuery();
+  const fundsRes = useFundsQuery();
+  const categoriesRes = useCategoriesQuery({
+    filters: { type: { operator: 'eq', value: 'expense_transaction' } },
+  });
+  const sourcesRes = useSourcesQuery({
+    filters: { is_active: { operator: 'eq', value: true } },
+  });
+
+  const accounts = accountsRes.data?.data || [];
+  const funds = fundsRes.data?.data || [];
+  const categories = categoriesRes.data?.data || [];
+  const sources = sourcesRes.data?.data || [];
+
+  const isLoading =
+    accountsRes.isLoading ||
+    fundsRes.isLoading ||
+    categoriesRes.isLoading ||
+    sourcesRes.isLoading;
+
+  const accountOptions = React.useMemo(
+    () => accounts.map(a => ({ value: a.id, label: a.name })),
+    [accounts]
+  );
+  const fundOptions = React.useMemo(
+    () => funds.map(f => ({ value: f.id, label: f.name })),
+    [funds]
+  );
+  const categoryOptions = React.useMemo(
+    () => categories.map(c => ({ value: c.id, label: c.name })),
+    [categories]
+  );
+  const sourceOptions = React.useMemo(
+    () => sources.map(s => ({ value: s.id, label: s.name })),
+    [sources]
+  );
+
+  const onSubmit = async (values: FormValues) => {
+    await svc.createBatch(
+      {
+        transaction_date: format(values.transaction_date, 'yyyy-MM-dd'),
+        description: values.description,
+      },
+      [
+        {
+          accounts_account_id: values.account_id,
+          fund_id: values.fund_id,
+          category_id: values.category_id,
+          source_id: values.source_id,
+          amount: parseFloat(values.amount || '0'),
+          source_account_id: sources.find(s => s.id === values.source_id)?.account_id || null,
+          category_account_id: categories.find(c => c.id === values.category_id)?.chart_of_account_id || null,
+        },
+      ]
+    );
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[90vw] sm:w-full sm:max-w-md max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Record Expense</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="transaction_date"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Date</FormLabel>
+                  <FormControl>
+                    <DatePickerInput value={field.value} onChange={field.onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="account_id"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Account</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      options={accountOptions}
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder={isLoading ? 'Loading...' : 'Select account'}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="fund_id"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Fund</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      options={fundOptions}
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder={isLoading ? 'Loading...' : 'Select fund'}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="category_id"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Category</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      options={categoryOptions}
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder={isLoading ? 'Loading...' : 'Select category'}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="source_id"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Source</FormLabel>
+                  <FormControl>
+                    <Combobox
+                      options={sourceOptions}
+                      value={field.value}
+                      onChange={field.onChange}
+                      placeholder={isLoading ? 'Loading...' : 'Select source'}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="amount"
+              rules={{ required: true }}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Amount</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={svc.createMutation.isPending}>
+                {svc.createMutation.isPending ? 'Saving...' : 'Save'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add expense dashboard hook with metrics
- add expense components and pages
- register `/expenses` route
- update navigation and exports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686791621b1c8326a1616e352b641e6e