### PR TITLE
Improve financial dashboard UX with skeleton loading

### DIFF
--- a/src/components/dashboard/ChartCardSkeleton.tsx
+++ b/src/components/dashboard/ChartCardSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Card, CardHeader, CardContent, CardTitle, CardDescription } from '../ui2/card';
+import { Skeleton } from '../ui2/skeleton';
+
+interface Props {
+  title?: string;
+  description?: string;
+  height?: number;
+}
+
+export function ChartCardSkeleton({ title, description, height = 350 }: Props) {
+  return (
+    <Card className="animate-pulse">
+      <CardHeader>
+        {title && <CardTitle><Skeleton className="h-6 w-1/3" /></CardTitle>}
+        {description && <CardDescription><Skeleton className="h-4 w-1/2" /></CardDescription>}
+      </CardHeader>
+      <CardContent>
+        <Skeleton className={`w-full rounded-md`} style={{ height }} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/MetricCardSkeleton.tsx
+++ b/src/components/dashboard/MetricCardSkeleton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Card, CardContent } from '../ui2/card';
+import { Skeleton } from '../ui2/skeleton';
+
+export function MetricCardSkeleton() {
+  return (
+    <Card className="animate-pulse">
+      <CardContent className="p-5 space-y-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-6 w-1/2" />
+        <Skeleton className="h-4 w-16" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/finances/RecentFinancialTransactionItemSkeleton.tsx
+++ b/src/components/finances/RecentFinancialTransactionItemSkeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Card, CardContent } from '../ui2/card';
+import { Skeleton } from '../ui2/skeleton';
+
+export function RecentFinancialTransactionItemSkeleton() {
+  return (
+    <Card size="sm" className="animate-pulse">
+      <CardContent className="flex justify-between items-center gap-4 py-3 px-4">
+        <div className="flex flex-col space-y-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <Skeleton className="h-6 w-20" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -5,6 +5,8 @@ import { useFinanceDashboardData } from "../../hooks/useFinanceDashboardData";
 import { useCurrencyStore } from "../../stores/currencyStore";
 import { formatCurrency } from "../../utils/currency";
 import MetricCard from "../../components/dashboard/MetricCard";
+import { MetricCardSkeleton } from "../../components/dashboard/MetricCardSkeleton";
+import { ChartCardSkeleton } from "../../components/dashboard/ChartCardSkeleton";
 import { Container } from "../../components/ui2/container";
 import {
   Card,
@@ -30,6 +32,7 @@ import {
 } from "../../components/ui2/tabs";
 import { Input } from "../../components/ui2/input";
 import RecentTransactionItem from "../../components/finances/RecentFinancialTransactionItem";
+import { RecentFinancialTransactionItemSkeleton } from "../../components/finances/RecentFinancialTransactionItemSkeleton";
 import { useFinancialTransactionHeaderRepository } from "../../hooks/useFinancialTransactionHeaderRepository";
 import {
   TrendingUp,
@@ -37,7 +40,6 @@ import {
   Banknote,
   Percent,
   Settings,
-  Loader2,
   Search,
   ChevronRight,
 } from "lucide-react";
@@ -189,14 +191,6 @@ function FinancialOverviewDashboard() {
     };
   }, [filteredTrends, currency]);
 
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      </div>
-    );
-  }
-
   return (
     <Container className="space-y-6 max-w-[1200px]" size="xl">
       <div className="sm:flex sm:items-center">
@@ -257,38 +251,46 @@ function FinancialOverviewDashboard() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricCard
-          label="Total Income"
-          value={formatCurrency(totalIncome, currency)}
-          icon={TrendingUp}
-          iconClassName="text-success"
-          subtext={`${incomeChange.toFixed(1)}% from last month`}
-          subtextClassName={incomeChangeColor}
-        />
-        <MetricCard
-          label="Total Expenses"
-          value={formatCurrency(totalExpenses, currency)}
-          icon={TrendingDown}
-          iconClassName="text-destructive"
-          subtext={`${expenseChange.toFixed(1)}% from last month`}
-          subtextClassName={expenseChangeColor}
-        />
-        <MetricCard
-          label="Net Income"
-          value={formatCurrency(netIncome, currency)}
-          icon={Banknote}
-          iconClassName={netIncome >= 0 ? 'text-success' : 'text-destructive'}
-          subtext={`${netChange.toFixed(1)}% from last month`}
-          subtextClassName={netChangeColor}
-        />
-        <MetricCard
-          label="Expense Ratio"
-          value={`${expenseRatio.toFixed(1)}%`}
-          icon={Percent}
-          iconClassName="text-warning"
-          subtext={getExpenseRating(expenseRatio)}
-          subtextClassName="text-warning/70"
-        />
+        {isLoading ? (
+          Array(4)
+            .fill(0)
+            .map((_, i) => <MetricCardSkeleton key={i} />)
+        ) : (
+          <>
+            <MetricCard
+              label="Total Income"
+              value={formatCurrency(totalIncome, currency)}
+              icon={TrendingUp}
+              iconClassName="text-success"
+              subtext={`${incomeChange.toFixed(1)}% from last month`}
+              subtextClassName={incomeChangeColor}
+            />
+            <MetricCard
+              label="Total Expenses"
+              value={formatCurrency(totalExpenses, currency)}
+              icon={TrendingDown}
+              iconClassName="text-destructive"
+              subtext={`${expenseChange.toFixed(1)}% from last month`}
+              subtextClassName={expenseChangeColor}
+            />
+            <MetricCard
+              label="Net Income"
+              value={formatCurrency(netIncome, currency)}
+              icon={Banknote}
+              iconClassName={netIncome >= 0 ? 'text-success' : 'text-destructive'}
+              subtext={`${netChange.toFixed(1)}% from last month`}
+              subtextClassName={netChangeColor}
+            />
+            <MetricCard
+              label="Expense Ratio"
+              value={`${expenseRatio.toFixed(1)}%`}
+              icon={Percent}
+              iconClassName="text-warning"
+              subtext={getExpenseRating(expenseRatio)}
+              subtextClassName="text-warning/70"
+            />
+          </>
+        )}
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -309,84 +311,106 @@ function FinancialOverviewDashboard() {
 
         <TabsContent value="overview" className="mt-4 space-y-6">
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {isLoading ? (
+              <>
+                <ChartCardSkeleton title="Monthly financial trends" description="Income, expense, and net income over time" />
+                <ChartCardSkeleton title="Income Distribution" description="Breakdown of income categories" />
+              </>
+            ) : (
+              <>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Monthly financial trends</CardTitle>
+                    <CardDescription>
+                      Income, expense, and net income over time
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Charts
+                      type="area"
+                      series={trendsChartData.series}
+                      options={trendsChartData.options}
+                      height={350}
+                    />
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Income Distribution</CardTitle>
+                    <CardDescription>
+                      Breakdown of income categories
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Charts
+                      type="donut"
+                      series={incomeCategoryChartData.series}
+                      options={incomeCategoryChartData.options}
+                      height={350}
+                    />
+                  </CardContent>
+                </Card>
+              </>
+            )}
+          </div>
+
+          {isLoading ? (
+            <ChartCardSkeleton title="Expense Breakdown" description="Current month expense categories" />
+          ) : (
             <Card>
               <CardHeader>
-                <CardTitle>Monthly financial trends</CardTitle>
+                <CardTitle>Expense Breakdown</CardTitle>
                 <CardDescription>
-                  Income, expense, and net income over time
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Charts
-                  type="area"
-                  series={trendsChartData.series}
-                  options={trendsChartData.options}
-                  height={350}
-                />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle>Income Distribution</CardTitle>
-                <CardDescription>
-                  Breakdown of income categories
+                  Current month expense categories
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <Charts
                   type="donut"
-                  series={incomeCategoryChartData.series}
-                  options={incomeCategoryChartData.options}
+                  series={expenseCategoryChartData.series}
+                  options={expenseCategoryChartData.options}
                   height={350}
                 />
               </CardContent>
             </Card>
-          </div>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Expense Breakdown</CardTitle>
-              <CardDescription>
-                Current month expense categories
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Charts
-                type="donut"
-                series={expenseCategoryChartData.series}
-                options={expenseCategoryChartData.options}
-                height={350}
-              />
-            </CardContent>
-          </Card>
+          )}
 
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-            <Card>
-              <CardHeader>
-                <CardTitle>Financial Source Balances</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Charts
-                  type="bar"
-                  series={sourceBalanceChartData.series}
-                  options={sourceBalanceChartData.options}
-                  height={350}
-                />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle>Fund Balances</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <Charts
-                  type="bar"
-                  series={fundBalanceChartData.series}
-                  options={fundBalanceChartData.options}
-                  height={350}
-                />
-              </CardContent>
-            </Card>
+            {isLoading ? (
+              <>
+                <ChartCardSkeleton title="Financial Source Balances" />
+                <ChartCardSkeleton title="Fund Balances" />
+              </>
+            ) : (
+              <>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Financial Source Balances</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <Charts
+                      type="bar"
+                      series={sourceBalanceChartData.series}
+                      options={sourceBalanceChartData.options}
+                      height={350}
+                    />
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Fund Balances</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <Charts
+                      type="bar"
+                      series={fundBalanceChartData.series}
+                      options={fundBalanceChartData.options}
+                      height={350}
+                    />
+                  </CardContent>
+                </Card>
+              </>
+            )}
           </div>
         </TabsContent>
 
@@ -413,9 +437,11 @@ function FinancialOverviewDashboard() {
             </CardHeader>
             <CardContent className="space-y-2">
               {transactionsLoading ? (
-                <div className="flex justify-center py-4">
-                  <Loader2 className="h-6 w-6 animate-spin" />
-                </div>
+                Array(3)
+                  .fill(0)
+                  .map((_, i) => (
+                    <RecentFinancialTransactionItemSkeleton key={i} />
+                  ))
               ) : filteredTransactions.length > 0 ? (
                 filteredTransactions.map((t) => (
                   <RecentTransactionItem key={t.id} transaction={t} />


### PR DESCRIPTION
## Summary
- load the financial overview UI immediately
- show skeleton metric cards, charts, and transaction items during data fetch
- replace old spinners to avoid blocking page rendering

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cda8562483269d4dd3e810dedd07