### PR TITLE
Add license admin page and service

### DIFF
--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -144,6 +144,7 @@ import { SupabaseErrorLogService, type ErrorLogService } from '../services/Error
 import { SupabaseAnnouncementService, type AnnouncementService } from '../services/AnnouncementService';
 import { SupabaseActivityLogService, type ActivityLogService } from '../services/ActivityLogService';
 import { UserRoleService } from '../services/UserRoleService';
+import { LicenseService } from '../services/LicenseService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -308,6 +309,10 @@ container
 container
   .bind<SettingService>(TYPES.SettingService)
   .to(SupabaseSettingService)
+  .inSingletonScope();
+container
+  .bind<LicenseService>(TYPES.LicenseService)
+  .to(LicenseService)
   .inSingletonScope();
 container
   .bind<UserRoleService>(TYPES.UserRoleService)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,5 +70,6 @@ export const TYPES = {
   AnnouncementService: 'AnnouncementService',
   DonationImportService: 'DonationImportService',
   SettingService: 'SettingService',
-  UserRoleService: 'UserRoleService'
+  UserRoleService: 'UserRoleService',
+  LicenseService: 'LicenseService'
 };

--- a/src/pages/admin/Administration.tsx
+++ b/src/pages/admin/Administration.tsx
@@ -8,6 +8,7 @@ import Announcements from './announcements/Announcements';
 import ChurchSettings from './account-management/ChurchSettings';
 import Permissions from './configuration/Permissions';
 import MenuPermissions from './MenuPermissions';
+import License from './license/License';
 
 function Administration() {
   return (
@@ -18,9 +19,9 @@ function Administration() {
       <Route path="menu-permissions" element={<MenuPermissions />} />
       <Route path="configuration/permissions/*" element={<Permissions />} />
       <Route path="account-management/church" element={<ChurchSettings />} />
+      <Route path="license" element={<License />} />
       <Route path="*" element={<Navigate to="users" replace />} />
     </Routes>
   );
 }
-
 export default Administration;

--- a/src/pages/admin/license/License.tsx
+++ b/src/pages/admin/license/License.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { useLicenseRepository } from '../../../hooks/useLicenseRepository';
+import { useLicenseFeatureRepository } from '../../../hooks/useLicenseFeatureRepository';
+import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
+import { Input } from '../../../components/ui2/input';
+import { Button } from '../../../components/ui2/button';
+import { Loader2 } from 'lucide-react';
+import { License } from '../../../models/license.model';
+
+function LicensePage() {
+  const { useQuery, useCreate, useUpdate } = useLicenseRepository();
+  const { useQuery: useFeatureQuery } = useLicenseFeatureRepository();
+
+  const { data: licenseRes, isLoading } = useQuery();
+  const license = licenseRes?.data?.[0] as License | undefined;
+
+  const { data: featureRes } = useFeatureQuery(
+    license
+      ? { filters: { plan_name: { operator: 'eq', value: license.plan_name } } }
+      : { enabled: false }
+  );
+
+  const features = featureRes?.data || [];
+
+  const [formData, setFormData] = useState<Partial<License>>({});
+
+  useEffect(() => {
+    if (license) {
+      setFormData({ ...license });
+    }
+  }, [license]);
+
+  const createMutation = useCreate();
+  const updateMutation = useUpdate();
+
+  const handleChange = (field: keyof License, value: any) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = async () => {
+    if (license) {
+      await updateMutation.mutateAsync({ id: license.id, data: formData });
+    } else {
+      await createMutation.mutateAsync({ data: formData });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 w-full px-4 sm:px-6 lg:px-8">
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium">Current License</h3>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            label="Plan Name"
+            value={formData.plan_name || ''}
+            onChange={e => handleChange('plan_name', e.target.value)}
+          />
+          <Input
+            label="Tier"
+            value={formData.tier || ''}
+            onChange={e => handleChange('tier', e.target.value)}
+          />
+          <Input
+            label="Status"
+            value={formData.status || ''}
+            onChange={e => handleChange('status', e.target.value)}
+          />
+          <Input
+            type="date"
+            label="Starts At"
+            value={formData.starts_at || ''}
+            onChange={e => handleChange('starts_at', e.target.value)}
+          />
+          <Input
+            type="date"
+            label="Expires At"
+            value={formData.expires_at || ''}
+            onChange={e => handleChange('expires_at', e.target.value)}
+          />
+        </CardContent>
+        <CardFooter className="flex justify-end space-x-3">
+          <Button onClick={handleSave}>Save</Button>
+        </CardFooter>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium">Active Features</h3>
+        </CardHeader>
+        <CardContent>
+          {features.length === 0 ? (
+            <p className="text-muted-foreground">No features enabled</p>
+          ) : (
+            <ul className="list-disc pl-5 space-y-1">
+              {features.map(f => (
+                <li key={f.id}>{f.feature}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default LicensePage;

--- a/src/services/LicenseService.ts
+++ b/src/services/LicenseService.ts
@@ -1,0 +1,14 @@
+import { injectable } from 'inversify';
+import type { License } from '../models/license.model';
+
+export interface LicenseOverrides extends Partial<License> {}
+
+@injectable()
+export class LicenseService {
+  resolveLicense(current: License | null, overrides?: LicenseOverrides | null): License | null {
+    if (!current) {
+      return overrides ? ({ ...overrides } as License) : null;
+    }
+    return { ...current, ...(overrides || {}) } as License;
+  }
+}

--- a/tests/licenseService.test.ts
+++ b/tests/licenseService.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { LicenseService } from '../src/services/LicenseService';
+import type { License } from '../src/models/license.model';
+
+describe('LicenseService.resolveLicense', () => {
+  const service = new LicenseService();
+
+  it('returns current license when no overrides', () => {
+    const lic: License = {
+      id: '1',
+      tenant_id: 't1',
+      plan_name: 'basic',
+      tier: 'basic',
+      status: 'active',
+      starts_at: null,
+      expires_at: null
+    };
+    expect(service.resolveLicense(lic)).toEqual(lic);
+  });
+
+  it('merges overrides with current license', () => {
+    const lic: License = {
+      id: '1',
+      tenant_id: 't1',
+      plan_name: 'basic',
+      tier: 'basic',
+      status: 'active',
+      starts_at: null,
+      expires_at: null
+    };
+    const result = service.resolveLicense(lic, { plan_name: 'pro', status: 'trial' });
+    expect(result).toEqual({
+      ...lic,
+      plan_name: 'pro',
+      status: 'trial'
+    });
+  });
+
+  it('returns override when no current license', () => {
+    const override = { plan_name: 'pro', tier: 'premium', status: 'active' };
+    expect(service.resolveLicense(null, override)).toEqual(override);
+  });
+});


### PR DESCRIPTION
## Summary
- add admin license page with simple editing
- include license route in admin routing
- create LicenseService for merging license overrides
- register service in IoC container
- test license merging logic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ef656208326a45e210cce148dd7