### PR TITLE
Add fund balance summary to reports

### DIFF
--- a/src/pages/finances/dashboard/FundBalances.tsx
+++ b/src/pages/finances/dashboard/FundBalances.tsx
@@ -12,16 +12,17 @@ interface FundBalance {
 interface Props {
   funds?: FundBalance[];
   currency: string;
+  title?: string;
 }
 
-export function FundBalances({ funds, currency }: Props) {
+export function FundBalances({ funds, currency, title = 'Fund Balances' }: Props) {
   if (!funds || funds.length === 0) return null;
   return (
     <Card className="mt-6">
       <CardContent className="p-4">
         <div className="flex items-center mb-4">
           <DollarSign className="h-5 w-5 text-muted-foreground mr-2" />
-          <h3 className="text-base font-medium text-foreground">Fund Balances</h3>
+          <h3 className="text-base font-medium text-foreground">{title}</h3>
         </div>
         <ul className="space-y-2">
           {funds.map(f => (

--- a/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
+++ b/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
@@ -13,6 +13,7 @@ import { TYPES } from '../../../lib/types';
 import type { IFinanceDashboardRepository } from '../../../repositories/financeDashboard.repository';
 import { formatCurrency } from '../../../utils/currency';
 import { useCurrencyStore } from '../../../stores/currencyStore';
+import { FundBalances } from '../dashboard/FundBalances';
 
 interface Props {
   tenantId: string | null;
@@ -73,11 +74,6 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
         header: 'Fund',
       },
       {
-        accessorKey: 'fund_balance',
-        header: 'Fund Balance',
-        cell: ({ row }) => formatCurrency(row.original.fund_balance, currency),
-      },
-      {
         accessorKey: 'amount',
         header: 'Amount',
         cell: ({ row }) => formatCurrency(row.original.amount, currency),
@@ -89,7 +85,12 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
   const handlePrint = () => window.print();
   const handlePdf = async () => {
     const tenant = await tenantUtils.getCurrentTenant();
-    const blob = await generateExpenseSummaryPdf(tenant?.name || '', dateRange, records);
+    const blob = await generateExpenseSummaryPdf(
+      tenant?.name || '',
+      dateRange,
+      records,
+      fundBalances || [],
+    );
     const url = URL.createObjectURL(blob);
     const fileName = `expense-summary-${format(dateRange.from, 'yyyyMMdd')}-${format(dateRange.to, 'yyyyMMdd')}.pdf`;
     const link = document.createElement('a');
@@ -113,6 +114,7 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
         loading={isLoading}
         exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'expense-summary' }}
       />
+      <FundBalances title="Fund Balances Summary" funds={fundBalances} currency={currency} />
     </div>
   );
 }

--- a/src/utils/expenseSummaryPdf.ts
+++ b/src/utils/expenseSummaryPdf.ts
@@ -20,6 +20,7 @@ export async function generateExpenseSummaryPdf(
   tenantName: string,
   dateRange: { from: Date; to: Date },
   records: ExpenseSummaryRecord[],
+  fundBalances: { id: string; name: string; balance: number }[],
 ): Promise<Blob> {
   const pdfDoc = await PDFDocument.create();
   const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
@@ -29,7 +30,7 @@ export async function generateExpenseSummaryPdf(
 
   const margin = 40;
   const rowHeight = 18;
-  const columnWidth = (width - margin * 2) / 5;
+  const columnWidth = (width - margin * 2) / 4;
 
   const pages: any[] = [];
   let page = pdfDoc.addPage([width, height]);
@@ -68,7 +69,7 @@ export async function generateExpenseSummaryPdf(
   };
 
   const drawTableHeader = () => {
-    const headers = ['Expense Description', 'Expense Category', 'Fund', 'Fund Balance', 'Amount'];
+    const headers = ['Expense Description', 'Expense Category', 'Fund', 'Amount'];
     headers.forEach((h, idx) => {
       page.drawText(h, { x: margin + idx * columnWidth, y, size: 10, font: boldFont });
     });
@@ -91,7 +92,6 @@ export async function generateExpenseSummaryPdf(
       r.description || '',
       r.category_name || '',
       r.fund_name || '',
-      formatAmount(r.fund_balance),
       formatAmount(r.amount),
     ];
     cells.forEach((c, idx) => {
@@ -105,16 +105,29 @@ export async function generateExpenseSummaryPdf(
   const total = records.reduce((sum, r) => sum + (r.amount || 0), 0);
   if (y - rowHeight < margin) addPage();
   page.drawText('Expense Grand Total', {
-    x: margin + 3 * columnWidth,
+    x: margin + 2 * columnWidth,
     y,
     size: 10,
     font: boldFont,
   });
   page.drawText(formatAmount(total), {
-    x: margin + 4 * columnWidth,
+    x: margin + 3 * columnWidth,
     y,
     size: 10,
     font: boldFont,
+  });
+
+  y -= rowHeight * 2;
+  if (y - rowHeight < margin) addPage();
+  page.drawText('Fund Balances Summary', { x: margin, y, size: 12, font: boldFont });
+  y -= rowHeight;
+  fundBalances.forEach(f => {
+    if (y - rowHeight < margin) addPage();
+    page.drawText(f.name, { x: margin, y, size: 10, font });
+    const bal = formatAmount(f.balance);
+    const tw = font.widthOfTextAtSize(bal, 10);
+    page.drawText(bal, { x: width - margin - tw, y, size: 10, font });
+    y -= rowHeight;
   });
 
   pages.forEach((p, idx) => {


### PR DESCRIPTION
## Summary
- allow custom title for `FundBalances`
- show fund balance summary on Expense Summary Report page and PDF
- adjust PDF generator for new layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684a1f9e808326b91fe2ffcd0292e5