### PR TITLE
Set date range to this month by default

### DIFF
--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -59,9 +59,7 @@ function FinancialOverviewDashboard() {
   const [transactionSearch, setTransactionSearch] = React.useState('');
 
   const initialFrom = React.useMemo(() => {
-    const d = new Date();
-    d.setMonth(d.getMonth() - 11);
-    return startOfMonth(d);
+    return startOfMonth(new Date());
   }, []);
 
   const [dateRange, setDateRange] = React.useState<{ from: Date; to: Date }>({


### PR DESCRIPTION
## Summary
- update `FinancialOverviewDashboard` to default its date range to this month

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d6c3b99083268a804733e2e4dde0