### PR TITLE
Exclude zero-balance funds from overview chart

### DIFF
--- a/src/hooks/useFinanceDashboardData.ts
+++ b/src/hooks/useFinanceDashboardData.ts
@@ -157,9 +157,8 @@ export function useFinanceDashboardData(dateRange?: { from: Date; to: Date }) {
   }, [stats, expenseCategories, currency]);
 
   const fundBalanceChartData = useMemo(() => {
-    const sorted = [...(fundBalances || [])].sort(
-      (a, b) => b.balance - a.balance,
-    );
+    const filtered = (fundBalances || []).filter((f) => f.balance !== 0);
+    const sorted = [...filtered].sort((a, b) => b.balance - a.balance);
 
     return {
       series: [


### PR DESCRIPTION
## Summary
- filter out zero-balance funds when preparing fund balance chart data

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0f468d4832694ec61c1b0791ce3