### PR TITLE
Fix header relationship alias

### DIFF
--- a/src/pages/expenses/ExpensesDashboard.tsx
+++ b/src/pages/expenses/ExpensesDashboard.tsx
@@ -133,6 +133,7 @@ function ExpensesDashboard() {
       {
         table: 'financial_transaction_headers',
         foreignKey: 'header_id',
+        alias: 'header',
         select: ['id', 'status'],
       },
       {
@@ -166,6 +167,7 @@ function ExpensesDashboard() {
       {
         table: 'financial_transaction_headers',
         foreignKey: 'header_id',
+        alias: 'header',
         select: ['id', 'status'],
       },
       {

--- a/src/pages/offerings/OfferingsDashboard.tsx
+++ b/src/pages/offerings/OfferingsDashboard.tsx
@@ -133,6 +133,7 @@ function OfferingsDashboard() {
       {
         table: 'financial_transaction_headers',
         foreignKey: 'header_id',
+        alias: 'header',
         select: ['id', 'status'],
       },
       {
@@ -166,6 +167,7 @@ function OfferingsDashboard() {
       {
         table: 'financial_transaction_headers',
         foreignKey: 'header_id',
+        alias: 'header',
         select: ['id', 'status'],
       },
       {


### PR DESCRIPTION
## Summary
- add alias 'header' for header relationships in `useTxQuery`
- ensure DataGrid uses `params.row.header?.status`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce16b64648326ac919bde4b7b0ba0