### PR TITLE
Add permission and feature keys to menu items

### DIFF
--- a/src/adapters/menuItem.adapter.ts
+++ b/src/adapters/menuItem.adapter.ts
@@ -28,6 +28,8 @@ export class MenuItemAdapter
     sort_order,
     is_system,
     section,
+    permission_key,
+    feature_key,
     created_by,
     updated_by,
     created_at,

--- a/src/models/menuItem.model.ts
+++ b/src/models/menuItem.model.ts
@@ -10,4 +10,6 @@ export interface MenuItem extends BaseModel {
   sort_order: number;
   is_system: boolean;
   section: string | null;
+  permission_key: string;
+  feature_key: string | null;
 }

--- a/supabase/migrations/20250816000000_menu_item_keys.sql
+++ b/supabase/migrations/20250816000000_menu_item_keys.sql
@@ -1,0 +1,40 @@
+-- Add permission_key and feature_key columns to menu_items
+ALTER TABLE menu_items
+  ADD COLUMN IF NOT EXISTS permission_key text NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS feature_key text;
+
+-- Populate permission_key by joining menu_permissions and permissions tables
+UPDATE menu_items mi
+SET permission_key = p.code
+FROM menu_permissions mp
+JOIN permissions p ON p.id = mp.permission_id
+WHERE mp.menu_item_id = mi.id
+  AND mp.tenant_id = mi.tenant_id
+  AND mi.permission_key = '';
+
+-- Remove default from permission_key column
+ALTER TABLE menu_items ALTER COLUMN permission_key DROP DEFAULT;
+
+-- Update create_default_menu_items_for_tenant to include new columns
+CREATE OR REPLACE FUNCTION create_default_menu_items_for_tenant(p_tenant_id uuid, p_user_id uuid)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO menu_items (
+    tenant_id, parent_id, code, label, path, icon, sort_order, is_system, section,
+    permission_key, feature_key, created_by, updated_by
+  )
+  SELECT p_tenant_id, parent_id, code, label, path, icon, sort_order, is_system, section,
+    permission_key, feature_key, p_user_id, p_user_id
+  FROM menu_items
+  WHERE tenant_id IS NULL
+  ON CONFLICT (tenant_id, code) DO NOTHING;
+
+  INSERT INTO menu_permissions (tenant_id, menu_item_id, permission_id, created_by, updated_by)
+  SELECT p_tenant_id, t_item.id, mp.permission_id, p_user_id, p_user_id
+  FROM menu_permissions mp
+  JOIN menu_items g_item ON g_item.id = mp.menu_item_id AND g_item.tenant_id IS NULL
+  JOIN menu_items t_item ON t_item.code = g_item.code AND t_item.tenant_id = p_tenant_id
+  WHERE mp.tenant_id IS NULL
+  ON CONFLICT (tenant_id, menu_item_id, permission_id) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20250816001000_update_menu_item_keys.sql
+++ b/supabase/migrations/20250816001000_update_menu_item_keys.sql
@@ -1,0 +1,26 @@
+-- Populate permission_key and feature_key values for existing menu items
+
+-- Set permission_key and feature_key for global menu items
+UPDATE menu_items
+SET permission_key = CASE code
+    WHEN 'members' THEN 'member.view'
+    WHEN 'attendance' THEN 'member.view'
+    WHEN 'events' THEN 'member.view'
+    WHEN 'finances' THEN 'finance.view'
+    WHEN 'offerings' THEN 'finance.view'
+    WHEN 'expenses' THEN 'finance.view'
+    WHEN 'financial-reports' THEN 'finance.view'
+    WHEN 'administration' THEN 'user.view'
+    WHEN 'menu-permissions' THEN 'role.edit'
+    ELSE permission_key
+  END,
+    feature_key = code
+WHERE tenant_id IS NULL;
+
+-- Propagate feature_key to tenant menu items
+UPDATE menu_items t
+SET feature_key = g.code
+FROM menu_items g
+WHERE g.code = t.code
+  AND g.tenant_id IS NULL
+  AND t.tenant_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- add permission_key and feature_key columns via new migration
- seed global menu items with these fields
- update create_default_menu_items_for_tenant function
- expose new fields in MenuItem model
- return these fields from the menu item adapter
- add update script for existing menu item keys

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d1bf96883269545e40a2b453627