### PR TITLE
Remove unused imports in date-range-picker

### DIFF
--- a/src/components/ui2/date-range-picker.tsx
+++ b/src/components/ui2/date-range-picker.tsx
@@ -9,14 +9,13 @@ import {
   addDays,
   parse,
 } from 'date-fns';
-import { Calendar as CalendarIcon, ChevronDown, X } from 'lucide-react';
+import { Calendar as CalendarIcon, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from './button';
 import { Calendar } from './calendar';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 import { Input } from './input';
 import { Badge } from './badge';
-import { Separator } from './separator';
 
 export type DateRange = {
   from: Date | undefined;


### PR DESCRIPTION
## Summary
- remove unused `X` icon and `Separator` import from date-range-picker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68690eaf4b888326a405aaf430ecf746