### PR TITLE
Fix duplicate toast notifications in finance entry editor

### DIFF
--- a/src/repositories/financialTransaction.repository.ts
+++ b/src/repositories/financialTransaction.repository.ts
@@ -28,7 +28,7 @@ export class FinancialTransactionRepository
   protected override async afterCreate(
     data: FinancialTransaction
   ): Promise<void> {
-    NotificationService.showSuccess('Transaction entry created successfully');
+    // Notification handled at service level
   }
 
   protected override async beforeUpdate(
@@ -42,11 +42,11 @@ export class FinancialTransactionRepository
   protected override async afterUpdate(
     data: FinancialTransaction
   ): Promise<void> {
-    NotificationService.showSuccess('Transaction entry updated successfully');
+    // Notification handled at service level
   }
 
   protected override async afterDelete(id: string): Promise<void> {
-    NotificationService.showSuccess('Transaction entry deleted successfully');
+    // Notification handled at service level
   }
 
   private formatData(

--- a/src/repositories/financialTransactionHeader.repository.ts
+++ b/src/repositories/financialTransactionHeader.repository.ts
@@ -41,8 +41,7 @@ export class FinancialTransactionHeaderRepository
   }
 
   protected override async afterCreate(data: FinancialTransactionHeader): Promise<void> {
-    // Additional repository-level operations after creation
-    NotificationService.showSuccess(`Transaction "${data.transaction_number}" created successfully`);
+    // Notification handled at service level
   }
 
   protected override async beforeUpdate(id: string, data: Partial<FinancialTransactionHeader>): Promise<Partial<FinancialTransactionHeader>> {
@@ -54,8 +53,7 @@ export class FinancialTransactionHeaderRepository
   }
 
   protected override async afterUpdate(data: FinancialTransactionHeader): Promise<void> {
-    // Additional repository-level operations after update
-    NotificationService.showSuccess(`Transaction "${data.transaction_number}" updated successfully`);
+    // Notification handled at service level
   }
 
   protected override async beforeDelete(id: string): Promise<void> {
@@ -71,8 +69,7 @@ export class FinancialTransactionHeaderRepository
   }
 
   protected override async afterDelete(id: string): Promise<void> {
-    // Additional repository-level cleanup after delete
-    NotificationService.showSuccess('Transaction deleted successfully');
+    // Notification handled at service level
   }
 
   public async createWithTransactions(

--- a/src/repositories/incomeExpenseTransaction.repository.ts
+++ b/src/repositories/incomeExpenseTransaction.repository.ts
@@ -28,7 +28,7 @@ export class IncomeExpenseTransactionRepository
   }
 
   protected override async afterCreate(data: IncomeExpenseTransaction): Promise<void> {
-    NotificationService.showSuccess('Transaction created successfully');
+    // Notification handled at service level
   }
 
   protected override async beforeUpdate(
@@ -40,11 +40,11 @@ export class IncomeExpenseTransactionRepository
   }
 
   protected override async afterUpdate(data: IncomeExpenseTransaction): Promise<void> {
-    NotificationService.showSuccess('Transaction updated successfully');
+    // Notification handled at service level
   }
 
   protected override async afterDelete(id: string): Promise<void> {
-    NotificationService.showSuccess('Transaction deleted successfully');
+    // Notification handled at service level
   }
 
   private formatData(

--- a/src/repositories/incomeExpenseTransactionMapping.repository.ts
+++ b/src/repositories/incomeExpenseTransactionMapping.repository.ts
@@ -31,7 +31,7 @@ export class IncomeExpenseTransactionMappingRepository
   protected override async afterCreate(
     data: IncomeExpenseTransactionMapping
   ): Promise<void> {
-    NotificationService.showSuccess('Mapping created successfully');
+    // Notification handled at service level
   }
 
   protected override async beforeUpdate(
@@ -45,11 +45,11 @@ export class IncomeExpenseTransactionMappingRepository
   protected override async afterUpdate(
     data: IncomeExpenseTransactionMapping
   ): Promise<void> {
-    NotificationService.showSuccess('Mapping updated successfully');
+    // Notification handled at service level
   }
 
   protected override async afterDelete(id: string): Promise<void> {
-    NotificationService.showSuccess('Mapping deleted successfully');
+    // Notification handled at service level
   }
 
   public async getByTransactionId(


### PR DESCRIPTION
## Summary
- remove NotificationService calls from transaction repositories so the Add/Edit page only shows a single success toast

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68695567d2248326bc71d87d55cab969