### PR TITLE
Rename license code column

### DIFF
--- a/supabase/migrations/20250816002000_license_plan_name.sql
+++ b/supabase/migrations/20250816002000_license_plan_name.sql
@@ -1,0 +1,4 @@
+-- Rename licenses.code to plan_name and adjust constraints
+ALTER TABLE licenses RENAME COLUMN code TO plan_name;
+ALTER TABLE licenses DROP CONSTRAINT IF EXISTS licenses_tenant_id_code_key;
+ALTER TABLE licenses ADD CONSTRAINT licenses_tenant_id_plan_name_key UNIQUE (tenant_id, plan_name);


### PR DESCRIPTION
## Summary
- migrate licenses `code` column to `plan_name`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d212d73d883268f3bbcfb20ef5cab