### PR TITLE
Fix entry description handling

### DIFF
--- a/src/services/IncomeExpenseTransactionService.ts
+++ b/src/services/IncomeExpenseTransactionService.ts
@@ -40,6 +40,11 @@ export class IncomeExpenseTransactionService {
     line: IncomeExpenseEntry,
     headerId: string,
   ) {
+    const detailDescription =
+      line.description && line.description.trim()
+        ? line.description.trim()
+        : undefined;
+
     const base = {
       type: line.transaction_type,
       accounts_account_id: line.accounts_account_id,
@@ -47,7 +52,7 @@ export class IncomeExpenseTransactionService {
       source_id: line.source_id,
       category_id: line.category_id,
       date: header.transaction_date!,
-      description: line.description ?? header.description ?? '',
+      description: detailDescription ?? header.description ?? '',
       batch_id: line.batch_id ?? null,
       header_id: headerId,
     } as any;
@@ -90,11 +95,16 @@ export class IncomeExpenseTransactionService {
     line: IncomeExpenseEntry,
     headerId: string,
   ) {
+    const detailDescription =
+      line.description && line.description.trim()
+        ? line.description.trim()
+        : undefined;
+
     return {
       transaction_type: line.transaction_type,
       transaction_date: header.transaction_date!,
       amount: line.amount,
-      description: line.description ?? header.description ?? '',
+      description: detailDescription ?? header.description ?? '',
       reference: (header as any).reference ?? null,
       member_id: line.member_id ?? null,
       category_id: line.category_id,

--- a/src/validators/incomeExpenseTransaction.validator.ts
+++ b/src/validators/incomeExpenseTransaction.validator.ts
@@ -5,9 +5,9 @@ export class IncomeExpenseTransactionValidator {
     if (data.transaction_date !== undefined && !data.transaction_date) {
       throw new Error('Transaction date is required');
     }
-    if (data.description !== undefined && !data.description.trim()) {
-      throw new Error('Description is required');
-    }
+    // Description is optional for individual income/expense entries.
+    // When not provided or blank, it will default to the header description at
+    // the service layer, so no validation error should be raised here.
     if (
       data.amount !== undefined &&
       (isNaN(Number(data.amount)) || data.amount === null)

--- a/tests/incomeExpenseTransactionRepositoryValidation.test.ts
+++ b/tests/incomeExpenseTransactionRepositoryValidation.test.ts
@@ -41,10 +41,14 @@ describe('IncomeExpenseTransactionRepository validation', () => {
     expect(data.reference).toBe('Ref');
   });
 
-  it('validates on update', async () => {
+  it('allows blank descriptions on update', async () => {
     const repo = new TestRepo({} as IIncomeExpenseTransactionAdapter);
     await expect(
       repo.runBeforeUpdate('1', { description: ' ', transaction_date: '2025-06-01', amount: 10 })
-    ).rejects.toThrow('Description is required');
+    ).resolves.toEqual({
+      transaction_date: '2025-06-01',
+      description: '',
+      amount: 10
+    });
   });
 });

--- a/tests/incomeExpenseTransactionService.test.ts
+++ b/tests/incomeExpenseTransactionService.test.ts
@@ -87,6 +87,19 @@ describe('IncomeExpenseTransactionService', () => {
     });
   });
 
+  it('uses header description for blank entry descriptions', async () => {
+    const entry: IncomeExpenseEntry = {
+      ...baseEntry,
+      transaction_type: 'income',
+      description: '  '
+    };
+    await service.create(header, [entry]);
+
+    expect(ieRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ description: header.description })
+    );
+  });
+
   it('creates expense transactions and records on update', async () => {
     const entry: IncomeExpenseEntry = { ...baseEntry, transaction_type: 'expense' };
     await service.update('t1', header, entry);


### PR DESCRIPTION
## Summary
- description not required for income/expense transaction lines
- fallback to header description when a line's description is blank
- adjust tests for repository and service

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e49ac15c832681065fcc35b4c2c0