### PR TITLE
Update errorHandler to return raw message

### DIFF
--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -39,6 +39,9 @@ function getErrorType(error: any): ErrorType {
 // Function to get user-friendly message
 function getUserFriendlyMessage(error: any): string {
   const errorType = getErrorType(error);
+  if (errorType === 'unknown' && error?.message) {
+    return error.message;
+  }
   return USER_FRIENDLY_MESSAGES[errorType];
 }
 

--- a/tests/errorHandler.test.ts
+++ b/tests/errorHandler.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { handleError } from '../src/utils/errorHandler';
+
+describe('handleError', () => {
+  it('returns error message when error type is unknown', () => {
+    const result = handleError(new Error('foo'));
+    expect(result.message).toBe('foo');
+  });
+});


### PR DESCRIPTION
## Summary
- allow unknown errors to return their original message
- test error handler's raw message behavior

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1d3d4f88326a40970edc5cdaa6b