### PR TITLE
Add progress feedback for transaction batch saves

### DIFF
--- a/src/components/ui2/progress-dialog.tsx
+++ b/src/components/ui2/progress-dialog.tsx
@@ -3,11 +3,13 @@ import { Dialog, DialogHeader, DialogTitle, DialogOverlay } from './dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { cn } from '@/lib/utils';
 import { Loader2 } from 'lucide-react';
+import { Progress } from './progress';
 
 interface ProgressDialogProps {
   open: boolean;
   title?: string;
   message?: string;
+  progress?: number;
 }
 
 const ProgressDialogContent = React.forwardRef<
@@ -32,7 +34,7 @@ const ProgressDialogContent = React.forwardRef<
 ));
 ProgressDialogContent.displayName = 'ProgressDialogContent';
 
-export function ProgressDialog({ open, title = 'Processing', message }: ProgressDialogProps) {
+export function ProgressDialog({ open, title = 'Processing', message, progress }: ProgressDialogProps) {
   return (
     <Dialog open={open}>
       <ProgressDialogContent className="flex flex-col items-center space-y-4">
@@ -41,7 +43,11 @@ export function ProgressDialog({ open, title = 'Processing', message }: Progress
             <DialogTitle>{title}</DialogTitle>
           </DialogHeader>
         )}
-        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        {typeof progress === 'number' ? (
+          <Progress value={progress} showValue className="w-full" />
+        ) : (
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        )}
         {message && <p className="text-sm text-muted-foreground text-center">{message}</p>}
       </ProgressDialogContent>
     </Dialog>

--- a/src/hooks/useIncomeExpenseService.ts
+++ b/src/hooks/useIncomeExpenseService.ts
@@ -17,8 +17,8 @@ export function useIncomeExpenseService(transactionType: TransactionType) {
   const queryClient = useQueryClient();
 
   const createMutation = useMutation({
-    mutationFn: ({ header, entries }: { header: Partial<FinancialTransactionHeader>; entries: IncomeExpenseEntryBase[] }) =>
-      service.create(header, entries.map(e => ({ ...e, transaction_type: transactionType }))),
+    mutationFn: ({ header, entries, onProgress }: { header: Partial<FinancialTransactionHeader>; entries: IncomeExpenseEntryBase[]; onProgress?: (p: number) => void }) =>
+      service.create(header, entries.map(e => ({ ...e, transaction_type: transactionType })), onProgress),
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['financial_transaction_headers'] });
         queryClient.invalidateQueries({ queryKey: ['income_expense_transactions'] });
@@ -30,8 +30,8 @@ export function useIncomeExpenseService(transactionType: TransactionType) {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, header, entries }: { id: string; header: Partial<FinancialTransactionHeader>; entries: IncomeExpenseEntryBase[] }) =>
-      service.updateBatch(id, header, entries.map(e => ({ ...e, transaction_type: transactionType }))),
+    mutationFn: ({ id, header, entries, onProgress }: { id: string; header: Partial<FinancialTransactionHeader>; entries: IncomeExpenseEntryBase[]; onProgress?: (p: number) => void }) =>
+      service.updateBatch(id, header, entries.map(e => ({ ...e, transaction_type: transactionType })), onProgress),
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['financial_transaction_headers'] });
         queryClient.invalidateQueries({ queryKey: ['income_expense_transactions'] });
@@ -69,13 +69,15 @@ export function useIncomeExpenseService(transactionType: TransactionType) {
   const createBatch = async (
     header: Partial<FinancialTransactionHeader>,
     entries: IncomeExpenseEntryBase[],
-  ) => createMutation.mutateAsync({ header, entries });
+    onProgress?: (p: number) => void,
+  ) => createMutation.mutateAsync({ header, entries, onProgress });
 
   const updateBatch = async (
     id: string,
     header: Partial<FinancialTransactionHeader>,
     entries: IncomeExpenseEntryBase[],
-  ) => updateMutation.mutateAsync({ id, header, entries });
+    onProgress?: (p: number) => void,
+  ) => updateMutation.mutateAsync({ id, header, entries, onProgress });
 
   const deleteTransaction = async (id: string) => deleteMutation.mutateAsync(id);
 

--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -116,6 +116,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
   ]);
 
   const [processing, setProcessing] = useState(false);
+  const [progress, setProgress] = useState<number | undefined>(undefined);
 
   const header = headerResponse?.data?.[0];
   const entryRecords = entryResponse?.data || [];
@@ -237,15 +238,18 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setProcessing(true);
+    setProgress(0);
     try {
       if (isEditMode && id) {
-        await updateBatch(id, headerData, entries);
+        await updateBatch(id, headerData, entries, p => setProgress(p));
       } else {
-        await createBatch(headerData, entries);
+        await createBatch(headerData, entries, p => setProgress(p));
       }
+      setProgress(undefined);
       navigate(`/finances/${basePath}`);
     } catch (error) {
       setProcessing(false);
+      setProgress(undefined);
     }
   };
 
@@ -417,7 +421,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
           </CardFooter>
         </Card>
       </form>
-      <ProgressDialog open={processing} message="Saving transaction..." />
+      <ProgressDialog open={processing} message="Saving transaction..." progress={progress} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show progress bar in ProgressDialog when available
- expose progress callbacks from IncomeExpenseTransactionService
- wire progress callbacks through useIncomeExpenseService
- display save progress on the Income/Expense form

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a189aac4c8326a1a0f1824aef9b4b