### PR TITLE
Use tenant_users link for current member

### DIFF
--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,27 +1,14 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../lib/supabase';
+import { getCurrentUserMember } from '../utils/memberUtils';
 import { useAuthStore } from '../stores/authStore';
 
 function DashboardHeader() {
   const { user } = useAuthStore();
   const { data: member } = useQuery({
-    queryKey: ['dashboard-header-member', user?.email],
-    queryFn: async () => {
-      if (!user?.email) return null;
-      const { data, error } = await supabase
-        .from('members')
-        .select('first_name')
-        .eq('email', user.email)
-        .is('deleted_at', null)
-        .single();
-      if (error) {
-        console.error('Error fetching member data:', error);
-        return null;
-      }
-      return data;
-    },
-    enabled: !!user?.email,
+    queryKey: ['dashboard-header-member', user?.id],
+    queryFn: getCurrentUserMember,
+    enabled: !!user?.id,
   });
 
   const userName = member?.first_name || user?.email || 'User';

--- a/src/components/WelcomeGreeting.tsx
+++ b/src/components/WelcomeGreeting.tsx
@@ -1,31 +1,13 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../lib/supabase';
+import { getCurrentUserMember } from '../utils/memberUtils';
 import { Cake, Book } from 'lucide-react';
 import { Card } from './ui2/card';
 
 function WelcomeGreeting() {
   const { data: member } = useQuery({
     queryKey: ['current-user-member'],
-    queryFn: async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user?.email) return null;
-
-      // Then get the member details
-      const { data: member, error: memberError } = await supabase
-        .from('members')
-        .select('id, first_name, last_name, birthday')
-        .eq('email', user.email)
-        .is('deleted_at', null)
-        .single();
-
-      if (memberError) {
-        console.error('Error fetching member data:', memberError);
-        return null;
-      }
-
-      return member;
-    },
+    queryFn: getCurrentUserMember,
   });
 
   // Get time-based greeting

--- a/src/pages/Welcome.tsx
+++ b/src/pages/Welcome.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { supabase } from '../lib/supabase';
+import { getCurrentUserMember } from '../utils/memberUtils';
 import { tenantUtils } from '../utils/tenantUtils';
 import { usePermissions } from '../hooks/usePermissions';
 import { container } from '../lib/container';
@@ -36,21 +36,7 @@ function Welcome() {
   // Fetch the logged in member
   const { data: member, isLoading: memberLoading } = useQuery({
     queryKey: ['current-user-member'],
-    queryFn: async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user?.email) return null;
-      const { data, error } = await supabase
-        .from('members')
-        .select('first_name, last_name, email')
-        .eq('email', user.email)
-        .is('deleted_at', null)
-        .single();
-      if (error) {
-        console.error('Error fetching member data:', error);
-        return null;
-      }
-      return data;
-    },
+    queryFn: getCurrentUserMember,
   });
 
   // Fetch current tenant info

--- a/src/pages/dashboard/DashboardLayout.tsx
+++ b/src/pages/dashboard/DashboardLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link, useLocation, Outlet } from 'react-router-dom';
 import { Building2, User } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '../../lib/supabase';
+import { getCurrentUserMember } from '../../utils/memberUtils';
 import { useAuthStore } from '../../stores/authStore';
 import { Tabs } from '../../components/ui2/tabs';
 import { Card, CardContent } from '../../components/ui2/card';
@@ -14,25 +14,9 @@ function DashboardLayout() {
 
   // Get associated member data
   const { data: memberData } = useQuery({
-    queryKey: ['current-user-member', user?.email],
-    queryFn: async () => {
-      if (!user?.email) return null;
-
-      const { data, error } = await supabase
-        .from('members')
-        .select('id, first_name, last_name')
-        .eq('email', user.email)
-        .is('deleted_at', null)
-        .single();
-
-      if (error) {
-        console.error('Error fetching member data:', error);
-        return null;
-      }
-
-      return data;
-    },
-    enabled: !!user?.email,
+    queryKey: ['current-user-member', user?.id],
+    queryFn: getCurrentUserMember,
+    enabled: !!user?.id,
   });
 
   const tabs = [

--- a/src/pages/dashboard/PersonalDashboard.tsx
+++ b/src/pages/dashboard/PersonalDashboard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
+import { getCurrentUserMember } from '../../utils/memberUtils';
 import { format, subMonths, startOfMonth, endOfMonth, startOfDay, endOfDay } from 'date-fns';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
@@ -32,21 +33,9 @@ function PersonalDashboard() {
 
   // Get associated member data
   const { data: memberData } = useQuery({
-    queryKey: ['current-user-member', user?.email],
-    queryFn: async () => {
-      if (!user?.email) return null;
-
-      const { data, error } = await supabase
-        .from('members')
-        .select('id, first_name, last_name')
-        .eq('email', user.email)
-        .is('deleted_at', null)
-        .single();
-
-      if (error) throw error;
-      return data;
-    },
-    enabled: !!user?.email,
+    queryKey: ['current-user-member', user?.id],
+    queryFn: getCurrentUserMember,
+    enabled: !!user?.id,
   });
 
   // Get personal monthly trends

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,3 +20,4 @@ export * from './memberGivingSummaryPdf';
 export * from './memberOfferingSummaryPdf';
 export * from './expenseSummaryPdf';
 export * from './churchFinancialStatementPdf';
+export * from './memberUtils';

--- a/src/utils/memberUtils.ts
+++ b/src/utils/memberUtils.ts
@@ -1,0 +1,37 @@
+import { supabase } from '../lib/supabase';
+import { tenantUtils } from './tenantUtils';
+import type { Member } from '../models/member.model';
+
+export async function getCurrentUserMember(): Promise<Member | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const tenantId = await tenantUtils.getTenantId();
+  if (!tenantId) return null;
+
+  const { data: tenantUser, error: tuError } = await supabase
+    .from('tenant_users')
+    .select('member_id')
+    .eq('user_id', user.id)
+    .eq('tenant_id', tenantId)
+    .single();
+
+  if (tuError || !tenantUser?.member_id) {
+    if (tuError) console.error('Error fetching tenant user:', tuError);
+    return null;
+  }
+
+  const { data: member, error: memberError } = await supabase
+    .from('members')
+    .select('*')
+    .eq('id', tenantUser.member_id)
+    .is('deleted_at', null)
+    .single();
+
+  if (memberError) {
+    console.error('Error fetching member:', memberError);
+    return null;
+  }
+
+  return member as Member;
+}


### PR DESCRIPTION
## Summary
- add `getCurrentUserMember` utility
- refactor DashboardHeader, WelcomeGreeting and dashboard pages to use new helper
- re-export helper from utils index

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f287a9a0832692dc8d5938af3ce5