### PR TITLE
Fix icon lookup in dynamic menu items

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ the database.
    `VITE_ENABLE_DYNAMIC_MENU` is set to `true` (the default). Set it to
    `false` in your `.env` file to use the static menu defined in the source
    code.
+   Menu items are grouped by a `section` column that mirrors the
+   configuration in `src/config/navigation.ts`.
 
 ## Running tests
 

--- a/src/adapters/menuItem.adapter.ts
+++ b/src/adapters/menuItem.adapter.ts
@@ -27,6 +27,7 @@ export class MenuItemAdapter
     icon,
     sort_order,
     is_system,
+    section,
     created_by,
     updated_by,
     created_at,

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -11,7 +11,6 @@ import {
   Bell,
   LifeBuoy,
   Shield,
-  ListChecks,
   LucideIcon,
 } from 'lucide-react';
 

--- a/src/hooks/useMenuItems.ts
+++ b/src/hooks/useMenuItems.ts
@@ -4,10 +4,28 @@ import { navigation as staticNavigation, NavItem } from "../config/navigation";
 import * as Icons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+function toPascalCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
 function getIcon(name: string | null): LucideIcon {
-  const icon = (Icons as Record<string, LucideIcon>)[name ?? ""];
+  if (!name) return Icons.Circle;
+  const pascal = toPascalCase(name);
+  const icon = (Icons as Record<string, LucideIcon>)[pascal];
   return icon || Icons.Circle;
 }
+
+const sectionMap = new Map<string, string>();
+function collectSections(items: NavItem[]) {
+  items.forEach((it) => {
+    if (it.href) sectionMap.set(it.href, it.section ?? "General");
+    if (it.submenu) collectSections(it.submenu);
+  });
+}
+collectSections(staticNavigation);
 
 export function useMenuItems(roleIds: string[]) {
   const enableDynamicMenu =
@@ -29,7 +47,7 @@ export function useMenuItems(roleIds: string[]) {
       const { data: items, error } = await supabase
         .from("menu_items")
         .select(
-          `id,parent_id,code,label,path,icon,sort_order,is_system,menu_permissions(permission_id)`,
+          `id,parent_id,code,label,path,icon,sort_order,is_system,section,menu_permissions(permission_id)`,
         )
         .eq("tenant_id", tenant.id)
         .is("deleted_at", null)
@@ -105,16 +123,19 @@ export function useMenuItems(roleIds: string[]) {
       };
       sortItems(roots);
 
-      const convert = (item: any): NavItem => ({
-        name: item.label,
-        href: item.path,
-        icon: getIcon(item.icon),
-        permission: null,
-        section: "General",
-        submenu: item.submenu.map(convert),
-      });
+      const convert = (item: any, parentSection?: string): NavItem => {
+        const section = item.section ?? parentSection ?? sectionMap.get(item.path) ?? "General";
+        return {
+          name: item.label,
+          href: item.path,
+          icon: getIcon(item.icon),
+          permission: null,
+          section,
+          submenu: item.submenu.map((sub: any) => convert(sub, section)),
+        };
+      };
 
-      return roots.map(convert) as NavItem[];
+      return roots.map((r) => convert(r)) as NavItem[];
     },
     staleTime: 5 * 60 * 1000,
   });

--- a/src/models/menuItem.model.ts
+++ b/src/models/menuItem.model.ts
@@ -9,4 +9,5 @@ export interface MenuItem extends BaseModel {
   icon: string | null;
   sort_order: number;
   is_system: boolean;
+  section: string | null;
 }

--- a/supabase/migrations/20250808000000_menu_item_sections.sql
+++ b/supabase/migrations/20250808000000_menu_item_sections.sql
@@ -1,0 +1,43 @@
+-- Add section column to menu_items and populate existing records
+ALTER TABLE menu_items ADD COLUMN IF NOT EXISTS section text;
+
+-- Update default global menu items with their sections
+UPDATE menu_items
+SET section = CASE code
+  WHEN 'welcome' THEN 'General'
+  WHEN 'announcements' THEN 'General'
+  WHEN 'support' THEN 'General'
+  WHEN 'members' THEN 'Community'
+  WHEN 'attendance' THEN 'Community'
+  WHEN 'events' THEN 'Community'
+  WHEN 'finances' THEN 'Financial'
+  WHEN 'offerings' THEN 'Financial'
+  WHEN 'expenses' THEN 'Financial'
+  WHEN 'financial-reports' THEN 'Financial'
+  WHEN 'administration' THEN 'Administration'
+  WHEN 'menu-permissions' THEN 'Administration'
+  ELSE 'General'
+END
+WHERE tenant_id IS NULL AND section IS NULL;
+
+-- Updated helper to copy defaults to tenants including section
+CREATE OR REPLACE FUNCTION create_default_menu_items_for_tenant(p_tenant_id uuid, p_user_id uuid)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO menu_items (
+    tenant_id, parent_id, code, label, path, icon, sort_order, is_system, section, created_by, updated_by
+  )
+  SELECT p_tenant_id, parent_id, code, label, path, icon, sort_order, is_system, section, p_user_id, p_user_id
+  FROM menu_items
+  WHERE tenant_id IS NULL
+  ON CONFLICT (tenant_id, code) DO NOTHING;
+
+  INSERT INTO menu_permissions (tenant_id, menu_item_id, permission_id, created_by, updated_by)
+  SELECT p_tenant_id, t_item.id, mp.permission_id, p_user_id, p_user_id
+  FROM menu_permissions mp
+  JOIN menu_items g_item ON g_item.id = mp.menu_item_id AND g_item.tenant_id IS NULL
+  JOIN menu_items t_item ON t_item.code = g_item.code AND t_item.tenant_id = p_tenant_id
+  WHERE mp.tenant_id IS NULL
+  ON CONFLICT (tenant_id, menu_item_id, permission_id) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- map icon names from the database to Lucide icons
- tidy navigation icon imports
- preserve section groupings when loading menu items from Supabase
- add section column to menu items table and update copy helper

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686b45f1ddec832699113e57ceba8fcd