### PR TITLE
Add line field to income_expense_transactions

### DIFF
--- a/src/adapters/incomeExpenseTransaction.adapter.ts
+++ b/src/adapters/incomeExpenseTransaction.adapter.ts
@@ -21,6 +21,7 @@ export class IncomeExpenseTransactionAdapter
     id,
     transaction_type,
     transaction_date,
+    line,
     amount,
     description,
     reference,
@@ -46,7 +47,8 @@ export class IncomeExpenseTransactionAdapter
 
   public async getByHeaderId(headerId: string): Promise<IncomeExpenseTransaction[]> {
     const result = await this.fetch({
-      filters: { header_id: { operator: 'eq', value: headerId } }
+      filters: { header_id: { operator: 'eq', value: headerId } },
+      order: { column: 'line', ascending: true }
     });
     return result.data;
   }

--- a/src/models/incomeExpenseTransaction.model.ts
+++ b/src/models/incomeExpenseTransaction.model.ts
@@ -29,4 +29,5 @@ export interface IncomeExpenseTransaction extends BaseModel {
   account?: Account;
   header_id: string | null;
   header?: FinancialTransactionHeader;
+  line: number | null;
 }

--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -29,6 +29,7 @@ interface Entry {
   amount: number;
   source_account_id: string | null;
   category_account_id: string | null;
+  line?: number;
   isDirty?: boolean;
   isDeleted?: boolean;
 }
@@ -108,6 +109,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
       amount: 0,
       source_account_id: null,
       category_account_id: null,
+      line: 1,
       isDirty: true,
       isDeleted: false,
     },
@@ -143,6 +145,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
           amount: e.amount || 0,
           source_account_id: e.source_account_id || null,
           category_account_id: e.category_account_id || null,
+          line: e.line ?? undefined,
           isDirty: false,
           isDeleted: false,
         }))
@@ -211,6 +214,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
         amount: 0,
         source_account_id: null,
         category_account_id: null,
+        line: entries.length + 1,
         isDirty: true,
         isDeleted: false,
       },

--- a/src/services/IncomeExpenseTransactionService.ts
+++ b/src/services/IncomeExpenseTransactionService.ts
@@ -20,6 +20,7 @@ export interface IncomeExpenseEntry {
   category_account_id: string | null;
   batch_id?: string | null;
   member_id?: string | null;
+  line?: number | null;
   isDirty?: boolean;
   isDeleted?: boolean;
 }
@@ -114,6 +115,7 @@ export class IncomeExpenseTransactionService {
       source_id: line.source_id,
       account_id: line.accounts_account_id,
       header_id: headerId,
+      line: line.line ?? null,
     };
   }
 

--- a/src/validators/incomeExpenseTransaction.validator.ts
+++ b/src/validators/incomeExpenseTransaction.validator.ts
@@ -14,5 +14,12 @@ export class IncomeExpenseTransactionValidator {
     ) {
       throw new Error('Amount must be a valid number');
     }
+
+    if (
+      data.line !== undefined &&
+      (isNaN(Number(data.line)) || data.line === null)
+    ) {
+      throw new Error('Line must be a valid number');
+    }
   }
 }

--- a/supabase/migrations/20250729000000_add_line_to_income_expense_transactions.sql
+++ b/supabase/migrations/20250729000000_add_line_to_income_expense_transactions.sql
@@ -1,0 +1,14 @@
+-- Add optional line column to income_expense_transactions
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'income_expense_transactions'
+      AND column_name = 'line'
+  ) THEN
+    ALTER TABLE income_expense_transactions
+      ADD COLUMN line integer;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN income_expense_transactions.line IS 'Detail transaction line number';

--- a/tests/incomeExpenseTransactionRepositoryValidation.test.ts
+++ b/tests/incomeExpenseTransactionRepositoryValidation.test.ts
@@ -29,6 +29,18 @@ describe('IncomeExpenseTransactionRepository validation', () => {
     ).rejects.toThrow('Amount must be a valid number');
   });
 
+  it('throws error for invalid line', async () => {
+    const repo = new TestRepo({} as IIncomeExpenseTransactionAdapter);
+    await expect(
+      repo.runBeforeCreate({
+        transaction_date: '2024-01-01',
+        description: 't',
+        amount: 1,
+        line: 'abc' as any,
+      })
+    ).rejects.toThrow('Line must be a valid number');
+  });
+
   it('formats data on create', async () => {
     const repo = new TestRepo({} as IIncomeExpenseTransactionAdapter);
     const data = await repo.runBeforeCreate({


### PR DESCRIPTION
## Summary
- add SQL migration for `line` column on income_expense_transactions
- support line property in IncomeExpenseTransaction model and service
- order transactions by line in adapter
- validate line on repository
- support line field in donation edit UI and tests

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695722f39883269848e6c47d357c3f