### PR TITLE
Improve Fund Balances chart

### DIFF
--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -151,16 +151,21 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
   }, [stats, expenseCategories, currency]);
 
   const fundBalanceChartData = useMemo(() => {
+    const sorted = [...(fundBalances || [])].sort(
+      (a, b) => b.balance - a.balance,
+    );
+
     return {
       series: [
         {
           name: "Balance",
-          data: (fundBalances || []).map((f) => f.balance),
+          data: sorted.map((f) => f.balance),
         },
       ],
       options: {
         chart: { type: "bar" },
-        xaxis: { categories: (fundBalances || []).map((f) => f.name) },
+        plotOptions: { bar: { horizontal: true } },
+        xaxis: { categories: sorted.map((f) => f.name) },
         yaxis: {
           labels: {
             formatter: (value: number) => formatCurrency(value, currency),

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -90,6 +90,7 @@ function FinancialOverviewDashboard() {
     expenseCategoryChartData,
     fundBalanceChartData,
     sourceBalanceChartData,
+    fundBalances,
     isLoading,
   } = useFinanceDashboardData(dateRange);
   const { useQuery: useTransactionQuery } = useFinancialTransactionHeaderRepository();
@@ -162,6 +163,23 @@ function FinancialOverviewDashboard() {
   const incomeChangeColor = incomeChange >= 0 ? 'text-success' : 'text-danger';
   const expenseChangeColor = expenseChange <= 0 ? 'text-success' : 'text-danger';
   const netChangeColor = netChange >= 0 ? 'text-success' : 'text-danger';
+
+  const fundSummary = React.useMemo(() => {
+    const funds = fundBalances || [];
+    const total = funds.length;
+    if (total === 0) {
+      return { total: 0, average: 0, highest: null as any, lowest: null as any };
+    }
+    const totalBalance = funds.reduce((sum, f) => sum + f.balance, 0);
+    const average = totalBalance / total;
+    const sorted = [...funds].sort((a, b) => b.balance - a.balance);
+    return {
+      total,
+      average,
+      highest: sorted[0],
+      lowest: sorted[sorted.length - 1],
+    };
+  }, [fundBalances]);
 
   const trendsChartData = React.useMemo(() => {
     return {
@@ -434,7 +452,7 @@ function FinancialOverviewDashboard() {
             </Card>
           )}
 
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <div className="space-y-6">
             {isLoading ? (
               <>
                 <ChartCardSkeleton title="Financial Source Balances" />
@@ -460,6 +478,36 @@ function FinancialOverviewDashboard() {
                     <CardTitle>Fund Balances</CardTitle>
                   </CardHeader>
                   <CardContent>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 text-center gap-4 mb-4">
+                      <div>
+                        <p className="text-lg font-semibold">{fundSummary.total}</p>
+                        <p className="text-sm text-muted-foreground">Total Funds</p>
+                      </div>
+                      <div>
+                        <p className="text-lg font-semibold">{formatCurrency(fundSummary.average, currency)}</p>
+                        <p className="text-sm text-muted-foreground">Average Balance</p>
+                      </div>
+                      {fundSummary.highest && (
+                        <div>
+                          <p className="text-lg font-semibold">
+                            {formatCurrency(fundSummary.highest.balance, currency)}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Highest: {fundSummary.highest.name}
+                          </p>
+                        </div>
+                      )}
+                      {fundSummary.lowest && (
+                        <div>
+                          <p className="text-lg font-semibold">
+                            {formatCurrency(fundSummary.lowest.balance, currency)}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Lowest: {fundSummary.lowest.name}
+                          </p>
+                        </div>
+                      )}
+                    </div>
                     <Charts
                       type="bar"
                       series={fundBalanceChartData.series}


### PR DESCRIPTION
## Summary
- sort funds by balance and switch to horizontal bars
- show fund summary metrics above the chart
- expand fund balance section to full width

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867ea34505c832680a2496ca2811255