### PR TITLE
Remove redundant error rethrows

### DIFF
--- a/src/adapters/authUser.adapter.ts
+++ b/src/adapters/authUser.adapter.ts
@@ -40,7 +40,6 @@ export class AuthUserAdapter
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       const users = (data || []) as User[];
@@ -67,7 +66,6 @@ export class AuthUserAdapter
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       const user = (data || []).find((u: any) => u.id === id) || null;
@@ -147,7 +145,6 @@ export class AuthUserAdapter
         await supabase.from('user_roles').delete().eq('user_id', userId);
         await supabase.rpc('delete_user', { user_id: userId });
         handleSupabaseError(insertError as any);
-        throw insertError;
       }
 
       const { data: userData, error: fetchError } = await supabase.rpc('get_tenant_user', {
@@ -157,7 +154,6 @@ export class AuthUserAdapter
 
       if (fetchError) {
         handleSupabaseError(fetchError);
-        throw fetchError;
       }
 
       const user = (userData as any)?.[0] as User;
@@ -179,7 +175,6 @@ export class AuthUserAdapter
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       const user = (updated as any) as User;
@@ -196,7 +191,6 @@ export class AuthUserAdapter
       const { error } = await supabase.rpc('delete_user', { user_id: id });
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       await this.auditService.logAuditEvent('delete', 'user', id, { id });

--- a/src/adapters/base.adapter.ts
+++ b/src/adapters/base.adapter.ts
@@ -230,7 +230,6 @@ export class BaseAdapter<T extends BaseModel> {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       return { data: data || [], count };
@@ -252,7 +251,6 @@ export class BaseAdapter<T extends BaseModel> {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       return data;
@@ -299,7 +297,6 @@ export class BaseAdapter<T extends BaseModel> {
 
       if (createError) {
         handleSupabaseError(createError);
-        throw createError;
       }
 
       // Handle relations if provided
@@ -352,7 +349,6 @@ export class BaseAdapter<T extends BaseModel> {
 
       if (updateError) {
         handleSupabaseError(updateError);
-        throw updateError;
       }
 
       // Handle relations if provided
@@ -396,7 +392,6 @@ export class BaseAdapter<T extends BaseModel> {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       // Run post-delete hook

--- a/src/utils/queryUtils.ts
+++ b/src/utils/queryUtils.ts
@@ -212,7 +212,6 @@ export class QueryUtils {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       return { data: data || [], count };
@@ -239,7 +238,6 @@ export class QueryUtils {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       return data;
@@ -425,7 +423,6 @@ export class QueryUtils {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
     } catch (error) {
       console.error(`Error deleting ${table}:`, error);
@@ -446,7 +443,6 @@ export class QueryUtils {
 
       if (error) {
         handleSupabaseError(error);
-        throw error;
       }
 
       return (count || 0) > 0;


### PR DESCRIPTION
## Summary
- clean up redundant `throw error` calls after `handleSupabaseError`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1e584e88326868df8bab42ff282