### PR TITLE
Add date range filtering to finance dashboard

### DIFF
--- a/src/adapters/financeDashboard.adapter.ts
+++ b/src/adapters/financeDashboard.adapter.ts
@@ -6,11 +6,18 @@ import { format } from "date-fns";
 
 @injectable()
 export class FinanceDashboardAdapter {
-  async fetchMonthlyTrends() {
-    const { data, error } = await supabase
-      .from("finance_monthly_trends")
-      .select("*")
-      .order("month");
+  async fetchMonthlyTrends(startDate?: Date, endDate?: Date) {
+    let query = supabase.from("finance_monthly_trends").select("*");
+
+    if (startDate) {
+      query = query.gte("month", format(startDate, "yyyy-MM"));
+    }
+
+    if (endDate) {
+      query = query.lte("month", format(endDate, "yyyy-MM"));
+    }
+
+    const { data, error } = await query.order("month");
     if (error) throw error;
     return data || [];
   }

--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -18,8 +18,8 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
   const end = dateRange?.to ?? endOfMonth(new Date());
 
   const { data: monthlyTrends, isLoading: trendsLoading } = useQuery({
-    queryKey: ["monthly-trends"],
-    queryFn: () => repository.getMonthlyTrends(),
+    queryKey: ["monthly-trends", start, end],
+    queryFn: () => repository.getMonthlyTrends(start, end),
   });
 
   const { data: stats, isLoading: statsLoading } = useQuery({

--- a/src/repositories/financeDashboard.repository.ts
+++ b/src/repositories/financeDashboard.repository.ts
@@ -9,7 +9,7 @@ import {
 } from "../models/financeDashboard.model";
 
 export interface IFinanceDashboardRepository {
-  getMonthlyTrends(): Promise<MonthlyTrend[]>;
+  getMonthlyTrends(startDate?: Date, endDate?: Date): Promise<MonthlyTrend[]>;
   getMonthlyStats(startDate: Date, endDate: Date): Promise<FinanceStats | null>;
   getFundBalances(): Promise<FundBalance[]>;
   getSourceBalances(): Promise<SourceBalance[]>;
@@ -22,8 +22,11 @@ export class FinanceDashboardRepository implements IFinanceDashboardRepository {
     private adapter: IFinanceDashboardAdapter,
   ) {}
 
-  async getMonthlyTrends(): Promise<MonthlyTrend[]> {
-    const rows = await this.adapter.fetchMonthlyTrends();
+  async getMonthlyTrends(
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<MonthlyTrend[]> {
+    const rows = await this.adapter.fetchMonthlyTrends(startDate, endDate);
     return rows.map((r: any) => ({
       month: new Date(`${r.month}-01`).toLocaleString("en-US", {
         month: "short",

--- a/tests/financeDashboardRepository.test.ts
+++ b/tests/financeDashboardRepository.test.ts
@@ -3,7 +3,7 @@ import { FinanceDashboardRepository } from "../src/repositories/financeDashboard
 import type { IFinanceDashboardAdapter } from "../src/adapters/financeDashboard.adapter";
 
 const adapter: IFinanceDashboardAdapter = {
-  fetchMonthlyTrends: async () => [
+  fetchMonthlyTrends: async (_start?: Date, _end?: Date) => [
     {
       month: "2025-06",
       income: "100",


### PR DESCRIPTION
## Summary
- allow FinanceDashboardAdapter to filter monthly trends by date range
- pass date range through FinanceDashboardRepository
- query monthly trend data with range in the hook
- update repository tests

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e33b4b648326a7b45925f098958a