### PR TITLE
Add menu permissions page

### DIFF
--- a/src/adapters/menuPermission.adapter.ts
+++ b/src/adapters/menuPermission.adapter.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata';
+import { injectable, inject } from 'inversify';
+import { BaseAdapter } from './base.adapter';
+import { MenuPermission } from '../models/menuPermission.model';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/types';
+
+export interface IMenuPermissionAdapter extends BaseAdapter<MenuPermission> {}
+
+@injectable()
+export class MenuPermissionAdapter
+  extends BaseAdapter<MenuPermission>
+  implements IMenuPermissionAdapter
+{
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
+    super();
+  }
+
+  protected tableName = 'menu_permissions';
+
+  protected defaultSelect = `
+    id,
+    menu_item_id,
+    permission_id,
+    created_by,
+    updated_by,
+    created_at,
+    updated_at
+  `;
+
+  protected override async onAfterCreate(data: MenuPermission): Promise<void> {
+    await this.auditService.logAuditEvent('create', 'menu_permission', data.id, data);
+  }
+
+  protected override async onAfterUpdate(data: MenuPermission): Promise<void> {
+    await this.auditService.logAuditEvent('update', 'menu_permission', data.id, data);
+  }
+
+  protected override async onAfterDelete(id: string): Promise<void> {
+    await this.auditService.logAuditEvent('delete', 'menu_permission', id, { id });
+  }
+}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -10,6 +10,7 @@ import {
   Bell,
   LifeBuoy,
   Shield,
+  ListChecks,
   LucideIcon,
 } from 'lucide-react';
 
@@ -99,6 +100,13 @@ export const navigation: NavItem[] = [
     href: '/administration',
     icon: Shield,
     permission: 'user.view',
+    section: 'Administration',
+  },
+  {
+    name: 'Menu Permissions',
+    href: '/administration/menu-permissions',
+    icon: ListChecks,
+    permission: 'role.edit',
     section: 'Administration',
   },
 ];

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -35,3 +35,4 @@ export * from './useSettingService';
 export * from './useAuthorization';
 export * from './useMenuItemRepository';
 export * from './useMenuItems';
+export * from './useMenuPermissionRepository';

--- a/src/hooks/useMenuPermissionRepository.ts
+++ b/src/hooks/useMenuPermissionRepository.ts
@@ -1,0 +1,9 @@
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { IMenuPermissionRepository } from '../repositories/menuPermission.repository';
+import { useBaseRepository } from './useBaseRepository';
+
+export function useMenuPermissionRepository() {
+  const repository = container.get<IMenuPermissionRepository>(TYPES.IMenuPermissionRepository);
+  return useBaseRepository(repository, 'Menu Permission', 'menu-permissions');
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -52,6 +52,7 @@ import {
 import { RoleAdapter, type IRoleAdapter } from '../adapters/role.adapter';
 import { PermissionAdapter, type IPermissionAdapter } from '../adapters/permission.adapter';
 import { MenuItemAdapter, type IMenuItemAdapter } from '../adapters/menuItem.adapter';
+import { MenuPermissionAdapter, type IMenuPermissionAdapter } from '../adapters/menuPermission.adapter';
 import { AuthUserAdapter, type IAuthUserAdapter } from '../adapters/authUser.adapter';
 import { ErrorLogAdapter, type IErrorLogAdapter } from '../adapters/errorLog.adapter';
 import { ActivityLogAdapter, type IActivityLogAdapter } from '../adapters/activityLog.adapter';
@@ -114,6 +115,7 @@ import {
 import { RoleRepository, type IRoleRepository } from '../repositories/role.repository';
 import { PermissionRepository, type IPermissionRepository } from '../repositories/permission.repository';
 import { MenuItemRepository, type IMenuItemRepository } from '../repositories/menuItem.repository';
+import { MenuPermissionRepository, type IMenuPermissionRepository } from '../repositories/menuPermission.repository';
 import { UserRepository, type IUserRepository } from '../repositories/user.repository';
 import { ErrorLogRepository, type IErrorLogRepository } from '../repositories/errorLog.repository';
 import { ActivityLogRepository, type IActivityLogRepository } from '../repositories/activityLog.repository';
@@ -211,6 +213,10 @@ container
 container
   .bind<IMenuItemAdapter>(TYPES.IMenuItemAdapter)
   .to(MenuItemAdapter)
+  .inSingletonScope();
+container
+  .bind<IMenuPermissionAdapter>(TYPES.IMenuPermissionAdapter)
+  .to(MenuPermissionAdapter)
   .inSingletonScope();
 container
   .bind<IOfferingBatchAdapter>(TYPES.IOfferingBatchAdapter)
@@ -341,6 +347,10 @@ container
 container
   .bind<IMenuItemRepository>(TYPES.IMenuItemRepository)
   .to(MenuItemRepository)
+  .inSingletonScope();
+container
+  .bind<IMenuPermissionRepository>(TYPES.IMenuPermissionRepository)
+  .to(MenuPermissionRepository)
   .inSingletonScope();
 container
   .bind<IFinancialTransactionRepository>(TYPES.IFinancialTransactionRepository)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,8 @@ export const TYPES = {
   IRoleRepository: 'IRoleRepository',
   IPermissionRepository: 'IPermissionRepository',
   IMenuItemRepository: 'IMenuItemRepository',
+  IMenuPermissionAdapter: 'IMenuPermissionAdapter',
+  IMenuPermissionRepository: 'IMenuPermissionRepository',
   IUserRepository: 'IUserRepository',
   IErrorLogRepository: 'IErrorLogRepository',
   IActivityLogRepository: 'IActivityLogRepository',

--- a/src/models/menuPermission.model.ts
+++ b/src/models/menuPermission.model.ts
@@ -1,0 +1,7 @@
+import { BaseModel } from './base.model';
+
+export interface MenuPermission extends BaseModel {
+  id: string;
+  menu_item_id: string;
+  permission_id: string;
+}

--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -7,6 +7,7 @@ import Roles from './roles/Roles';
 import Announcements from './announcements/Announcements';
 import ChurchSettings from './account-management/ChurchSettings';
 import Permissions from './configuration/Permissions';
+import MenuPermissions from './MenuPermissions';
 
 function Administration() {
   return (
@@ -14,6 +15,7 @@ function Administration() {
       <Route path="users/*" element={<Users />} />
       <Route path="roles/*" element={<Roles />} />
       <Route path="announcements/*" element={<Announcements />} />
+      <Route path="menu-permissions" element={<MenuPermissions />} />
       <Route path="configuration/permissions/*" element={<Permissions />} />
       <Route path="account-management/church" element={<ChurchSettings />} />
       <Route path="*" element={<Navigate to="users" replace />} />

--- a/src/pages/admin/MenuPermissions.tsx
+++ b/src/pages/admin/MenuPermissions.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../../lib/supabase';
+import { useMenuPermissionRepository } from '../../hooks/useMenuPermissionRepository';
+import { useMenuItemRepository } from '../../hooks/useMenuItemRepository';
+import { Card, CardContent } from '../../components/ui2/card';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '../../components/ui2/select';
+import { Checkbox } from '../../components/ui2/checkbox';
+import { Button } from '../../components/ui2/button';
+import { Loader2, ListChecks } from 'lucide-react';
+
+interface Role {
+  id: string;
+  name: string;
+}
+
+interface MenuItem {
+  id: string;
+  code: string;
+  label: string;
+  is_system: boolean;
+}
+
+function MenuPermissions() {
+  const [roleId, setRoleId] = useState<string>('');
+  const { useQuery: useMenuPermQuery, useCreate, useDelete } = useMenuPermissionRepository();
+  const { useQuery: useMenuItemsQuery } = useMenuItemRepository();
+
+  const { data: roles } = useQuery({
+    queryKey: ['roles'],
+    queryFn: async () => {
+      const { data, error } = await supabase.from('roles').select('id,name').order('name');
+      if (error) throw error;
+      return data as Role[];
+    },
+  });
+
+  const { data: itemsRes } = useMenuItemsQuery({ order: { column: 'sort_order' } });
+  const menuItems = (itemsRes?.data as MenuItem[]) || [];
+
+  const { data: featureRows } = useQuery({
+    queryKey: ['license-features'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('license_features')
+        .select('feature,licenses(status,expires_at)');
+      if (error) throw error;
+      return data || [];
+    },
+  });
+
+  const activeFeatures = React.useMemo(() => {
+    if (!featureRows) return [] as string[];
+    const today = new Date().toISOString().slice(0, 10);
+    return featureRows
+      .filter(
+        (f: any) =>
+          f.licenses?.status === 'active' && (!f.licenses.expires_at || f.licenses.expires_at >= today)
+      )
+      .map((f: any) => f.feature);
+  }, [featureRows]);
+
+  const { data: permsRes } = useMenuPermQuery({
+    filters: roleId ? { permission_id: { operator: 'eq', value: roleId } } : {},
+    enabled: !!roleId,
+  });
+  const current = (permsRes?.data as any[]) || [];
+
+  const createMutation = useCreate();
+  const deleteMutation = useDelete();
+
+  const toggle = async (item: MenuItem) => {
+    if (!roleId) return;
+    const existing = current.find(p => p.menu_item_id === item.id);
+    if (existing) {
+      await deleteMutation.mutateAsync(existing.id);
+    } else {
+      await createMutation.mutateAsync({ data: { menu_item_id: item.id, permission_id: roleId } });
+    }
+  };
+
+  return (
+    <div className="w-full px-4 sm:px-6 lg:px-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <ListChecks className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Menu Permissions</h1>
+      </div>
+      <div className="max-w-xs">
+        <Select value={roleId} onValueChange={setRoleId}>
+          <SelectTrigger label="Role">
+            <SelectValue placeholder="Select role" />
+          </SelectTrigger>
+          <SelectContent>
+            {roles?.map(r => (
+              <SelectItem key={r.id} value={r.id} className="capitalize">
+                {r.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {roleId && (
+        <Card>
+          <CardContent className="space-y-2 py-4">
+            {menuItems.length === 0 && (
+              <div className="flex justify-center py-6">
+                <Loader2 className="h-6 w-6 animate-spin" />
+              </div>
+            )}
+            {menuItems.map(item => (
+              <div key={item.id} className="flex items-center gap-3">
+                <Checkbox
+                  id={item.id}
+                  checked={!!current.find(p => p.menu_item_id === item.id)}
+                  onCheckedChange={() => toggle(item)}
+                  disabled={!item.is_system && !activeFeatures.includes(item.code)}
+                />
+                <label htmlFor={item.id} className="capitalize">
+                  {item.label}
+                </label>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default MenuPermissions;

--- a/src/repositories/menuPermission.repository.ts
+++ b/src/repositories/menuPermission.repository.ts
@@ -1,0 +1,17 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { MenuPermission } from '../models/menuPermission.model';
+import type { IMenuPermissionAdapter } from '../adapters/menuPermission.adapter';
+import { TYPES } from '../lib/types';
+
+export interface IMenuPermissionRepository extends BaseRepository<MenuPermission> {}
+
+@injectable()
+export class MenuPermissionRepository
+  extends BaseRepository<MenuPermission>
+  implements IMenuPermissionRepository
+{
+  constructor(@inject(TYPES.IMenuPermissionAdapter) adapter: IMenuPermissionAdapter) {
+    super(adapter);
+  }
+}


### PR DESCRIPTION
## Summary
- add menu permission model, adapter, repository and hook
- create `MenuPermissions` admin page
- register bindings in container and export hook
- link page in admin routes and sidebar navigation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a9d6298508326901fb48b9d1c9118