### PR TITLE
Add Expense Summary subtotals

### DIFF
--- a/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
+++ b/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
@@ -75,7 +75,6 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
           format(new Date(row.original.transaction_date), 'MMM dd, yyyy'),
         size: 120,
       },
-      { accessorKey: 'description', header: 'Expense Description' },
       {
         accessorKey: 'category_name',
         header: 'Expense Category',
@@ -86,6 +85,7 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
         ),
         size: 200,
       },
+      { accessorKey: 'description', header: 'Expense Description' },
       {
         accessorKey: 'fund_name',
         header: 'Fund',

--- a/src/utils/expenseSummaryPdf.ts
+++ b/src/utils/expenseSummaryPdf.ts
@@ -103,7 +103,7 @@ export async function generateExpenseSummaryPdf(
   };
 
   const drawTableHeader = () => {
-    const headers = ['Expense Description', 'Expense Category', 'Fund', 'Amount'];
+    const headers = ['Expense Category', 'Expense Description', 'Fund', 'Amount'];
     headers.forEach((h, idx) => {
       page.drawText(h, { x: margin + columnWidths.slice(0, idx).reduce((a, b) => a + b, 0), y, size: 10, font: boldFont });
     });
@@ -122,8 +122,8 @@ export async function generateExpenseSummaryPdf(
 
   const drawRow = (r: ExpenseSummaryRecord) => {
     const cellLines = [
-      splitTextIntoLines(r.description || '', font, 8, columnWidths[0] - 2),
-      splitTextIntoLines(r.category_name || '', font, 8, columnWidths[1] - 2),
+      splitTextIntoLines(r.category_name || '', font, 8, columnWidths[0] - 2),
+      splitTextIntoLines(r.description || '', font, 8, columnWidths[1] - 2),
       splitTextIntoLines(r.fund_name || '', font, 8, columnWidths[2] - 2),
       [formatAmount(r.amount)],
     ];
@@ -159,6 +159,22 @@ export async function generateExpenseSummaryPdf(
       page.drawText(dateStr, { x: margin, y, size: 10, font: boldFont });
       y -= rowHeight;
       recs.forEach(r => drawRow(r));
+
+      const subTotal = recs.reduce((sum, r) => sum + r.amount, 0);
+      if (y - rowHeight < margin) addPage();
+      page.drawText('Sub Total', {
+        x: margin + columnWidths[0] + columnWidths[1],
+        y,
+        size: 10,
+        font: boldFont,
+      });
+      page.drawText(formatAmount(subTotal), {
+        x: margin + columnWidths[0] + columnWidths[1] + columnWidths[2],
+        y,
+        size: 10,
+        font: boldFont,
+      });
+      y -= rowHeight * 1.5;
     });
 
   const total = records.reduce((sum, r) => sum + (r.amount || 0), 0);


### PR DESCRIPTION
## Summary
- include per-date subtotal rows in the expense summary PDF
- reorder report columns so the expense category appears before description
- update table column order on the Expense Summary report page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868517dcf34832680e5ddb85ef46554