### PR TITLE
Add member linkage to tenant_users

### DIFF
--- a/src/adapters/authUser.adapter.ts
+++ b/src/adapters/authUser.adapter.ts
@@ -136,6 +136,7 @@ export class AuthUserAdapter
             tenant_id: tenantId,
             user_id: userId,
             admin_role: (data as any).admin_role || 'member',
+            member_id: (data as any).member_id || null,
             created_by: currentUser,
           },
         ]);

--- a/supabase/migrations/20250705030000_update_tenant_registration.sql
+++ b/supabase/migrations/20250705030000_update_tenant_registration.sql
@@ -22,6 +22,7 @@ DECLARE
   member_role_id uuid;
   v_membership_category_id uuid;
   v_status_category_id uuid;
+  v_member_id uuid;
 BEGIN
   -- Input validation
   IF p_tenant_subdomain !~ '^[a-z0-9-]+$' THEN
@@ -266,7 +267,13 @@ BEGIN
     v_status_category_id,
     CURRENT_DATE,
     p_user_id
-  );
+  ) RETURNING id INTO v_member_id;
+
+  -- Link member to tenant_users record
+  UPDATE tenant_users
+  SET member_id = v_member_id
+  WHERE tenant_id = new_tenant_id
+    AND user_id = p_user_id;
 
   RETURN new_tenant_id;
 EXCEPTION

--- a/supabase/migrations/20250715000000_membership_tables.sql
+++ b/supabase/migrations/20250715000000_membership_tables.sql
@@ -135,6 +135,7 @@ DECLARE
   member_role_id uuid;
   v_membership_category_id uuid;
   v_status_category_id uuid;
+  v_member_id uuid;
 BEGIN
   -- Input validation
   IF p_tenant_subdomain !~ '^[a-z0-9-]+$' THEN
@@ -350,7 +351,13 @@ BEGIN
     v_status_category_id,
     CURRENT_DATE,
     p_user_id
-  );
+  ) RETURNING id INTO v_member_id;
+
+  -- Link member to tenant_users record
+  UPDATE tenant_users
+  SET member_id = v_member_id
+  WHERE tenant_id = new_tenant_id
+    AND user_id = p_user_id;
 
   RETURN new_tenant_id;
 EXCEPTION

--- a/supabase/migrations/20250715021000_complete_member_registration.sql
+++ b/supabase/migrations/20250715021000_complete_member_registration.sql
@@ -74,6 +74,12 @@ BEGIN
     p_user_id
   ) RETURNING id INTO v_member_id;
 
+  -- Link member to tenant_users record
+  UPDATE tenant_users
+  SET member_id = v_member_id
+  WHERE tenant_id = p_tenant_id
+    AND user_id = p_user_id;
+
   RETURN jsonb_build_object(
     'member_id', v_member_id,
     'user_id', p_user_id,

--- a/supabase/migrations/20250724001000_add_member_id_to_tenant_users.sql
+++ b/supabase/migrations/20250724001000_add_member_id_to_tenant_users.sql
@@ -1,0 +1,8 @@
+-- Add member_id column to tenant_users table
+ALTER TABLE tenant_users
+  ADD COLUMN member_id uuid REFERENCES members(id);
+
+-- Index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_tenant_users_member_id ON tenant_users(member_id);
+
+COMMENT ON COLUMN tenant_users.member_id IS 'Reference to members table';


### PR DESCRIPTION
## Summary
- link tenant users to members via new `member_id` column
- propagate member_id in registration functions
- update tenant registration flows and adapter

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687965bfa083269e6c7b7b656f76f3