### PR TITLE
refetch options on combobox open

### DIFF
--- a/src/components/ui2/combobox.tsx
+++ b/src/components/ui2/combobox.tsx
@@ -30,6 +30,7 @@ interface ComboboxProps {
   disabled?: boolean;
   onKeyDown?: (e: React.KeyboardEvent) => void;
   onSearchChange?: (value: string) => void;
+  onOpen?: () => void;
 }
 
 export function Combobox({
@@ -42,6 +43,7 @@ export function Combobox({
   disabled = false,
   onKeyDown,
   onSearchChange,
+  onOpen,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
@@ -71,8 +73,15 @@ export function Combobox({
     }
   }, [open, filteredOptions, handleSelect, onKeyDown]);
 
+  const handleOpenChange = React.useCallback((o: boolean) => {
+    setOpen(o);
+    if (o) {
+      onOpen?.();
+    }
+  }, [onOpen]);
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"

--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -57,12 +57,28 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
   const { useQuery: useCategoriesQuery } = useCategoryRepository();
   const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
 
-  const { data: accountsData, isLoading: accountsLoading } = useAccountsQuery();
-  const { data: fundsData, isLoading: fundsLoading } = useFundsQuery();
-  const { data: categoriesData, isLoading: categoriesLoading } = useCategoriesQuery({
+  const {
+    data: accountsData,
+    isLoading: accountsLoading,
+    refetch: refetchAccounts,
+  } = useAccountsQuery();
+  const {
+    data: fundsData,
+    isLoading: fundsLoading,
+    refetch: refetchFunds,
+  } = useFundsQuery();
+  const {
+    data: categoriesData,
+    isLoading: categoriesLoading,
+    refetch: refetchCategories,
+  } = useCategoriesQuery({
     filters: { type: { operator: 'eq', value: transactionType === 'income' ? 'income_transaction' : 'expense_transaction' } },
   });
-  const { data: sourcesData, isLoading: sourcesLoading } = useSourcesQuery({
+  const {
+    data: sourcesData,
+    isLoading: sourcesLoading,
+    refetch: refetchSources,
+  } = useSourcesQuery({
     filters: { is_active: { operator: 'eq', value: true } },
   });
 
@@ -326,6 +342,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                         onChange={v => handleEntryChange(idx, 'accounts_account_id', v)}
                         disabled={isDisabled}
                         placeholder="Select account"
+                        onOpen={refetchAccounts}
                       />
                     </td>
                     <td className="px-4 py-2">
@@ -335,6 +352,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                         onChange={v => handleEntryChange(idx, 'fund_id', v)}
                         disabled={isDisabled}
                         placeholder="Select fund"
+                        onOpen={refetchFunds}
                       />
                     </td>
                     <td className="px-4 py-2">
@@ -344,6 +362,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                         onChange={v => handleEntryChange(idx, 'category_id', v)}
                         disabled={isDisabled}
                         placeholder="Select category"
+                        onOpen={refetchCategories}
                       />
                     </td>
                     <td className="px-4 py-2">
@@ -353,6 +372,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                         onChange={v => handleEntryChange(idx, 'source_id', v)}
                         disabled={isDisabled}
                         placeholder="Select source"
+                        onOpen={refetchSources}
                       />
                     </td>
                     <td className="px-4 py-2 min-w-[200px]">


### PR DESCRIPTION
## Summary
- allow Combobox to notify when opened
- refetch account, fund, category and source options in IncomeExpenseAddEdit when opening the select boxes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a175e5e20832698d17c6c81449d95