### PR TITLE
Add unique constraint on tenant_users

### DIFF
--- a/supabase/migrations/20250724002000_tenant_users_member_unique.sql
+++ b/supabase/migrations/20250724002000_tenant_users_member_unique.sql
@@ -1,0 +1,18 @@
+-- Remove duplicate tenant_user rows by tenant and member before enforcing unique constraint
+DELETE FROM tenant_users tu
+USING (
+  SELECT ctid
+  FROM (
+    SELECT ctid,
+           ROW_NUMBER() OVER (PARTITION BY tenant_id, member_id ORDER BY created_at) AS rn
+    FROM tenant_users
+    WHERE member_id IS NOT NULL
+  ) sub
+  WHERE rn > 1
+) dup
+WHERE tu.ctid = dup.ctid;
+
+-- Add unique constraint to ensure a member can only belong to a tenant once
+ALTER TABLE tenant_users
+  ADD CONSTRAINT tenant_users_member_unique
+  UNIQUE (tenant_id, member_id);


### PR DESCRIPTION
## Summary
- dedupe tenant_users by tenant and member
- ensure tenant/member combinations are unique

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f28d7e708326a5217460cf434716