### PR TITLE
Fix expense breakdown bar appearance

### DIFF
--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -134,7 +134,13 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
       ],
       options: {
         chart: { type: "bar" },
-        plotOptions: { bar: { horizontal: true } },
+        plotOptions: {
+          bar: {
+            horizontal: true,
+            barHeight: '60%',
+            borderRadius: 8,
+          },
+        },
         xaxis: { categories: items.map((i) => i.name) },
         yaxis: {
           labels: {


### PR DESCRIPTION
## Summary
- widen bars in Financial Overview's expense breakdown chart

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ed076c288326bad41715af4fc334