### PR TITLE
Add expense summary report

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ and show the total amount at the bottom.
 The `FinancialReportsPage` component now generates the PDF directly in the
 browser using [pdf-lib](https://pdf-lib.js.org/) when you click the **PDF** button.
 
+The new **Expense Summary** report lists expenses with their fund balances and
+can also be exported to PDF.
+
 ## Changelog
 
 - Dates are now stored and parsed using local `yyyy-MM-dd` format instead of ISO strings.

--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -22,6 +22,7 @@ import GivingStatementReport from './financialReports/GivingStatementReport';
 import OfferingSummaryReport from './financialReports/OfferingSummaryReport';
 import CategoryFinancialReport from './financialReports/CategoryFinancialReport';
 import CashFlowSummaryReport from './financialReports/CashFlowSummaryReport';
+import ExpenseSummaryReport from './financialReports/ExpenseSummaryReport';
 
 const reportOptions = [
   { id: 'trial-balance', label: 'Trial Balance' },
@@ -36,6 +37,7 @@ const reportOptions = [
   { id: 'member-offering-summary', label: 'Member Offering Summary' },
   { id: 'category-financial', label: 'Category Based Report' },
   { id: 'cash-flow', label: 'Cash Flow Summary' },
+  { id: 'expense-summary', label: 'Expense Summary' },
 ];
 
 function FinancialReportsPage() {
@@ -184,6 +186,9 @@ function FinancialReportsPage() {
           )}
           {reportType === 'cash-flow' && (
             <CashFlowSummaryReport tenantId={tenantId} dateRange={dateRange} />
+          )}
+          {reportType === 'expense-summary' && (
+            <ExpenseSummaryReport tenantId={tenantId} dateRange={dateRange} />
           )}
         </CardContent>
       </Card>

--- a/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
+++ b/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import { useQuery } from '@tanstack/react-query';
+import { Printer, Download } from 'lucide-react';
+import { DataGrid } from '../../../components/ui2/data-grid';
+import { Button } from '../../../components/ui2/button';
+import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
+import { tenantUtils } from '../../../utils/tenantUtils';
+import { generateExpenseSummaryPdf, ExpenseSummaryRecord } from '../../../utils';
+import { container } from '../../../lib/container';
+import { TYPES } from '../../../lib/types';
+import type { IFinanceDashboardRepository } from '../../../repositories/financeDashboard.repository';
+import { formatCurrency } from '../../../utils/currency';
+import { useCurrencyStore } from '../../../stores/currencyStore';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
+  const { useQuery: useTransactions } = useIncomeExpenseTransactionRepository();
+  const { currency } = useCurrencyStore();
+
+  const {
+    data: txRes,
+    isLoading,
+  } = useTransactions({
+    filters: {
+      transaction_type: { operator: 'eq', value: 'expense' },
+      transaction_date: {
+        operator: 'between',
+        value: format(dateRange.from, 'yyyy-MM-dd'),
+        valueTo: format(dateRange.to, 'yyyy-MM-dd'),
+      },
+    },
+    order: { column: 'transaction_date', ascending: true },
+    enabled: !!tenantId,
+  });
+
+  const financeRepo = container.get<IFinanceDashboardRepository>(TYPES.IFinanceDashboardRepository);
+  const { data: fundBalances } = useQuery(['fund-balances'], () => financeRepo.getFundBalances());
+
+  const fundMap = React.useMemo(() => {
+    const map = new Map<string, number>();
+    (fundBalances || []).forEach(f => map.set(f.id, f.balance));
+    return map;
+  }, [fundBalances]);
+
+  const records = React.useMemo<ExpenseSummaryRecord[]>(
+    () =>
+      (txRes?.data || []).map(tx => ({
+        description: tx.description,
+        category_name: tx.category?.name || '',
+        fund_name: tx.fund?.name || '',
+        fund_balance: fundMap.get(tx.fund_id || '') || 0,
+        amount: tx.amount,
+      })),
+    [txRes, fundMap],
+  );
+
+  const columns = React.useMemo<ColumnDef<ExpenseSummaryRecord>[]>(
+    () => [
+      { accessorKey: 'description', header: 'Expense Description' },
+      { accessorKey: 'category_name', header: 'Expense Category' },
+      {
+        accessorKey: 'fund_name',
+        header: 'Fund',
+      },
+      {
+        accessorKey: 'fund_balance',
+        header: 'Fund Balance',
+        cell: ({ row }) => formatCurrency(row.original.fund_balance, currency),
+      },
+      {
+        accessorKey: 'amount',
+        header: 'Amount',
+        cell: ({ row }) => formatCurrency(row.original.amount, currency),
+      },
+    ],
+    [currency],
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = async () => {
+    const tenant = await tenantUtils.getCurrentTenant();
+    const blob = await generateExpenseSummaryPdf(tenant?.name || '', dateRange, records);
+    const url = URL.createObjectURL(blob);
+    const fileName = `expense-summary-${format(dateRange.from, 'yyyyMMdd')}-${format(dateRange.to, 'yyyyMMdd')}.pdf`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+      <DataGrid<ExpenseSummaryRecord>
+        data={records}
+        columns={columns}
+        loading={isLoading}
+        exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'expense-summary' }}
+      />
+    </div>
+  );
+}

--- a/src/utils/expenseSummaryPdf.ts
+++ b/src/utils/expenseSummaryPdf.ts
@@ -1,0 +1,123 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { format } from 'date-fns';
+import { useCurrencyStore } from '../stores/currencyStore';
+import { formatCurrency } from './currency';
+
+export interface ExpenseSummaryRecord {
+  description: string;
+  category_name: string | null;
+  fund_name: string | null;
+  fund_balance: number;
+  amount: number;
+}
+
+export async function generateExpenseSummaryPdf(
+  tenantName: string,
+  dateRange: { from: Date; to: Date },
+  records: ExpenseSummaryRecord[],
+): Promise<Blob> {
+  const pdfDoc = await PDFDocument.create();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const boldFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+  const width = 595.28;
+  const height = 841.89;
+
+  const margin = 40;
+  const rowHeight = 18;
+  const columnWidth = (width - margin * 2) / 5;
+
+  const pages: any[] = [];
+  let page = pdfDoc.addPage([width, height]);
+  pages.push(page);
+  let y = height - margin;
+
+  const { currency } = useCurrencyStore.getState();
+
+  const headerText = 'Expense Summary Report';
+
+  const drawHeader = () => {
+    y = height - margin;
+    const titleWidth = boldFont.widthOfTextAtSize(headerText, 16);
+    page.drawText(headerText, {
+      x: width / 2 - titleWidth / 2,
+      y,
+      size: 16,
+      font: boldFont,
+    });
+    y -= rowHeight;
+
+    const tenantWidth = font.widthOfTextAtSize(tenantName, 12);
+    page.drawText(tenantName, { x: width / 2 - tenantWidth / 2, y, size: 12, font });
+    y -= rowHeight;
+
+    const rangeStr = `${format(dateRange.from, 'MMM dd, yyyy')} - ${format(dateRange.to, 'MMM dd, yyyy')}`;
+    const rangeWidth = font.widthOfTextAtSize(rangeStr, 12);
+    page.drawText(rangeStr, { x: width / 2 - rangeWidth / 2, y, size: 12, font });
+    y -= rowHeight / 2;
+    page.drawLine({
+      start: { x: margin, y },
+      end: { x: width - margin, y },
+      thickness: 1,
+    });
+    y -= rowHeight;
+  };
+
+  const drawTableHeader = () => {
+    const headers = ['Expense Description', 'Expense Category', 'Fund', 'Fund Balance', 'Amount'];
+    headers.forEach((h, idx) => {
+      page.drawText(h, { x: margin + idx * columnWidth, y, size: 12, font: boldFont });
+    });
+    y -= rowHeight;
+  };
+
+  const addPage = () => {
+    page = pdfDoc.addPage([width, height]);
+    pages.push(page);
+    drawHeader();
+    drawTableHeader();
+  };
+
+  drawHeader();
+  drawTableHeader();
+
+  const drawRow = (r: ExpenseSummaryRecord) => {
+    if (y - rowHeight < margin) addPage();
+    const cells = [
+      r.description || '',
+      r.category_name || '',
+      r.fund_name || '',
+      formatCurrency(r.fund_balance, currency),
+      formatCurrency(r.amount, currency),
+    ];
+    cells.forEach((c, idx) => {
+      page.drawText(String(c), { x: margin + idx * columnWidth, y, size: 11, font });
+    });
+    y -= rowHeight;
+  };
+
+  records.forEach(rec => drawRow(rec));
+
+  const total = records.reduce((sum, r) => sum + (r.amount || 0), 0);
+  if (y - rowHeight < margin) addPage();
+  page.drawText('Expense Grand Total', {
+    x: margin + 3 * columnWidth,
+    y,
+    size: 12,
+    font: boldFont,
+  });
+  page.drawText(formatCurrency(total, currency), {
+    x: margin + 4 * columnWidth,
+    y,
+    size: 12,
+    font: boldFont,
+  });
+
+  pages.forEach((p, idx) => {
+    const text = `Page ${idx + 1} of ${pages.length}`;
+    const tw = font.widthOfTextAtSize(text, 10);
+    p.drawText(text, { x: width / 2 - tw / 2, y: margin / 2, size: 10, font });
+  });
+
+  const pdfBytes = await pdfDoc.save();
+  return new Blob([pdfBytes], { type: 'application/pdf' });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,3 +18,4 @@ export * from './accounting';
 export * from './reportPdf';
 export * from './memberGivingSummaryPdf';
 export * from './memberOfferingSummaryPdf';
+export * from './expenseSummaryPdf';


### PR DESCRIPTION
## Summary
- generate Expense Summary PDF utility
- expose new PDF generator in utils entrypoint
- implement ExpenseSummaryReport page
- enable Expense Summary option in FinancialReportsPage
- document new report in README

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868404875f88326b4d29266c0c80144