### PR TITLE
Disable sorting on all data grid columns

### DIFF
--- a/src/pages/finances/financialReports/BudgetVsActualReport.tsx
+++ b/src/pages/finances/financialReports/BudgetVsActualReport.tsx
@@ -21,10 +21,10 @@ export default function BudgetVsActualReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'budget_name', header: 'Budget' },
-      { accessorKey: 'budget_amount', header: 'Budgeted' },
-      { accessorKey: 'actual_amount', header: 'Actual' },
-      { accessorKey: 'variance', header: 'Variance' },
+      { accessorKey: 'budget_name', header: 'Budget', enableSorting: false },
+      { accessorKey: 'budget_amount', header: 'Budgeted', enableSorting: false },
+      { accessorKey: 'actual_amount', header: 'Actual', enableSorting: false },
+      { accessorKey: 'variance', header: 'Variance', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/CashFlowSummaryReport.tsx
+++ b/src/pages/finances/financialReports/CashFlowSummaryReport.tsx
@@ -21,10 +21,10 @@ export default function CashFlowSummaryReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'month', header: 'Month' },
-      { accessorKey: 'inflow', header: 'Inflow' },
-      { accessorKey: 'outflow', header: 'Outflow' },
-      { accessorKey: 'net_change', header: 'Net Change' },
+      { accessorKey: 'month', header: 'Month', enableSorting: false },
+      { accessorKey: 'inflow', header: 'Inflow', enableSorting: false },
+      { accessorKey: 'outflow', header: 'Outflow', enableSorting: false },
+      { accessorKey: 'net_change', header: 'Net Change', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/CategoryFinancialReport.tsx
+++ b/src/pages/finances/financialReports/CategoryFinancialReport.tsx
@@ -28,9 +28,9 @@ export default function CategoryFinancialReport({ tenantId, dateRange, categoryI
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'category_name', header: 'Category' },
-      { accessorKey: 'income', header: 'Income' },
-      { accessorKey: 'expenses', header: 'Expenses' },
+      { accessorKey: 'category_name', header: 'Category', enableSorting: false },
+      { accessorKey: 'income', header: 'Income', enableSorting: false },
+      { accessorKey: 'expenses', header: 'Expenses', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
+++ b/src/pages/finances/financialReports/ExpenseSummaryReport.tsx
@@ -74,6 +74,7 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
         cell: ({ row }) =>
           format(new Date(row.original.transaction_date), 'MMM dd, yyyy'),
         size: 120,
+        enableSorting: false,
       },
       {
         accessorKey: 'category_name',
@@ -84,16 +85,19 @@ export default function ExpenseSummaryReport({ tenantId, dateRange }: Props) {
           </span>
         ),
         size: 200,
+        enableSorting: false,
       },
-      { accessorKey: 'description', header: 'Expense Description' },
+      { accessorKey: 'description', header: 'Expense Description', enableSorting: false },
       {
         accessorKey: 'fund_name',
         header: 'Fund',
+        enableSorting: false,
       },
       {
         accessorKey: 'amount',
         header: 'Amount',
         cell: ({ row }) => formatCurrency(row.original.amount, currency),
+        enableSorting: false,
       },
     ],
     [currency],

--- a/src/pages/finances/financialReports/FundSummaryReport.tsx
+++ b/src/pages/finances/financialReports/FundSummaryReport.tsx
@@ -22,10 +22,10 @@ export default function FundSummaryReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<FundSummary>[]>(
     () => [
-      { accessorKey: 'fund_name', header: 'Fund' },
-      { accessorKey: 'income', header: 'Income' },
-      { accessorKey: 'expenses', header: 'Expenses' },
-      { accessorKey: 'net_change', header: 'Net Change' },
+      { accessorKey: 'fund_name', header: 'Fund', enableSorting: false },
+      { accessorKey: 'income', header: 'Income', enableSorting: false },
+      { accessorKey: 'expenses', header: 'Expenses', enableSorting: false },
+      { accessorKey: 'net_change', header: 'Net Change', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/GeneralLedgerReport.tsx
+++ b/src/pages/finances/financialReports/GeneralLedgerReport.tsx
@@ -28,13 +28,13 @@ export default function GeneralLedgerReport({ tenantId, dateRange, accountId }: 
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'entry_date', header: 'Date' },
-      { accessorKey: 'account_code', header: 'Account Code' },
-      { accessorKey: 'account_name', header: 'Account Name' },
-      { accessorKey: 'description', header: 'Description' },
-      { accessorKey: 'debit', header: 'Debit' },
-      { accessorKey: 'credit', header: 'Credit' },
-      { accessorKey: 'running_balance', header: 'Balance' },
+      { accessorKey: 'entry_date', header: 'Date', enableSorting: false },
+      { accessorKey: 'account_code', header: 'Account Code', enableSorting: false },
+      { accessorKey: 'account_name', header: 'Account Name', enableSorting: false },
+      { accessorKey: 'description', header: 'Description', enableSorting: false },
+      { accessorKey: 'debit', header: 'Debit', enableSorting: false },
+      { accessorKey: 'credit', header: 'Credit', enableSorting: false },
+      { accessorKey: 'running_balance', header: 'Balance', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/GivingStatementReport.tsx
+++ b/src/pages/finances/financialReports/GivingStatementReport.tsx
@@ -29,10 +29,10 @@ export default function GivingStatementReport({ tenantId, dateRange, memberId }:
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'entry_date', header: 'Date' },
-      { accessorKey: 'fund_name', header: 'Fund' },
-      { accessorKey: 'amount', header: 'Amount' },
-      { accessorKey: 'description', header: 'Description' },
+      { accessorKey: 'entry_date', header: 'Date', enableSorting: false },
+      { accessorKey: 'fund_name', header: 'Fund', enableSorting: false },
+      { accessorKey: 'amount', header: 'Amount', enableSorting: false },
+      { accessorKey: 'description', header: 'Description', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/IncomeStatementReport.tsx
+++ b/src/pages/finances/financialReports/IncomeStatementReport.tsx
@@ -21,10 +21,10 @@ export default function IncomeStatementReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'account_code', header: 'Account Code' },
-      { accessorKey: 'account_name', header: 'Account Name' },
-      { accessorKey: 'account_type', header: 'Account Type' },
-      { accessorKey: 'amount', header: 'Amount' },
+      { accessorKey: 'account_code', header: 'Account Code', enableSorting: false },
+      { accessorKey: 'account_name', header: 'Account Name', enableSorting: false },
+      { accessorKey: 'account_type', header: 'Account Type', enableSorting: false },
+      { accessorKey: 'amount', header: 'Amount', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/JournalReport.tsx
+++ b/src/pages/finances/financialReports/JournalReport.tsx
@@ -21,12 +21,12 @@ export default function JournalReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'entry_date', header: 'Date' },
-      { accessorKey: 'account_code', header: 'Account Code' },
-      { accessorKey: 'account_name', header: 'Account Name' },
-      { accessorKey: 'description', header: 'Description' },
-      { accessorKey: 'debit', header: 'Debit' },
-      { accessorKey: 'credit', header: 'Credit' },
+      { accessorKey: 'entry_date', header: 'Date', enableSorting: false },
+      { accessorKey: 'account_code', header: 'Account Code', enableSorting: false },
+      { accessorKey: 'account_name', header: 'Account Name', enableSorting: false },
+      { accessorKey: 'description', header: 'Description', enableSorting: false },
+      { accessorKey: 'debit', header: 'Debit', enableSorting: false },
+      { accessorKey: 'credit', header: 'Credit', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/MemberGivingSummaryReport.tsx
+++ b/src/pages/finances/financialReports/MemberGivingSummaryReport.tsx
@@ -33,10 +33,10 @@ export default function MemberGivingSummaryReport({ tenantId, dateRange, memberI
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'first_name', header: 'First Name' },
-      { accessorKey: 'last_name', header: 'Last Name' },
-      { accessorKey: 'fund_name', header: 'Fund' },
-      { accessorKey: 'total_amount', header: 'Total Amount' },
+      { accessorKey: 'first_name', header: 'First Name', enableSorting: false },
+      { accessorKey: 'last_name', header: 'Last Name', enableSorting: false },
+      { accessorKey: 'fund_name', header: 'Fund', enableSorting: false },
+      { accessorKey: 'total_amount', header: 'Total Amount', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/OfferingSummaryReport.tsx
+++ b/src/pages/finances/financialReports/OfferingSummaryReport.tsx
@@ -21,8 +21,8 @@ export default function OfferingSummaryReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'category_name', header: 'Category' },
-      { accessorKey: 'total_amount', header: 'Total Amount' },
+      { accessorKey: 'category_name', header: 'Category', enableSorting: false },
+      { accessorKey: 'total_amount', header: 'Total Amount', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/finances/financialReports/TrialBalanceReport.tsx
+++ b/src/pages/finances/financialReports/TrialBalanceReport.tsx
@@ -18,11 +18,11 @@ export default function TrialBalanceReport({ tenantId, dateRange }: Props) {
 
   const columns = React.useMemo<ColumnDef<any>[]>(
     () => [
-      { accessorKey: 'account_code', header: 'Account Code' },
-      { accessorKey: 'account_name', header: 'Account Name' },
-      { accessorKey: 'account_type', header: 'Account Type' },
-      { accessorKey: 'debit_balance', header: 'Debit' },
-      { accessorKey: 'credit_balance', header: 'Credit' },
+      { accessorKey: 'account_code', header: 'Account Code', enableSorting: false },
+      { accessorKey: 'account_name', header: 'Account Name', enableSorting: false },
+      { accessorKey: 'account_type', header: 'Account Type', enableSorting: false },
+      { accessorKey: 'debit_balance', header: 'Debit', enableSorting: false },
+      { accessorKey: 'credit_balance', header: 'Credit', enableSorting: false },
     ],
     [],
   );

--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -144,10 +144,12 @@ function MemberList() {
           </span>
         </div>
       ),
+      enableSorting: false,
     },
     {
       accessorKey: 'preferred_name',
       header: 'Preferred Name',
+      enableSorting: false,
     },
     {
       accessorKey: 'email',
@@ -158,6 +160,7 @@ function MemberList() {
           {getValue<string>()}
         </div>
       ),
+      enableSorting: false,
     },
     {
       accessorKey: 'contact_number',
@@ -168,6 +171,7 @@ function MemberList() {
           {getValue<string>()}
         </div>
       ),
+      enableSorting: false,
     },
     {
       id: 'membership_status.name',
@@ -180,6 +184,7 @@ function MemberList() {
           </Badge>
         </div>
       ),
+      enableSorting: false,
     },
     {
       accessorKey: 'membership_date',
@@ -193,6 +198,7 @@ function MemberList() {
           </div>
         );
       },
+      enableSorting: false,
     },
     {
       accessorKey: 'birthday',
@@ -206,6 +212,7 @@ function MemberList() {
           </div>
         );
       },
+      enableSorting: false,
     },
   ];
 


### PR DESCRIPTION
## Summary
- disable column sorting for all financial report data grids
- disable column sorting on the members list

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693590350883269efd14b49e5d934e