### PR TITLE
Add source and fund balance charts to overview

### DIFF
--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -42,6 +42,11 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
     queryFn: () => repository.getFundBalances(),
   });
 
+  const { data: sourceBalances, isLoading: sourcesLoading } = useQuery({
+    queryKey: ["source-balances"],
+    queryFn: () => repository.getSourceBalances(),
+  });
+
   const monthlyTrendsChartData = useMemo(() => {
     return {
       series: [
@@ -144,10 +149,51 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
     };
   }, [stats, expenseCategories, currency]);
 
+  const fundBalanceChartData = useMemo(() => {
+    return {
+      series: [
+        {
+          name: "Balance",
+          data: (fundBalances || []).map((f) => f.balance),
+        },
+      ],
+      options: {
+        chart: { type: "bar" },
+        xaxis: { categories: (fundBalances || []).map((f) => f.name) },
+        yaxis: {
+          labels: {
+            formatter: (value: number) => formatCurrency(value, currency),
+          },
+        },
+      },
+    };
+  }, [fundBalances, currency]);
+
+  const sourceBalanceChartData = useMemo(() => {
+    return {
+      series: [
+        {
+          name: "Balance",
+          data: (sourceBalances || []).map((s) => s.balance),
+        },
+      ],
+      options: {
+        chart: { type: "bar" },
+        xaxis: { categories: (sourceBalances || []).map((s) => s.name) },
+        yaxis: {
+          labels: {
+            formatter: (value: number) => formatCurrency(value, currency),
+          },
+        },
+      },
+    };
+  }, [sourceBalances, currency]);
+
   const isLoading =
     trendsLoading ||
     statsLoading ||
     fundsLoading ||
+    sourcesLoading ||
     incomeCatsLoading ||
     expenseCatsLoading;
 
@@ -156,9 +202,12 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
     monthlyTrends,
     stats,
     fundBalances,
+    sourceBalances,
     monthlyTrendsChartData,
     incomeCategoryChartData,
     expenseCategoryChartData,
+    fundBalanceChartData,
+    sourceBalanceChartData,
     isLoading,
   };
 }

--- a/src/models/financeDashboard.model.ts
+++ b/src/models/financeDashboard.model.ts
@@ -18,3 +18,9 @@ export interface FundBalance {
   name: string;
   balance: number;
 }
+
+export interface SourceBalance {
+  id: string;
+  name: string;
+  balance: number;
+}

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -71,6 +71,8 @@ function FinancialOverviewDashboard() {
     monthlyTrends,
     incomeCategoryChartData,
     expenseCategoryChartData,
+    fundBalanceChartData,
+    sourceBalanceChartData,
     isLoading,
   } = useFinanceDashboardData(dateRange);
   const { useQuery: useTransactionQuery } = useFinancialTransactionHeaderRepository();
@@ -357,6 +359,35 @@ function FinancialOverviewDashboard() {
               />
             </CardContent>
           </Card>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Financial Source Balances</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Charts
+                  type="bar"
+                  series={sourceBalanceChartData.series}
+                  options={sourceBalanceChartData.options}
+                  height={350}
+                />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Fund Balances</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Charts
+                  type="bar"
+                  series={fundBalanceChartData.series}
+                  options={fundBalanceChartData.options}
+                  height={350}
+                />
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
 
         <TabsContent value="transactions" className="mt-4">

--- a/src/repositories/financeDashboard.repository.ts
+++ b/src/repositories/financeDashboard.repository.ts
@@ -5,12 +5,14 @@ import {
   MonthlyTrend,
   FinanceStats,
   FundBalance,
+  SourceBalance,
 } from "../models/financeDashboard.model";
 
 export interface IFinanceDashboardRepository {
   getMonthlyTrends(): Promise<MonthlyTrend[]>;
   getMonthlyStats(startDate: Date, endDate: Date): Promise<FinanceStats | null>;
   getFundBalances(): Promise<FundBalance[]>;
+  getSourceBalances(): Promise<SourceBalance[]>;
 }
 
 @injectable()
@@ -51,6 +53,15 @@ export class FinanceDashboardRepository implements IFinanceDashboardRepository {
 
   async getFundBalances(): Promise<FundBalance[]> {
     const rows = await this.adapter.fetchFundBalances();
+    return rows.map((r: any) => ({
+      id: r.id,
+      name: r.name,
+      balance: Number(r.balance),
+    }));
+  }
+
+  async getSourceBalances(): Promise<SourceBalance[]> {
+    const rows = await this.adapter.fetchSourceBalances();
     return rows.map((r: any) => ({
       id: r.id,
       name: r.name,

--- a/tests/financeDashboardRepository.test.ts
+++ b/tests/financeDashboardRepository.test.ts
@@ -19,6 +19,10 @@ const adapter: IFinanceDashboardAdapter = {
     expenses_by_category: { Utilities: 50, Uncategorized: 25 },
   }),
   fetchFundBalances: async () => [{ id: "f1", name: "General", balance: "25" }],
+  fetchSourceBalances: async () => [
+    { id: "s1", name: "Bank", balance: "100" },
+    { id: "s2", name: "Cash", balance: "50" },
+  ],
 } as any;
 
 describe("FinanceDashboardRepository mapping", () => {
@@ -54,5 +58,13 @@ describe("FinanceDashboardRepository mapping", () => {
   it("maps fund balances", async () => {
     const funds = await repo.getFundBalances();
     expect(funds[0]).toEqual({ id: "f1", name: "General", balance: 25 });
+  });
+
+  it("maps source balances", async () => {
+    const sources = await repo.getSourceBalances();
+    expect(sources).toEqual([
+      { id: "s1", name: "Bank", balance: 100 },
+      { id: "s2", name: "Cash", balance: 50 },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- extend dashboard models and adapter for source balances
- fetch source balances in dashboard hook
- compute fund/source balance chart data
- display financial source and fund balance charts
- cover repository source balance mapping in tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679b8761b883269cc6e10b36f1f28d