### PR TITLE
Add license-aware access checks

### DIFF
--- a/src/components/PermissionGate.tsx
+++ b/src/components/PermissionGate.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { usePermissions } from '../hooks/usePermissions';
+import { hasAccess } from '../utils/access';
 
 type PermissionGateProps = {
   permission?: string;
@@ -9,17 +10,17 @@ type PermissionGateProps = {
 };
 
 function PermissionGate({ permission, role, children, fallback = null }: PermissionGateProps) {
-  const { hasPermission, hasRole, isLoading } = usePermissions();
+  const { hasRole, isLoading } = usePermissions();
 
   if (isLoading) {
     return null;
   }
 
-  const hasAccess = 
-    (permission ? hasPermission(permission) : true) &&
+  const allowed =
+    (permission ? hasAccess(permission, permission) : true) &&
     (role ? hasRole(role) : true);
 
-  return hasAccess ? <>{children}</> : <>{fallback}</>;
+  return allowed ? <>{children}</> : <>{fallback}</>;
 }
 
 export default PermissionGate;

--- a/src/components/finances/DonationActions.tsx
+++ b/src/components/finances/DonationActions.tsx
@@ -20,6 +20,7 @@ import { Button } from '../ui2/button';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
 import { usePermissions } from '../../hooks/usePermissions';
+import { hasAccess } from '../../utils/access';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import type { TransactionItem as DonationItem } from './RecentTransactionItem';
@@ -51,7 +52,6 @@ export default function DonationActions({ donation }: DonationActionsProps) {
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
   const { deleteTransaction } = useIncomeExpenseService('income');
-  const { hasPermission } = usePermissions();
 
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
   const [showSubmitDialog, setShowSubmitDialog] = React.useState(false);
@@ -189,17 +189,17 @@ export default function DonationActions({ donation }: DonationActionsProps) {
                 <FileText className="h-4 w-4 mr-2" /> Submit
               </DropdownMenuItem>
             )}
-            {donation.header?.status === 'submitted' && hasPermission('finance.approve') && (
+            {donation.header?.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={() => setShowApproveDialog(true)} className="flex items-center">
                 <Check className="h-4 w-4 mr-2" /> Approve
               </DropdownMenuItem>
             )}
-            {donation.header?.status === 'submitted' && hasPermission('finance.approve') && (
+            {donation.header?.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={handleReject} className="flex items-center">
                 <X className="h-4 w-4 mr-2" /> Reject
               </DropdownMenuItem>
             )}
-            {donation.header?.status === 'approved' && hasPermission('finance.approve') && (
+            {donation.header?.status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={() => setShowPostDialog(true)} className="flex items-center">
                 <Check className="h-4 w-4 mr-2" /> Post
               </DropdownMenuItem>

--- a/src/components/finances/ExpenseActions.tsx
+++ b/src/components/finances/ExpenseActions.tsx
@@ -20,6 +20,7 @@ import { Button } from '../ui2/button';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
 import { usePermissions } from '../../hooks/usePermissions';
+import { hasAccess } from '../../utils/access';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import type { ExpenseItem } from './RecentExpenseItem';
@@ -51,7 +52,6 @@ export default function ExpenseActions({ expense }: ExpenseActionsProps) {
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
   const { deleteTransaction } = useIncomeExpenseService('expense');
-  const { hasPermission } = usePermissions();
 
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
   const [showSubmitDialog, setShowSubmitDialog] = React.useState(false);
@@ -189,17 +189,17 @@ export default function ExpenseActions({ expense }: ExpenseActionsProps) {
                 <FileText className="h-4 w-4 mr-2" /> Submit
               </DropdownMenuItem>
             )}
-            {expense.header?.status === 'submitted' && hasPermission('finance.approve') && (
+            {expense.header?.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={() => setShowApproveDialog(true)} className="flex items-center">
                 <Check className="h-4 w-4 mr-2" /> Approve
               </DropdownMenuItem>
             )}
-            {expense.header?.status === 'submitted' && hasPermission('finance.approve') && (
+            {expense.header?.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={handleReject} className="flex items-center">
                 <X className="h-4 w-4 mr-2" /> Reject
               </DropdownMenuItem>
             )}
-            {expense.header?.status === 'approved' && hasPermission('finance.approve') && (
+            {expense.header?.status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
               <DropdownMenuItem onClick={() => setShowPostDialog(true)} className="flex items-center">
                 <Check className="h-4 w-4 mr-2" /> Post
               </DropdownMenuItem>

--- a/src/components/finances/RecentFinancialTransactionItem.tsx
+++ b/src/components/finances/RecentFinancialTransactionItem.tsx
@@ -16,7 +16,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
-import { usePermissions } from '../../hooks/usePermissions';
+import { hasAccess } from '../../utils/access';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -52,7 +52,6 @@ export default function RecentTransactionItem({ transaction }: Props) {
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
   const deleteMutation = useDelete();
-  const { hasPermission } = usePermissions();
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
   const [showSubmitDialog, setShowSubmitDialog] = React.useState(false);
   const [showApproveDialog, setShowApproveDialog] = React.useState(false);
@@ -166,7 +165,7 @@ export default function RecentTransactionItem({ transaction }: Props) {
                   <FileText className="h-4 w-4 mr-2" /> Submit Transaction
                 </DropdownMenuItem>
               )}
-              {transaction.status === 'submitted' && hasPermission('finance.approve') && (
+              {transaction.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                 <DropdownMenuItem
                   onClick={() => setShowApproveDialog(true)}
                   className="flex items-center"
@@ -174,12 +173,12 @@ export default function RecentTransactionItem({ transaction }: Props) {
                   <Check className="h-4 w-4 mr-2" /> Approve Transaction
                 </DropdownMenuItem>
               )}
-              {transaction.status === 'submitted' && hasPermission('finance.approve') && (
+              {transaction.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                 <DropdownMenuItem onClick={async () => { await updateMutation.mutateAsync({ id: transaction.id, data: { status: 'draft' } }); }} className="flex items-center">
                   <X className="h-4 w-4 mr-2" /> Reject to Draft
                 </DropdownMenuItem>
               )}
-              {transaction.status === 'approved' && hasPermission('finance.approve') && (
+              {transaction.status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
                 <DropdownMenuItem
                   onClick={() => setShowPostDialog(true)}
                   className="flex items-center"

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
 import { useIncomeExpenseService } from '../../../hooks/useIncomeExpenseService';
-import { usePermissions } from '../../../hooks/usePermissions';
+import { hasAccess } from '../../../utils/access';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { Input } from '../../../components/ui2/input';
@@ -65,7 +65,6 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
     useUpdate,
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
-  const { hasPermission } = usePermissions();
   const { deleteBatch } = useIncomeExpenseService(transactionType);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -300,7 +299,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'submitted' && hasPermission('finance.approve') && (
+                {status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={() => {
                       setSelectedTransaction(params.row);
@@ -312,7 +311,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'submitted' && hasPermission('finance.approve') && (
+                {status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={async () => {
                       await updateMutation.mutateAsync({ id: params.row.id, data: { status: 'draft' } });
@@ -324,7 +323,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'approved' && hasPermission('finance.approve') && (
+                {status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={() => {
                       setSelectedTransaction(params.row);

--- a/src/pages/finances/transactions/TransactionDetail.tsx
+++ b/src/pages/finances/transactions/TransactionDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
-import { usePermissions } from '../../../hooks/usePermissions';
+import { hasAccess } from '../../../utils/access';
 import PermissionGate from '../../../components/PermissionGate';
 import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -63,7 +63,6 @@ function TransactionDetail() {
     voidTransaction
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
-  const { hasPermission } = usePermissions();
   
   const { data: headerData, isLoading: isHeaderLoading } = useQuery({
     filters: {
@@ -402,7 +401,7 @@ function TransactionDetail() {
                 </>
               )}
 
-              {header.status === 'submitted' && hasPermission('finance.approve') && (
+              {header.status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                 <>
                   <Button
                     variant="outline"
@@ -423,7 +422,7 @@ function TransactionDetail() {
                 </>
               )}
 
-              {header.status === 'approved' && hasPermission('finance.approve') && (
+              {header.status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
                 <Button
                   variant="outline"
                   onClick={() => setShowPostDialog(true)}

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
-import { usePermissions } from '../../../hooks/usePermissions';
+import { hasAccess } from '../../../utils/access';
 import PermissionGate from '../../../components/PermissionGate';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -98,7 +98,6 @@ function TransactionList() {
     useUpdate,
   } = useFinancialTransactionHeaderRepository();
   const updateMutation = useUpdate();
-  const { hasPermission } = usePermissions();
   
   const { data: result, isLoading, error } = useQuery({
     filters: {
@@ -414,7 +413,7 @@ function TransactionList() {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'submitted' && hasPermission('finance.approve') && (
+                {status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={() => {
                       setSelectedTransaction(params.row);
@@ -427,7 +426,7 @@ function TransactionList() {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'submitted' && hasPermission('finance.approve') && (
+                {status === 'submitted' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={async () => {
                       await updateMutation.mutateAsync({ id: params.row.id, data: { status: 'draft' } });
@@ -440,7 +439,7 @@ function TransactionList() {
                   </DropdownMenuItem>
                 )}
 
-                {status === 'approved' && hasPermission('finance.approve') && (
+                {status === 'approved' && hasAccess('finance.approve', 'finance.approve') && (
                   <DropdownMenuItem
                     onClick={() => {
                       setSelectedTransaction(params.row);

--- a/src/utils/access.ts
+++ b/src/utils/access.ts
@@ -1,0 +1,12 @@
+import { usePermissions } from '../hooks/usePermissions';
+import { useFeatures } from '../hooks/useFeatures';
+
+export function hasAccess(permissionKey: string, featureKey: string): boolean {
+  const { hasPermission } = usePermissions();
+  const { isEnabled } = useFeatures();
+
+  const permissionAllowed = permissionKey ? hasPermission(permissionKey) : true;
+  const featureAllowed = featureKey ? isEnabled(featureKey) : true;
+
+  return permissionAllowed && featureAllowed;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,3 +21,4 @@ export * from './memberOfferingSummaryPdf';
 export * from './expenseSummaryPdf';
 export * from './churchFinancialStatementPdf';
 export * from './memberUtils';
+export * from './access';


### PR DESCRIPTION
## Summary
- implement `hasAccess` utility
- integrate `hasAccess` with `PermissionGate`
- use `hasAccess` in finance action components
- export new helper via utils index

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aeb14f8948326b20563aa551775e9