### PR TITLE
Fix new tenant COA hierarchy

### DIFF
--- a/supabase/migrations/20250724003000_update_new_tenant_coa_function.sql
+++ b/supabase/migrations/20250724003000_update_new_tenant_coa_function.sql
@@ -1,0 +1,14 @@
+-- Ensure new tenants receive a full chart of accounts hierarchy
+-- by calling the helper that sets parent relationships.
+CREATE OR REPLACE FUNCTION create_default_chart_of_accounts_for_new_tenant()
+RETURNS TRIGGER AS $$
+BEGIN
+  BEGIN
+    PERFORM create_default_chart_of_accounts_for_tenant(NEW.id, NEW.created_by);
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'Error creating default chart of accounts for tenant %: %', NEW.id, SQLERRM;
+  END;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
## Summary
- update `create_default_chart_of_accounts_for_new_tenant` to call helper that sets parent relationships

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869051023288326ab68863055f1aaec