### PR TITLE
Add tests for access hook and utility

### DIFF
--- a/tests/hasAccess.test.ts
+++ b/tests/hasAccess.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { hasAccess } from '../src/utils/access';
+
+const permMock = vi.fn();
+const featureMock = vi.fn();
+
+vi.mock('../src/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasPermission: permMock })
+}));
+
+vi.mock('../src/hooks/useFeatures', () => ({
+  useFeatures: () => ({ isEnabled: featureMock })
+}));
+
+beforeEach(() => {
+  permMock.mockReset();
+  featureMock.mockReset();
+});
+
+describe('hasAccess', () => {
+  it('returns true when permission and feature allowed', () => {
+    permMock.mockReturnValue(true);
+    featureMock.mockReturnValue(true);
+    expect(hasAccess('perm.ok', 'feat.ok')).toBe(true);
+  });
+
+  it('returns false when permission missing', () => {
+    permMock.mockReturnValue(false);
+    featureMock.mockReturnValue(true);
+    expect(hasAccess('perm.no', 'feat.ok')).toBe(false);
+  });
+
+  it('returns false when feature disabled', () => {
+    permMock.mockReturnValue(true);
+    featureMock.mockReturnValue(false);
+    expect(hasAccess('perm.ok', 'feat.bad')).toBe(false);
+  });
+
+  it('allows when keys are empty', () => {
+    permMock.mockReturnValue(false);
+    featureMock.mockReturnValue(false);
+    expect(hasAccess('', '')).toBe(true);
+  });
+});

--- a/tests/menuAccess.test.ts
+++ b/tests/menuAccess.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMenuItems } from '../src/hooks/useMenuItems';
+import { navigation } from '../src/config/navigation';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: any) => ({ data: opts.queryFn() })
+}));
+
+let menuItems: any[] = [];
+let featureRows: any[] = [];
+let rolePerms: any[] = [];
+
+const itemsChain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  order: vi.fn(() => Promise.resolve({ data: menuItems, error: null }))
+};
+
+const featuresChain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  is: vi.fn(() => Promise.resolve({ data: featureRows, error: null }))
+};
+
+const permsChain = {
+  select: vi.fn().mockReturnThis(),
+  in: vi.fn(() => Promise.resolve({ data: rolePerms, error: null }))
+};
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(() => Promise.resolve({ data: [{ id: 't1' }], error: null })),
+    from: vi.fn((table: string) => {
+      if (table === 'menu_items') return itemsChain as any;
+      if (table === 'license_features') return featuresChain as any;
+      if (table === 'role_permissions') return permsChain as any;
+      return {} as any;
+    })
+  }
+}));
+
+beforeEach(() => {
+  menuItems = [];
+  featureRows = [];
+  rolePerms = [];
+  process.env.VITE_ENABLE_DYNAMIC_MENU = 'true';
+});
+
+describe('useMenuItems', () => {
+  it('filters menu items by role and license', async () => {
+    menuItems = [
+      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, menu_permissions: [] },
+      { id: '2', parent_id: null, code: 'finance.report', label: 'Report', path: '/report', icon: 'Home', sort_order: 2, is_system: false, menu_permissions: [] },
+      { id: '3', parent_id: null, code: 'admin.manage', label: 'Admin', path: '/admin', icon: 'Home', sort_order: 3, is_system: false, menu_permissions: [{ permission_id: 'perm_manage' }] }
+    ];
+    featureRows = [
+      { feature: 'finance.approve', licenses: { status: 'active', expires_at: null } },
+      { feature: 'admin.manage', licenses: { status: 'active', expires_at: null } }
+    ];
+    rolePerms = [{ permission_id: 'perm_manage' }];
+
+    const { data } = useMenuItems(['r1']);
+    const menus = await data;
+    expect(menus.map((m: any) => m.name)).toEqual(['Approve', 'Admin']);
+  });
+
+  it('falls back to static navigation when no licensed items remain', async () => {
+    menuItems = [
+      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, menu_permissions: [] }
+    ];
+    featureRows = [
+      { feature: 'other.feature', licenses: { status: 'active', expires_at: null } }
+    ];
+    rolePerms = [];
+
+    const { data } = useMenuItems(['r1']);
+    const menus = await data;
+    expect(menus).toBe(navigation);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `hasAccess` utility
- add unit tests for `useMenuItems` access hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aef0d8614832683a78e299a2da392