### PR TITLE
Fix account editing error due to members field

### DIFF
--- a/src/pages/accounts/account/AccountAddEdit.tsx
+++ b/src/pages/accounts/account/AccountAddEdit.tsx
@@ -120,7 +120,8 @@ function AccountAddEdit() {
       if (isEditMode) {
         await updateMutation.mutateAsync({
           id: id!,
-          data: formData
+          data: formData,
+          fieldsToRemove: ['members']
         });
         navigate(`/accounts/${id}`);
       } else {


### PR DESCRIPTION
## Summary
- remove the `members` relationship field before updating an account

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a16e716e88326809c16508cff7597