### PR TITLE
Add dynamic menu flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,5 @@ PGRST_APP_SETTINGS_SERVICE_ROLE_KEY=
 # -- Email service (Resend) configuration --
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
+# Enable database-driven menu (defaults to true)
+VITE_ENABLE_DYNAMIC_MENU=true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ supabase db reset
    RESEND_FROM_EMAIL=<default from address>
    ```
 
+6. By default the sidebar menu items are loaded from the database. Set
+   `VITE_ENABLE_DYNAMIC_MENU=false` in your `.env` file to use the static
+   menu defined in the source code.
+
 ## Running tests
 
 This project uses [Vitest](https://vitest.dev) for unit testing. After installing

--- a/src/hooks/useMenuItems.ts
+++ b/src/hooks/useMenuItems.ts
@@ -4,6 +4,8 @@ import { navigation as staticNavigation, NavItem } from '../config/navigation';
 import * as Icons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
+const enableDynamicMenu = import.meta.env.VITE_ENABLE_DYNAMIC_MENU !== 'false';
+
 function getIcon(name: string | null): LucideIcon {
   const icon = (Icons as Record<string, LucideIcon>)[name ?? ''];
   return icon || Icons.Circle;
@@ -15,6 +17,9 @@ export function useMenuItems(roleIds: string[]) {
   return useQuery({
     queryKey: ['menu-items', rolesKey],
     queryFn: async () => {
+      if (!enableDynamicMenu) {
+        return staticNavigation;
+      }
       const { data: tenantData, error: tenantError } = await supabase.rpc('get_current_tenant');
       if (tenantError) throw tenantError;
       const tenant = tenantData?.[0];


### PR DESCRIPTION
## Summary
- add `VITE_ENABLE_DYNAMIC_MENU` to `.env.example`
- read the new flag in `useMenuItems`
- document the flag in the README

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9be4ec588326ba275afcf95af11a