### PR TITLE
Fix hook usage in access checks

### DIFF
--- a/src/components/PermissionGate.tsx
+++ b/src/components/PermissionGate.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { usePermissions } from '../hooks/usePermissions';
-import { hasAccess } from '../utils/access';
+import { useAccess } from '../utils/access';
 
 type PermissionGateProps = {
   permission?: string;
@@ -11,6 +11,7 @@ type PermissionGateProps = {
 
 function PermissionGate({ permission, role, children, fallback = null }: PermissionGateProps) {
   const { hasRole, isLoading } = usePermissions();
+  const { hasAccess } = useAccess();
 
   if (isLoading) {
     return null;

--- a/src/components/finances/DonationActions.tsx
+++ b/src/components/finances/DonationActions.tsx
@@ -19,8 +19,7 @@ import {
 import { Button } from '../ui2/button';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
-import { usePermissions } from '../../hooks/usePermissions';
-import { hasAccess } from '../../utils/access';
+import { useAccess } from '../../utils/access';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import type { TransactionItem as DonationItem } from './RecentTransactionItem';
@@ -43,6 +42,7 @@ interface DonationActionsProps {
 
 export default function DonationActions({ donation }: DonationActionsProps) {
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const { currency } = useCurrencyStore();
   const {
     submitTransaction,

--- a/src/components/finances/ExpenseActions.tsx
+++ b/src/components/finances/ExpenseActions.tsx
@@ -19,8 +19,7 @@ import {
 import { Button } from '../ui2/button';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseService } from '../../hooks/useIncomeExpenseService';
-import { usePermissions } from '../../hooks/usePermissions';
-import { hasAccess } from '../../utils/access';
+import { useAccess } from '../../utils/access';
 import { useCurrencyStore } from '../../stores/currencyStore';
 import { formatCurrency } from '../../utils/currency';
 import type { ExpenseItem } from './RecentExpenseItem';
@@ -43,6 +42,7 @@ interface ExpenseActionsProps {
 
 export default function ExpenseActions({ expense }: ExpenseActionsProps) {
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const { currency } = useCurrencyStore();
   const {
     submitTransaction,

--- a/src/components/finances/RecentFinancialTransactionItem.tsx
+++ b/src/components/finances/RecentFinancialTransactionItem.tsx
@@ -16,7 +16,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useFinancialTransactionHeaderRepository } from '../../hooks/useFinancialTransactionHeaderRepository';
-import { hasAccess } from '../../utils/access';
+import { useAccess } from '../../utils/access';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -43,6 +43,7 @@ const statusVariantMap: Record<string, 'success' | 'warning' | 'info' | 'seconda
 
 export default function RecentTransactionItem({ transaction }: Props) {
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const {
     submitTransaction,
     approveTransaction,

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -4,7 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
 import { useIncomeExpenseTransactionRepository } from '../../../hooks/useIncomeExpenseTransactionRepository';
 import { useIncomeExpenseService } from '../../../hooks/useIncomeExpenseService';
-import { hasAccess } from '../../../utils/access';
+import { useAccess } from '../../../utils/access';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { Input } from '../../../components/ui2/input';
@@ -49,6 +49,7 @@ interface IncomeExpenseListProps {
 
 function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseProfile.tsx
@@ -27,7 +27,7 @@ import {
 } from 'lucide-react';
 import { format, parse } from 'date-fns';
 import BackButton from '../../../components/BackButton';
-import { hasAccess } from '../../../utils/access';
+import { useAccess } from '../../../utils/access';
 
 interface IncomeExpenseProfileProps {
   transactionType: 'income' | 'expense';
@@ -36,6 +36,7 @@ interface IncomeExpenseProfileProps {
 function IncomeExpenseProfile({ transactionType }: IncomeExpenseProfileProps) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const {
     useQuery,
     submitTransaction,

--- a/src/pages/finances/transactions/TransactionDetail.tsx
+++ b/src/pages/finances/transactions/TransactionDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
-import { hasAccess } from '../../../utils/access';
+import { useAccess } from '../../../utils/access';
 import PermissionGate from '../../../components/PermissionGate';
 import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -38,6 +38,7 @@ import {
 function TransactionDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const { currency } = useCurrencyStore();
   
   // State for dialogs

--- a/src/pages/finances/transactions/TransactionList.tsx
+++ b/src/pages/finances/transactions/TransactionList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useFinancialTransactionHeaderRepository } from '../../../hooks/useFinancialTransactionHeaderRepository';
-import { hasAccess } from '../../../utils/access';
+import { useAccess } from '../../../utils/access';
 import PermissionGate from '../../../components/PermissionGate';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -57,6 +57,7 @@ import { useIncomeExpenseService } from '../../../hooks/useIncomeExpenseService'
 
 function TransactionList() {
   const navigate = useNavigate();
+  const { hasAccess } = useAccess();
   const { currency } = useCurrencyStore();
   
   // State for filters

--- a/src/utils/access.ts
+++ b/src/utils/access.ts
@@ -1,12 +1,28 @@
+import React from 'react';
 import { usePermissions } from '../hooks/usePermissions';
 import { useFeatures } from '../hooks/useFeatures';
 
-export function hasAccess(permissionKey: string, featureKey: string): boolean {
-  const { hasPermission } = usePermissions();
-  const { isEnabled } = useFeatures();
-
+export function computeAccess(
+  hasPermission: (key: string) => boolean,
+  isEnabled: (key: string) => boolean,
+  permissionKey: string,
+  featureKey: string
+): boolean {
   const permissionAllowed = permissionKey ? hasPermission(permissionKey) : true;
   const featureAllowed = featureKey ? isEnabled(featureKey) : true;
 
   return permissionAllowed && featureAllowed;
+}
+
+export function useAccess() {
+  const { hasPermission } = usePermissions();
+  const { isEnabled } = useFeatures();
+
+  const hasAccess = React.useCallback(
+    (permissionKey: string, featureKey: string) =>
+      computeAccess(hasPermission, isEnabled, permissionKey, featureKey),
+    [hasPermission, isEnabled]
+  );
+
+  return { hasAccess };
 }

--- a/tests/hasAccess.test.ts
+++ b/tests/hasAccess.test.ts
@@ -1,44 +1,44 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { hasAccess } from '../src/utils/access';
+import { describe, it, expect } from 'vitest';
+import { computeAccess } from '../src/utils/access';
 
-const permMock = vi.fn();
-const featureMock = vi.fn();
-
-vi.mock('../src/hooks/usePermissions', () => ({
-  usePermissions: () => ({ hasPermission: permMock })
-}));
-
-vi.mock('../src/hooks/useFeatures', () => ({
-  useFeatures: () => ({ isEnabled: featureMock })
-}));
-
-beforeEach(() => {
-  permMock.mockReset();
-  featureMock.mockReset();
-});
-
-describe('hasAccess', () => {
+describe('computeAccess', () => {
   it('returns true when permission and feature allowed', () => {
-    permMock.mockReturnValue(true);
-    featureMock.mockReturnValue(true);
-    expect(hasAccess('perm.ok', 'feat.ok')).toBe(true);
+    const result = computeAccess(
+      () => true,
+      () => true,
+      'perm.ok',
+      'feat.ok'
+    );
+    expect(result).toBe(true);
   });
 
   it('returns false when permission missing', () => {
-    permMock.mockReturnValue(false);
-    featureMock.mockReturnValue(true);
-    expect(hasAccess('perm.no', 'feat.ok')).toBe(false);
+    const result = computeAccess(
+      () => false,
+      () => true,
+      'perm.no',
+      'feat.ok'
+    );
+    expect(result).toBe(false);
   });
 
   it('returns false when feature disabled', () => {
-    permMock.mockReturnValue(true);
-    featureMock.mockReturnValue(false);
-    expect(hasAccess('perm.ok', 'feat.bad')).toBe(false);
+    const result = computeAccess(
+      () => true,
+      () => false,
+      'perm.ok',
+      'feat.bad'
+    );
+    expect(result).toBe(false);
   });
 
   it('allows when keys are empty', () => {
-    permMock.mockReturnValue(false);
-    featureMock.mockReturnValue(false);
-    expect(hasAccess('', '')).toBe(true);
+    const result = computeAccess(
+      () => false,
+      () => false,
+      '',
+      ''
+    );
+    expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- avoid using React hooks inside a plain function
- provide `useAccess` hook and pure `computeAccess` helper
- adjust components to use new hook
- update unit test

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ce46df1ac8326bff1775887ed8042