### PR TITLE
Fix IncomeExpenseProfile pagination

### DIFF
--- a/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
@@ -32,6 +32,8 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
   const [entries, setEntries] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [entriesError, setEntriesError] = useState<string | null>(null);
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
 
   useEffect(() => {
     const loadEntries = async () => {
@@ -144,6 +146,10 @@ function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
             autoHeight
             paginationMode="client"
             storageKey="income-expense-profile-entries"
+            onPageChange={setPage}
+            onPageSizeChange={setPageSize}
+            page={page}
+            pageSize={pageSize}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- maintain local page/pageSize state in IncomeExpenseProfile
- feed pagination callbacks/values to DataGrid

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdd4095048326b0ca0ee590f18e4a