### PR TITLE
Add migration to seed tenant roles

### DIFF
--- a/supabase/migrations/20250817001000_seed_tenant_roles.sql
+++ b/supabase/migrations/20250817001000_seed_tenant_roles.sql
@@ -1,0 +1,29 @@
+-- Seed tenant-specific role records and update existing user assignments
+
+-- 1. Copy global roles to each tenant
+INSERT INTO roles (tenant_id, name, description, created_by)
+SELECT t.id, r.name, r.description, t.created_by
+FROM roles r CROSS JOIN tenants t
+WHERE r.tenant_id IS NULL
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- 2. Remove assignments that would conflict after update
+DELETE FROM user_roles ur
+USING roles r
+JOIN roles tr ON tr.tenant_id = ur.tenant_id AND tr.name = r.name
+WHERE ur.role_id = r.id
+  AND r.tenant_id IS NULL
+  AND EXISTS (
+    SELECT 1 FROM user_roles dup
+    WHERE dup.user_id = ur.user_id
+      AND dup.role_id = tr.id
+      AND dup.tenant_id = ur.tenant_id
+  );
+
+-- 3. Update remaining assignments to tenant-specific role IDs
+UPDATE user_roles ur
+SET role_id = tr.id
+FROM roles r
+JOIN roles tr ON tr.tenant_id = ur.tenant_id AND tr.name = r.name
+WHERE ur.role_id = r.id
+  AND r.tenant_id IS NULL;


### PR DESCRIPTION
## Summary
- create a migration to copy global roles to each tenant
- update existing `user_roles` entries to use tenant-specific roles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d777b9cac83269b7ee68777edd36c