### PR TITLE
Fix expense summary fonts and category display

### DIFF
--- a/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
+++ b/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
@@ -56,8 +56,8 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
     () =>
       (txRes?.data || []).map(tx => ({
         description: tx.description,
-        category_name: tx.category?.name || '',
-        fund_name: tx.fund?.name || '',
+        category_name: tx.categories?.name || '',
+        fund_name: tx.funds?.name || '',
         fund_balance: fundMap.get(tx.fund_id || '') || 0,
         amount: tx.amount,
       })),

--- a/src/utils/expenseSummaryPdf.ts
+++ b/src/utils/expenseSummaryPdf.ts
@@ -70,7 +70,7 @@ export async function generateExpenseSummaryPdf(
   const drawTableHeader = () => {
     const headers = ['Expense Description', 'Expense Category', 'Fund', 'Fund Balance', 'Amount'];
     headers.forEach((h, idx) => {
-      page.drawText(h, { x: margin + idx * columnWidth, y, size: 12, font: boldFont });
+      page.drawText(h, { x: margin + idx * columnWidth, y, size: 10, font: boldFont });
     });
     y -= rowHeight;
   };
@@ -95,7 +95,7 @@ export async function generateExpenseSummaryPdf(
       formatAmount(r.amount),
     ];
     cells.forEach((c, idx) => {
-      page.drawText(String(c), { x: margin + idx * columnWidth, y, size: 11, font });
+      page.drawText(String(c), { x: margin + idx * columnWidth, y, size: 8, font });
     });
     y -= rowHeight;
   };
@@ -107,13 +107,13 @@ export async function generateExpenseSummaryPdf(
   page.drawText('Expense Grand Total', {
     x: margin + 3 * columnWidth,
     y,
-    size: 12,
+    size: 10,
     font: boldFont,
   });
   page.drawText(formatAmount(total), {
     x: margin + 4 * columnWidth,
     y,
-    size: 12,
+    size: 10,
     font: boldFont,
   });
 


### PR DESCRIPTION
## Summary
- show category and fund names using plural relationship keys
- shrink fonts in generated Expense Summary PDF

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684784aa3c832682d939e5cfe7d134