### PR TITLE
Fix member offering report pagination

### DIFF
--- a/src/pages/finances/financialReports/MemberOfferingSummaryReport.tsx
+++ b/src/pages/finances/financialReports/MemberOfferingSummaryReport.tsx
@@ -18,16 +18,11 @@ interface Props {
 export default function MemberOfferingSummaryReport({ tenantId, dateRange }: Props) {
   const { useStatements } = useContributionStatements();
   const { currency } = useCurrencyStore();
-  const [pageIndex, setPageIndex] = React.useState(0);
-  const [pageSize, setPageSize] = React.useState(10);
   const { data: result, isLoading } = useStatements(
     format(dateRange.from, 'yyyy-MM-dd'),
     format(dateRange.to, 'yyyy-MM-dd'),
-    pageSize,
-    pageIndex * pageSize,
   );
   const rawData = result?.data || [];
-  const recordCount = result?.count ?? rawData.length;
 
   const categories = React.useMemo(() => {
     const set = new Set<string>();
@@ -152,15 +147,8 @@ export default function MemberOfferingSummaryReport({ tenantId, dateRange }: Pro
       </div>
       <DataGrid
         data={tableData}
-        recordCount={recordCount}
         columns={columns}
         loading={isLoading}
-        onPageChange={setPageIndex}
-        onPageSizeChange={size => {
-          setPageSize(size);
-          setPageIndex(0);
-        }}
-        pagination={{ pageSize }}
         exportOptions={{ enabled: true, excel: true, pdf: false, fileName: 'member-offering-summary' }}
       />
     </div>


### PR DESCRIPTION
## Summary
- fetch full result set for MemberOfferingSummaryReport
- rely on client-side pagination

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692cb50be8832696d35e08fcdf6235