### PR TITLE
Fix refresh by removing remote URL

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -5,7 +5,6 @@ const config: CapacitorConfig = {
   appName: 'StewardTrack',
   webDir: 'build',
   server: {
-    url: "https://stewardtrack.com",  
     cleartext: true
   },
   android: {


### PR DESCRIPTION
## Summary
- disable Capacitor `server.url` so the app no longer refreshes when regaining focus

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cfe4966483268ca18e2ea578de57