### PR TITLE
Fix DOM nesting in ChartCardSkeleton

### DIFF
--- a/src/components/dashboard/ChartCardSkeleton.tsx
+++ b/src/components/dashboard/ChartCardSkeleton.tsx
@@ -12,8 +12,16 @@ export function ChartCardSkeleton({ title, description, height = 350 }: Props) {
   return (
     <Card className="animate-pulse">
       <CardHeader>
-        {title && <CardTitle><Skeleton className="h-6 w-1/3" /></CardTitle>}
-        {description && <CardDescription><Skeleton className="h-4 w-1/2" /></CardDescription>}
+        {title && (
+          <CardTitle>
+            <Skeleton as="span" className="block h-6 w-1/3" />
+          </CardTitle>
+        )}
+        {description && (
+          <CardDescription>
+            <Skeleton as="span" className="block h-4 w-1/2" />
+          </CardDescription>
+        )}
       </CardHeader>
       <CardContent>
         <Skeleton className={`w-full rounded-md`} style={{ height }} />

--- a/src/components/ui2/skeleton.tsx
+++ b/src/components/ui2/skeleton.tsx
@@ -1,8 +1,17 @@
 // src/components/ui2/skeleton.tsx
 import { cn } from '@/lib/utils';
 
-function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('animate-pulse rounded-md bg-muted dark:bg-muted', className)} {...props} />;
+interface SkeletonProps extends React.HTMLAttributes<HTMLElement> {
+  as?: React.ElementType;
+}
+
+function Skeleton({ as: Component = 'div', className, ...props }: SkeletonProps) {
+  return (
+    <Component
+      className={cn('animate-pulse rounded-md bg-muted dark:bg-muted', className)}
+      {...props}
+    />
+  );
 }
 
 export { Skeleton };


### PR DESCRIPTION
## Summary
- update `Skeleton` component to allow customizing element via `as` prop
- render skeleton placeholders inside headings using `span` elements to avoid invalid DOM nesting

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686cdd310ba48326a5d2aca8867dcba2