### PR TITLE
Update PDF footers with generation timestamp

### DIFF
--- a/src/utils/churchFinancialStatementPdf.ts
+++ b/src/utils/churchFinancialStatementPdf.ts
@@ -82,10 +82,13 @@ const addFooters = (
   margin: number,
   font: any,
 ) => {
+  const generated = `Generated via StewardTrack on: ${format(new Date(), 'MMM dd, yyyy')}`;
   pages.forEach((p, i) => {
+    const footerY = margin / 2;
+    p.drawText(generated, { x: margin, y: footerY, size: 10, font });
     const text = `Page ${i + 1} of ${pages.length}`;
     const tw = font.widthOfTextAtSize(text, 10);
-    p.drawText(text, { x: width - margin - tw, y: margin / 2, size: 10, font });
+    p.drawText(text, { x: width - margin - tw, y: footerY, size: 10, font });
   });
 };
 
@@ -122,7 +125,10 @@ export async function generateChurchFinancialStatementPdf(
   centerCover(churchName, 18, true);
   centerCover('Comprehensive Church Financial Statement', 16, true);
   centerCover(rangeStr, 12);
-  centerCover(`Generated on: ${format(new Date(), 'MMM dd, yyyy')}`, 10);
+  centerCover(
+    `Generated via StewardTrack on: ${format(new Date(), 'MMM dd, yyyy')}`,
+    10,
+  );
   y -= rowHeight;
 
   // Summary Page

--- a/src/utils/expenseSummaryPdf.ts
+++ b/src/utils/expenseSummaryPdf.ts
@@ -207,10 +207,13 @@ export async function generateExpenseSummaryPdf(
       y -= rowHeight;
     });
 
+  const generated = `Generated via StewardTrack on: ${format(new Date(), 'MMM dd, yyyy')}`;
   pages.forEach((p, idx) => {
+    const footerY = margin / 2;
+    p.drawText(generated, { x: margin, y: footerY, size: 10, font });
     const text = `Page ${idx + 1} of ${pages.length}`;
     const tw = font.widthOfTextAtSize(text, 10);
-    p.drawText(text, { x: width / 2 - tw / 2, y: margin / 2, size: 10, font });
+    p.drawText(text, { x: width / 2 - tw / 2, y: footerY, size: 10, font });
   });
 
   const pdfBytes = await pdfDoc.save();


### PR DESCRIPTION
## Summary
- add "Generated via StewardTrack" footer in Expense Summary PDFs
- add same footer in Comprehensive Church Financial Statement
- show generation note on statement cover page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868551fd4948326b604d5e6668cf539