### PR TITLE
Fix link to financial reports page

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -89,7 +89,7 @@ export const navigation: NavItem[] = [
   },
   {
     name: 'Financial Reports',
-    href: '/financialreports',
+    href: '/finances/financial-reports',
     icon: FileBarChart,
     permission: 'finance.view',
     section: 'Financial',


### PR DESCRIPTION
## Summary
- link the Financial Reports sidebar entry to the actual route

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7446eb0832687be641c55792c1e