### PR TITLE
Fix multiple toast notifications in IncomeExpenseAddEdit

### DIFF
--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,17 +1,34 @@
 import { useMessageStore } from '../components/MessageHandler';
 
+type MaybePromise<T> = T | Promise<T>;
+
 export class NotificationService {
+  private static enabled = true;
+
+  static async runSilenced<T>(fn: () => MaybePromise<T>): Promise<T> {
+    const prev = NotificationService.enabled;
+    NotificationService.enabled = false;
+    try {
+      return await fn();
+    } finally {
+      NotificationService.enabled = prev;
+    }
+  }
+
   static showSuccess(text: string, duration = 3000) {
+    if (!NotificationService.enabled) return;
     const { addMessage } = useMessageStore.getState();
     addMessage({ type: 'success', text, duration });
   }
 
   static showError(text: string, duration = 5000) {
+    if (!NotificationService.enabled) return;
     const { addMessage } = useMessageStore.getState();
     addMessage({ type: 'error', text, duration });
   }
 
   static showInfo(text: string, duration = 3000) {
+    if (!NotificationService.enabled) return;
     const { addMessage } = useMessageStore.getState();
     addMessage({ type: 'info', text, duration });
   }


### PR DESCRIPTION
## Summary
- add `runSilenced` helper to `NotificationService`
- wrap income/expense service operations with notification silencing to avoid multiple toasts

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686950e5217883268daa6d4a1250b0fa