### PR TITLE
Add Church Financial Statement report

### DIFF
--- a/src/hooks/useFinancialReports.ts
+++ b/src/hooks/useFinancialReports.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../lib/supabase';
 import { useMessageStore } from '../components/MessageHandler';
 import { FundSummary } from '../models/financialReport.model';
+import type { ChurchFinancialStatementData } from '../utils/churchFinancialStatementPdf';
 
 interface QueryOptions {
   enabled?: boolean;
@@ -201,6 +202,23 @@ export function useFinancialReports(tenantId: string | null) {
       staleTime: 5 * 60 * 1000,
     });
 
+  const useChurchFinancialStatement = (
+    startDate: string,
+    endDate: string,
+    options?: QueryOptions,
+  ) =>
+    useQuery<ChurchFinancialStatementData>({
+      queryKey: ['church-financial-statement', tenantId, startDate, endDate],
+      queryFn: () =>
+        fetchReport('report_church_financial_statement', {
+          p_tenant_id: tenantId,
+          p_start_date: startDate,
+          p_end_date: endDate,
+        }) as Promise<ChurchFinancialStatementData>,
+      enabled: !!tenantId && (options?.enabled ?? true),
+      staleTime: 5 * 60 * 1000,
+    });
+
   return {
     useTrialBalance,
     useGeneralLedger,
@@ -212,6 +230,7 @@ export function useFinancialReports(tenantId: string | null) {
     useGivingStatement,
     useOfferingSummary,
     useCategoryFinancialReport,
+    useChurchFinancialStatement,
     useCashFlowSummary,
   };
 }

--- a/src/pages/finances/FinancialReportsPage.tsx
+++ b/src/pages/finances/FinancialReportsPage.tsx
@@ -23,6 +23,7 @@ import OfferingSummaryReport from './financialReports/OfferingSummaryReport';
 import CategoryFinancialReport from './financialReports/CategoryFinancialReport';
 import CashFlowSummaryReport from './financialReports/CashFlowSummaryReport';
 import ExpenseSummaryReport from './financialReports/ExpenseSummaryReport';
+import ChurchFinancialStatementReport from './financialReports/ChurchFinancialStatementReport';
 
 const reportOptions = [
   { id: 'trial-balance', label: 'Trial Balance' },
@@ -36,6 +37,7 @@ const reportOptions = [
   { id: 'offering-summary', label: 'Offering Summary' },
   { id: 'member-offering-summary', label: 'Member Offering Summary' },
   { id: 'category-financial', label: 'Category Based Report' },
+  { id: 'church-financial-statement', label: 'Church Financial Statement' },
   { id: 'cash-flow', label: 'Cash Flow Summary' },
   { id: 'expense-summary', label: 'Expense Summary' },
 ];
@@ -183,6 +185,9 @@ function FinancialReportsPage() {
           )}
           {reportType === 'category-financial' && (
             <CategoryFinancialReport tenantId={tenantId} dateRange={dateRange} categoryId={categoryId || undefined} />
+          )}
+          {reportType === 'church-financial-statement' && (
+            <ChurchFinancialStatementReport tenantId={tenantId} dateRange={dateRange} />
           )}
           {reportType === 'cash-flow' && (
             <CashFlowSummaryReport tenantId={tenantId} dateRange={dateRange} />

--- a/src/pages/finances/financialReports/ChurchFinancialStatementReport.tsx
+++ b/src/pages/finances/financialReports/ChurchFinancialStatementReport.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { Button } from '../../../components/ui2/button';
+import { Printer, Download } from 'lucide-react';
+import { useFinancialReports } from '../../../hooks/useFinancialReports';
+import { generateChurchFinancialStatementPdf } from '../../../utils';
+import { tenantUtils } from '../../../utils/tenantUtils';
+
+interface Props {
+  tenantId: string | null;
+  dateRange: { from: Date; to: Date };
+}
+
+export default function ChurchFinancialStatementReport({ tenantId, dateRange }: Props) {
+  const { useChurchFinancialStatement } = useFinancialReports(tenantId);
+  const { data } = useChurchFinancialStatement(
+    format(dateRange.from, 'yyyy-MM-dd'),
+    format(dateRange.to, 'yyyy-MM-dd'),
+  );
+
+  const handlePrint = () => window.print();
+  const handlePdf = async () => {
+    if (!data) return;
+    const tenant = await tenantUtils.getCurrentTenant();
+    const blob = await generateChurchFinancialStatementPdf(
+      tenant?.name || '',
+      dateRange,
+      data,
+    );
+    const url = URL.createObjectURL(blob);
+    const fileName = `church-financial-statement-${format(dateRange.from, 'yyyyMMdd')}-${format(dateRange.to, 'yyyyMMdd')}.pdf`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end space-x-2">
+        <Button variant="outline" onClick={handlePrint} icon={<Printer className="h-4 w-4" />}>Print</Button>
+        <Button variant="outline" onClick={handlePdf} icon={<Download className="h-4 w-4" />}>PDF</Button>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20250724000000_church_financial_statement.sql
+++ b/supabase/migrations/20250724000000_church_financial_statement.sql
@@ -1,0 +1,166 @@
+-- Comprehensive church financial statement RPC
+CREATE OR REPLACE FUNCTION report_church_financial_statement(
+  p_tenant_id uuid,
+  p_start_date date,
+  p_end_date date
+)
+RETURNS jsonb
+SECURITY DEFINER
+SET search_path = public
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  result jsonb;
+BEGIN
+  IF NOT check_tenant_access(p_tenant_id) THEN
+    RAISE EXCEPTION 'Permission denied';
+  END IF;
+
+  WITH opening AS (
+    SELECT COALESCE(SUM(
+      CASE
+        WHEN type = 'income' THEN credit
+        WHEN type = 'expense' THEN -debit
+        ELSE COALESCE(credit,0) - COALESCE(debit,0)
+      END
+    ),0) AS balance
+    FROM financial_transactions
+    WHERE tenant_id = p_tenant_id
+      AND date < p_start_date
+  ),
+  period AS (
+    SELECT
+      COALESCE(SUM(CASE WHEN type = 'income' THEN credit END),0) AS income,
+      COALESCE(SUM(CASE WHEN type = 'expense' THEN debit END),0) AS expenses
+    FROM financial_transactions
+    WHERE tenant_id = p_tenant_id
+      AND date BETWEEN p_start_date AND p_end_date
+  ),
+  fund_data AS (
+    SELECT
+      f.name AS fund_name,
+      COALESCE(SUM(CASE WHEN ft.date < p_start_date THEN
+        CASE WHEN ft.type = 'income' THEN ft.credit ELSE -ft.debit END
+      END),0) AS opening_balance,
+      COALESCE(SUM(CASE WHEN ft.date BETWEEN p_start_date AND p_end_date AND ft.type = 'income' THEN ft.credit END),0) AS income,
+      COALESCE(SUM(CASE WHEN ft.date BETWEEN p_start_date AND p_end_date AND ft.type = 'expense' THEN ft.debit END),0) AS expenses
+    FROM funds f
+    LEFT JOIN financial_transactions ft ON ft.fund_id = f.id AND ft.tenant_id = f.tenant_id
+    WHERE f.tenant_id = p_tenant_id
+    GROUP BY f.name
+  ),
+  income_cat AS (
+    SELECT
+      a.name AS account_name,
+      COALESCE(c.name, 'Uncategorized') AS category_name,
+      SUM(ft.credit) AS amount
+    FROM financial_transactions ft
+    JOIN chart_of_accounts a ON ft.account_id = a.id
+    LEFT JOIN categories c ON ft.category_id = c.id
+    WHERE ft.tenant_id = p_tenant_id
+      AND ft.type = 'income'
+      AND ft.date BETWEEN p_start_date AND p_end_date
+    GROUP BY a.name, COALESCE(c.name, 'Uncategorized')
+  ),
+  income_tot AS (
+    SELECT
+      account_name,
+      SUM(amount) AS subtotal,
+      jsonb_agg(jsonb_build_object('category_name', category_name, 'amount', amount) ORDER BY category_name) AS categories
+    FROM income_cat
+    GROUP BY account_name
+  ),
+  expense_cat AS (
+    SELECT
+      a.name AS account_name,
+      COALESCE(c.name, 'Uncategorized') AS category_name,
+      SUM(ft.debit) AS amount
+    FROM financial_transactions ft
+    JOIN chart_of_accounts a ON ft.account_id = a.id
+    LEFT JOIN categories c ON ft.category_id = c.id
+    WHERE ft.tenant_id = p_tenant_id
+      AND ft.type = 'expense'
+      AND ft.date BETWEEN p_start_date AND p_end_date
+    GROUP BY a.name, COALESCE(c.name, 'Uncategorized')
+  ),
+  expense_tot AS (
+    SELECT
+      account_name,
+      SUM(amount) AS subtotal,
+      jsonb_agg(jsonb_build_object('category_name', category_name, 'amount', amount) ORDER BY category_name) AS categories
+    FROM expense_cat
+    GROUP BY account_name
+  ),
+  member_cat AS (
+    SELECT
+      m.first_name || ' ' || m.last_name AS member_name,
+      COALESCE(c.name, 'Uncategorized') AS category_name,
+      SUM(ft.credit) AS amount
+    FROM financial_transactions ft
+    JOIN members m ON ft.member_id = m.id
+    LEFT JOIN categories c ON ft.category_id = c.id
+    WHERE ft.tenant_id = p_tenant_id
+      AND ft.type = 'income'
+      AND ft.date BETWEEN p_start_date AND p_end_date
+    GROUP BY member_name, COALESCE(c.name, 'Uncategorized')
+  ),
+  member_tot AS (
+    SELECT
+      member_name,
+      SUM(amount) AS total,
+      jsonb_agg(jsonb_build_object('category_name', category_name, 'amount', amount) ORDER BY category_name) AS categories
+    FROM member_cat
+    GROUP BY member_name
+  )
+  SELECT jsonb_build_object(
+    'summary', jsonb_build_object(
+      'opening_balance', (SELECT balance FROM opening),
+      'total_income', (SELECT income FROM period),
+      'total_expenses', (SELECT expenses FROM period),
+      'net_result', (SELECT income - expenses FROM period),
+      'ending_balance', (SELECT (SELECT balance FROM opening) + income - expenses FROM period)
+    ),
+    'funds', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'fund_name', fund_name,
+        'opening_balance', opening_balance,
+        'income', income,
+        'expenses', expenses,
+        'ending_balance', opening_balance + income - expenses
+      ) ORDER BY fund_name), '[]'::jsonb)
+      FROM fund_data
+    ),
+    'income', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'account_name', account_name,
+        'categories', categories,
+        'subtotal', subtotal
+      ) ORDER BY account_name), '[]'::jsonb)
+      FROM income_tot
+    ),
+    'expenses', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'account_name', account_name,
+        'categories', categories,
+        'subtotal', subtotal
+      ) ORDER BY account_name), '[]'::jsonb)
+      FROM expense_tot
+    ),
+    'memberGiving', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'member_name', member_name,
+        'categories', categories,
+        'total', total
+      ) ORDER BY member_name), '[]'::jsonb)
+      FROM member_tot
+    ),
+    'remarks', NULL
+  ) INTO result;
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION report_church_financial_statement(uuid, date, date) TO authenticated;
+COMMENT ON FUNCTION report_church_financial_statement(uuid, date, date) IS
+  'Comprehensive financial statement for a tenant within a date range';


### PR DESCRIPTION
## Summary
- add RPC `report_church_financial_statement`
- support new RPC in `useFinancialReports`
- add church financial statement page component
- update financial reports page to include new option

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868497a6bd08326844acd0f92cb2b8d