### PR TITLE
Add migration to populate user_roles tenant_id

### DIFF
--- a/supabase/migrations/20250807000000_populate_user_roles_tenant_id.sql
+++ b/supabase/migrations/20250807000000_populate_user_roles_tenant_id.sql
@@ -1,0 +1,13 @@
+-- Populate user_roles.tenant_id by joining tenant_users
+UPDATE user_roles ur
+SET tenant_id = tu.tenant_id
+FROM tenant_users tu
+WHERE ur.user_id = tu.user_id
+  AND ur.tenant_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM user_roles dup
+    WHERE dup.user_id = ur.user_id
+      AND dup.role_id = ur.role_id
+      AND dup.tenant_id = tu.tenant_id
+  );


### PR DESCRIPTION
## Summary
- add a migration that fills `user_roles.tenant_id` by joining `tenant_users`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_686af689e460832683520aade2601b4f