### PR TITLE
Show loading states on expenses dashboard

### DIFF
--- a/src/hooks/useExpenseDashboardData.ts
+++ b/src/hooks/useExpenseDashboardData.ts
@@ -62,32 +62,32 @@ export function useExpenseDashboardData(dateRange: { from: Date; to: Date }) {
   const weekStart = startOfWeek(dateRange.to, { weekStartsOn: 0 });
   const weekEnd = endOfWeek(dateRange.to, { weekStartsOn: 0 });
 
-  const { data: monthSummary } = useQuery({
+  const { data: monthSummary, isLoading: monthSummaryLoading } = useQuery({
     queryKey: ['expense-summary', monthStart, monthEnd],
     queryFn: () => fetchSummary(monthStart, monthEnd),
   });
 
-  const { data: prevMonthSummary } = useQuery({
+  const { data: prevMonthSummary, isLoading: prevMonthSummaryLoading } = useQuery({
     queryKey: ['expense-summary-prev', prevMonthStart, prevMonthEnd],
     queryFn: () => fetchSummary(prevMonthStart, prevMonthEnd),
   });
 
-  const { data: weekSummary } = useQuery({
+  const { data: weekSummary, isLoading: weekSummaryLoading } = useQuery({
     queryKey: ['expense-summary-week', weekStart, weekEnd],
     queryFn: () => fetchSummary(weekStart, weekEnd),
   });
 
-  const { data: monthCount } = useQuery({
+  const { data: monthCount, isLoading: monthCountLoading } = useQuery({
     queryKey: ['expense-count', monthStart, monthEnd],
     queryFn: () => fetchCount(monthStart, monthEnd),
   });
 
-  const { data: weekCount } = useQuery({
+  const { data: weekCount, isLoading: weekCountLoading } = useQuery({
     queryKey: ['expense-count-week', weekStart, weekEnd],
     queryFn: () => fetchCount(weekStart, weekEnd),
   });
 
-  const { data: payeeCount } = useQuery({
+  const { data: payeeCount, isLoading: payeeCountLoading } = useQuery({
     queryKey: ['expense-payees'],
     queryFn: fetchPayees,
   });
@@ -104,6 +104,14 @@ export function useExpenseDashboardData(dateRange: { from: Date; to: Date }) {
 
   const avgExpense = monthCount && monthCount > 0 ? thisMonthTotal / monthCount : 0;
 
+  const isLoading =
+    monthSummaryLoading ||
+    prevMonthSummaryLoading ||
+    weekSummaryLoading ||
+    monthCountLoading ||
+    weekCountLoading ||
+    payeeCountLoading;
+
   return {
     currency,
     thisMonthTotal,
@@ -112,5 +120,6 @@ export function useExpenseDashboardData(dateRange: { from: Date; to: Date }) {
     thisWeekTotal,
     weekCount: weekCount || 0,
     avgExpense,
+    isLoading,
   };
 }

--- a/src/pages/expenses/ExpensesDashboard.tsx
+++ b/src/pages/expenses/ExpensesDashboard.tsx
@@ -10,6 +10,8 @@ import {
   CardDescription,
 } from '../../components/ui2/card';
 import MetricCard from '../../components/dashboard/MetricCard';
+import { MetricCardSkeleton } from '../../components/dashboard/MetricCardSkeleton';
+import { DataGridSkeleton } from '../../components/dashboard/DataGridSkeleton';
 import { Container } from '../../components/ui2/container';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../components/ui2/tabs';
 import { Input } from '../../components/ui2/input';
@@ -52,7 +54,7 @@ function ExpensesDashboard() {
     queryFn: () => tenantUtils.getCurrentTenant(),
   });
 
-  const metrics = useExpenseDashboardData(dateRange);
+  const { isLoading: metricsLoading, ...metrics } = useExpenseDashboardData(dateRange);
   const { currency } = useCurrencyStore();
 
   const [recentPage, setRecentPage] = React.useState(0);
@@ -123,7 +125,7 @@ function ExpensesDashboard() {
   ];
 
   const { useQuery: useTxQuery } = useIncomeExpenseTransactionRepository();
-  const { data: recentResult } = useTxQuery({
+  const { data: recentResult, isLoading: recentLoading } = useTxQuery({
     filters: { transaction_type: { operator: 'eq', value: 'expense' } },
     order: { column: 'transaction_date', ascending: false },
     pagination: { page: 1, pageSize: 5 },
@@ -149,7 +151,7 @@ function ExpensesDashboard() {
   const recentExpenses = (recentResult?.data || []) as ExpenseItem[];
 
   const [historySearch, setHistorySearch] = React.useState('');
-  const { data: historyResult } = useTxQuery({
+  const { data: historyResult, isLoading: historyLoading } = useTxQuery({
     filters: {
       transaction_type: { operator: 'eq', value: 'expense' },
       ...(historySearch.trim()
@@ -243,17 +245,21 @@ function ExpensesDashboard() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {highlights.map((h) => (
-          <MetricCard
-            key={h.name}
-            label={h.name}
-            value={h.value}
-            icon={h.icon}
-            iconClassName={h.iconClassName}
-            subtext={h.subtext}
-            subtextClassName={h.subtextClassName}
-          />
-        ))}
+        {metricsLoading
+          ? Array(4)
+              .fill(0)
+              .map((_, i) => <MetricCardSkeleton key={i} />)
+          : highlights.map((h) => (
+              <MetricCard
+                key={h.name}
+                label={h.name}
+                value={h.value}
+                icon={h.icon}
+                iconClassName={h.iconClassName}
+                subtext={h.subtext}
+                subtextClassName={h.subtextClassName}
+              />
+            ))}
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -295,7 +301,9 @@ function ExpensesDashboard() {
                 <CardTitle>Recent Expenses</CardTitle>
                 <CardDescription>Latest donation entries</CardDescription>
               </div>
-              {recentExpenses && recentExpenses.length > 0 ? (
+              {recentLoading ? (
+                <DataGridSkeleton />
+              ) : recentExpenses && recentExpenses.length > 0 ? (
                 <DataGrid<ExpenseItem>
                   columns={columns}
                   data={recentExpenses}
@@ -316,6 +324,7 @@ function ExpensesDashboard() {
                     )
                   }
                   storageKey="recent-expenses-grid"
+                  loading={recentLoading}
                 />
               ) : (
                 <p className="text-sm text-muted-foreground">No recent expenses.</p>
@@ -349,7 +358,9 @@ function ExpensesDashboard() {
               </div>
             </CardHeader>
             <CardContent className="space-y-2">
-              {historyExpenses && historyExpenses.length > 0 ? (
+              {historyLoading ? (
+                <DataGridSkeleton />
+              ) : historyExpenses && historyExpenses.length > 0 ? (
                 <DataGrid<ExpenseItem>
                   columns={columns}
                   data={historyExpenses}
@@ -370,6 +381,7 @@ function ExpensesDashboard() {
                     )
                   }
                   storageKey="expense-records-grid"
+                  loading={historyLoading}
                 />
               ) : (
                 <p className="text-sm text-muted-foreground">No expenses found.</p>


### PR DESCRIPTION
## Summary
- surface `isLoading` from `useExpenseDashboardData`
- use skeletons and loader props in `ExpensesDashboard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6867d34de7ec83268306824950032d6f