### PR TITLE
Add role menu item mapping

### DIFF
--- a/src/adapters/menuItem.adapter.ts
+++ b/src/adapters/menuItem.adapter.ts
@@ -36,9 +36,9 @@ export class MenuItemAdapter
 
   protected defaultRelationships: QueryOptions['relationships'] = [
     {
-      table: 'menu_permissions',
+      table: 'role_menu_items',
       foreignKey: 'menu_item_id',
-      select: ['permission_id'],
+      select: ['role_id'],
     },
   ];
 

--- a/src/adapters/roleMenuItem.adapter.ts
+++ b/src/adapters/roleMenuItem.adapter.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata';
+import { injectable, inject } from 'inversify';
+import { BaseAdapter } from './base.adapter';
+import { RoleMenuItem } from '../models/roleMenuItem.model';
+import { AuditService } from '../services/AuditService';
+import { TYPES } from '../lib/types';
+
+export interface IRoleMenuItemAdapter extends BaseAdapter<RoleMenuItem> {}
+
+@injectable()
+export class RoleMenuItemAdapter
+  extends BaseAdapter<RoleMenuItem>
+  implements IRoleMenuItemAdapter
+{
+  constructor(@inject(TYPES.AuditService) private auditService: AuditService) {
+    super();
+  }
+
+  protected tableName = 'role_menu_items';
+
+  protected defaultSelect = `
+    id,
+    role_id,
+    menu_item_id,
+    created_by,
+    updated_by,
+    created_at,
+    updated_at
+  `;
+
+  protected override async onAfterCreate(data: RoleMenuItem): Promise<void> {
+    await this.auditService.logAuditEvent('create', 'role_menu_item', data.id, data);
+  }
+
+  protected override async onAfterUpdate(data: RoleMenuItem): Promise<void> {
+    await this.auditService.logAuditEvent('update', 'role_menu_item', data.id, data);
+  }
+
+  protected override async onAfterDelete(id: string): Promise<void> {
+    await this.auditService.logAuditEvent('delete', 'role_menu_item', id, { id });
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -36,3 +36,4 @@ export * from './useAuthorization';
 export * from './useMenuItemRepository';
 export * from './useMenuItems';
 export * from './useMenuPermissionRepository';
+export * from './useRoleMenuItemRepository';

--- a/src/hooks/useMenuItems.ts
+++ b/src/hooks/useMenuItems.ts
@@ -47,7 +47,7 @@ export function useMenuItems(roleIds: string[]) {
       const { data: items, error } = await supabase
         .from("menu_items")
         .select(
-          `id,parent_id,code,label,path,icon,sort_order,is_system,section,menu_permissions(permission_id)`,
+          `id,parent_id,code,label,path,icon,sort_order,is_system,section,role_menu_items(role_id)`,
         )
         .eq("tenant_id", tenant.id)
         .is("deleted_at", null)
@@ -74,22 +74,12 @@ export function useMenuItems(roleIds: string[]) {
         )
         .map((f) => f.feature);
 
-      let permissionIds: string[] = [];
-      if (roleIds.length) {
-        const { data: rolePerms, error: rpError } = await supabase
-          .from("role_permissions")
-          .select("permission_id")
-          .in("role_id", roleIds);
-        if (rpError) throw rpError;
-        permissionIds = rolePerms?.map((rp) => rp.permission_id) || [];
-      }
-
       const allowed = items.filter((item) => {
-        const perms =
-          (item.menu_permissions as { permission_id: string }[]) || [];
+        const roleItems =
+          (item.role_menu_items as { role_id: string }[]) || [];
         if (
-          perms.length &&
-          !perms.some((p) => permissionIds.includes(p.permission_id))
+          roleItems.length &&
+          !roleItems.some((r) => roleIds.includes(r.role_id))
         ) {
           return false;
         }

--- a/src/hooks/useRoleMenuItemRepository.ts
+++ b/src/hooks/useRoleMenuItemRepository.ts
@@ -1,0 +1,9 @@
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { IRoleMenuItemRepository } from '../repositories/roleMenuItem.repository';
+import { useBaseRepository } from './useBaseRepository';
+
+export function useRoleMenuItemRepository() {
+  const repository = container.get<IRoleMenuItemRepository>(TYPES.IRoleMenuItemRepository);
+  return useBaseRepository(repository, 'Role Menu Item', 'role-menu-items');
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -53,6 +53,7 @@ import { RoleAdapter, type IRoleAdapter } from '../adapters/role.adapter';
 import { PermissionAdapter, type IPermissionAdapter } from '../adapters/permission.adapter';
 import { MenuItemAdapter, type IMenuItemAdapter } from '../adapters/menuItem.adapter';
 import { MenuPermissionAdapter, type IMenuPermissionAdapter } from '../adapters/menuPermission.adapter';
+import { RoleMenuItemAdapter, type IRoleMenuItemAdapter } from '../adapters/roleMenuItem.adapter';
 import { AuthUserAdapter, type IAuthUserAdapter } from '../adapters/authUser.adapter';
 import { ErrorLogAdapter, type IErrorLogAdapter } from '../adapters/errorLog.adapter';
 import { ActivityLogAdapter, type IActivityLogAdapter } from '../adapters/activityLog.adapter';
@@ -116,6 +117,7 @@ import { RoleRepository, type IRoleRepository } from '../repositories/role.repos
 import { PermissionRepository, type IPermissionRepository } from '../repositories/permission.repository';
 import { MenuItemRepository, type IMenuItemRepository } from '../repositories/menuItem.repository';
 import { MenuPermissionRepository, type IMenuPermissionRepository } from '../repositories/menuPermission.repository';
+import { RoleMenuItemRepository, type IRoleMenuItemRepository } from '../repositories/roleMenuItem.repository';
 import { UserRepository, type IUserRepository } from '../repositories/user.repository';
 import { ErrorLogRepository, type IErrorLogRepository } from '../repositories/errorLog.repository';
 import { ActivityLogRepository, type IActivityLogRepository } from '../repositories/activityLog.repository';
@@ -217,6 +219,10 @@ container
 container
   .bind<IMenuPermissionAdapter>(TYPES.IMenuPermissionAdapter)
   .to(MenuPermissionAdapter)
+  .inSingletonScope();
+container
+  .bind<IRoleMenuItemAdapter>(TYPES.IRoleMenuItemAdapter)
+  .to(RoleMenuItemAdapter)
   .inSingletonScope();
 container
   .bind<IOfferingBatchAdapter>(TYPES.IOfferingBatchAdapter)
@@ -351,6 +357,10 @@ container
 container
   .bind<IMenuPermissionRepository>(TYPES.IMenuPermissionRepository)
   .to(MenuPermissionRepository)
+  .inSingletonScope();
+container
+  .bind<IRoleMenuItemRepository>(TYPES.IRoleMenuItemRepository)
+  .to(RoleMenuItemRepository)
   .inSingletonScope();
 container
   .bind<IFinancialTransactionRepository>(TYPES.IFinancialTransactionRepository)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -42,6 +42,8 @@ export const TYPES = {
   IMenuItemRepository: 'IMenuItemRepository',
   IMenuPermissionAdapter: 'IMenuPermissionAdapter',
   IMenuPermissionRepository: 'IMenuPermissionRepository',
+  IRoleMenuItemAdapter: 'IRoleMenuItemAdapter',
+  IRoleMenuItemRepository: 'IRoleMenuItemRepository',
   IUserRepository: 'IUserRepository',
   IErrorLogRepository: 'IErrorLogRepository',
   IActivityLogRepository: 'IActivityLogRepository',

--- a/src/models/roleMenuItem.model.ts
+++ b/src/models/roleMenuItem.model.ts
@@ -1,0 +1,7 @@
+import { BaseModel } from './base.model';
+
+export interface RoleMenuItem extends BaseModel {
+  id: string;
+  role_id: string;
+  menu_item_id: string;
+}

--- a/src/pages/admin/MenuPermissions.tsx
+++ b/src/pages/admin/MenuPermissions.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '../../lib/supabase';
-import { useMenuPermissionRepository } from '../../hooks/useMenuPermissionRepository';
+import { useRoleMenuItemRepository } from '../../hooks/useRoleMenuItemRepository';
 import { useMenuItemRepository } from '../../hooks/useMenuItemRepository';
 import { Card, CardContent } from '../../components/ui2/card';
 import {
@@ -12,7 +12,6 @@ import {
   SelectItem,
 } from '../../components/ui2/select';
 import { Checkbox } from '../../components/ui2/checkbox';
-import { Button } from '../../components/ui2/button';
 import { Loader2, ListChecks } from 'lucide-react';
 
 interface Role {
@@ -29,7 +28,7 @@ interface MenuItem {
 
 function MenuPermissions() {
   const [roleId, setRoleId] = useState<string>('');
-  const { useQuery: useMenuPermQuery, useCreate, useDelete } = useMenuPermissionRepository();
+  const { useQuery: useMenuPermQuery, useCreate, useDelete } = useRoleMenuItemRepository();
   const { useQuery: useMenuItemsQuery } = useMenuItemRepository();
 
   const { data: roles } = useQuery({
@@ -67,7 +66,7 @@ function MenuPermissions() {
   }, [featureRows]);
 
   const { data: permsRes } = useMenuPermQuery({
-    filters: roleId ? { permission_id: { operator: 'eq', value: roleId } } : {},
+    filters: roleId ? { role_id: { operator: 'eq', value: roleId } } : {},
     enabled: !!roleId,
   });
   const current = (permsRes?.data as any[]) || [];
@@ -81,7 +80,7 @@ function MenuPermissions() {
     if (existing) {
       await deleteMutation.mutateAsync(existing.id);
     } else {
-      await createMutation.mutateAsync({ data: { menu_item_id: item.id, permission_id: roleId } });
+      await createMutation.mutateAsync({ data: { menu_item_id: item.id, role_id: roleId } });
     }
   };
 

--- a/src/repositories/roleMenuItem.repository.ts
+++ b/src/repositories/roleMenuItem.repository.ts
@@ -1,0 +1,17 @@
+import { injectable, inject } from 'inversify';
+import { BaseRepository } from './base.repository';
+import { RoleMenuItem } from '../models/roleMenuItem.model';
+import type { IRoleMenuItemAdapter } from '../adapters/roleMenuItem.adapter';
+import { TYPES } from '../lib/types';
+
+export interface IRoleMenuItemRepository extends BaseRepository<RoleMenuItem> {}
+
+@injectable()
+export class RoleMenuItemRepository
+  extends BaseRepository<RoleMenuItem>
+  implements IRoleMenuItemRepository
+{
+  constructor(@inject(TYPES.IRoleMenuItemAdapter) adapter: IRoleMenuItemAdapter) {
+    super(adapter);
+  }
+}

--- a/supabase/migrations/20250815000000_role_menu_items.sql
+++ b/supabase/migrations/20250815000000_role_menu_items.sql
@@ -1,0 +1,43 @@
+-- Create table to map roles directly to menu items
+CREATE TABLE IF NOT EXISTS role_menu_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid REFERENCES tenants(id) ON DELETE CASCADE,
+  role_id uuid REFERENCES roles(id) ON DELETE CASCADE,
+  menu_item_id uuid REFERENCES menu_items(id) ON DELETE CASCADE,
+  created_by uuid REFERENCES auth.users(id),
+  updated_by uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (tenant_id, role_id, menu_item_id)
+);
+
+CREATE INDEX IF NOT EXISTS role_menu_items_tenant_id_idx ON role_menu_items(tenant_id);
+CREATE INDEX IF NOT EXISTS role_menu_items_role_id_idx ON role_menu_items(role_id);
+CREATE INDEX IF NOT EXISTS role_menu_items_menu_item_id_idx ON role_menu_items(menu_item_id);
+
+ALTER TABLE role_menu_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Role menu items are viewable within tenant" ON role_menu_items
+  FOR SELECT TO authenticated
+  USING (check_tenant_access(tenant_id));
+
+CREATE POLICY "Role menu items can be managed within tenant" ON role_menu_items
+  FOR ALL TO authenticated
+  USING (check_tenant_access(tenant_id))
+  WITH CHECK (check_tenant_access(tenant_id));
+
+CREATE TRIGGER update_role_menu_items_updated_at
+BEFORE UPDATE ON role_menu_items
+FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- Migrate existing role/menu relationships via menu_permissions and role_permissions
+INSERT INTO role_menu_items (tenant_id, role_id, menu_item_id)
+SELECT
+  COALESCE(rp.tenant_id, mp.tenant_id),
+  rp.role_id,
+  mp.menu_item_id
+FROM menu_permissions mp
+JOIN role_permissions rp
+  ON rp.permission_id = mp.permission_id
+  AND (rp.tenant_id = mp.tenant_id OR (rp.tenant_id IS NULL AND mp.tenant_id IS NULL))
+ON CONFLICT (tenant_id, role_id, menu_item_id) DO NOTHING;

--- a/tests/menuAccess.test.ts
+++ b/tests/menuAccess.test.ts
@@ -8,7 +8,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 let menuItems: any[] = [];
 let featureRows: any[] = [];
-let rolePerms: any[] = [];
+let roleItems: any[] = [];
 
 const itemsChain = {
   select: vi.fn().mockReturnThis(),
@@ -25,7 +25,7 @@ const featuresChain = {
 
 const permsChain = {
   select: vi.fn().mockReturnThis(),
-  in: vi.fn(() => Promise.resolve({ data: rolePerms, error: null }))
+  in: vi.fn(() => Promise.resolve({ data: roleItems, error: null }))
 };
 
 vi.mock('../src/lib/supabase', () => ({
@@ -34,7 +34,7 @@ vi.mock('../src/lib/supabase', () => ({
     from: vi.fn((table: string) => {
       if (table === 'menu_items') return itemsChain as any;
       if (table === 'license_features') return featuresChain as any;
-      if (table === 'role_permissions') return permsChain as any;
+      if (table === 'role_menu_items') return permsChain as any;
       return {} as any;
     })
   }
@@ -43,22 +43,22 @@ vi.mock('../src/lib/supabase', () => ({
 beforeEach(() => {
   menuItems = [];
   featureRows = [];
-  rolePerms = [];
+  roleItems = [];
   process.env.VITE_ENABLE_DYNAMIC_MENU = 'true';
 });
 
 describe('useMenuItems', () => {
   it('filters menu items by role and license', async () => {
     menuItems = [
-      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, menu_permissions: [] },
-      { id: '2', parent_id: null, code: 'finance.report', label: 'Report', path: '/report', icon: 'Home', sort_order: 2, is_system: false, menu_permissions: [] },
-      { id: '3', parent_id: null, code: 'admin.manage', label: 'Admin', path: '/admin', icon: 'Home', sort_order: 3, is_system: false, menu_permissions: [{ permission_id: 'perm_manage' }] }
+      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, role_menu_items: [] },
+      { id: '2', parent_id: null, code: 'finance.report', label: 'Report', path: '/report', icon: 'Home', sort_order: 2, is_system: false, role_menu_items: [] },
+      { id: '3', parent_id: null, code: 'admin.manage', label: 'Admin', path: '/admin', icon: 'Home', sort_order: 3, is_system: false, role_menu_items: roleItems }
     ];
     featureRows = [
       { feature: 'finance.approve', licenses: { status: 'active', expires_at: null } },
       { feature: 'admin.manage', licenses: { status: 'active', expires_at: null } }
     ];
-    rolePerms = [{ permission_id: 'perm_manage' }];
+    roleItems = [{ role_id: 'r1' }];
 
     const { data } = useMenuItems(['r1']);
     const menus = await data;
@@ -67,12 +67,12 @@ describe('useMenuItems', () => {
 
   it('falls back to static navigation when no licensed items remain', async () => {
     menuItems = [
-      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, menu_permissions: [] }
+      { id: '1', parent_id: null, code: 'finance.approve', label: 'Approve', path: '/approve', icon: 'Home', sort_order: 1, is_system: false, role_menu_items: [] }
     ];
     featureRows = [
       { feature: 'other.feature', licenses: { status: 'active', expires_at: null } }
     ];
-    rolePerms = [];
+    roleItems = [];
 
     const { data } = useMenuItems(['r1']);
     const menus = await data;


### PR DESCRIPTION
## Summary
- create `role_menu_items` table via migration and copy existing assignments
- add adapter/repository/hook for role-menu data
- switch menu permissions UI to use new table
- use role_menu_items in dynamic menu hook
- update container & types
- adapt menu access unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d037d10bc83269e615668acf019e4