### PR TITLE
Remove unused role permission relationship

### DIFF
--- a/src/adapters/role.adapter.ts
+++ b/src/adapters/role.adapter.ts
@@ -26,13 +26,24 @@ export class RoleAdapter extends BaseAdapter<Role> implements IRoleAdapter {
 
   protected defaultRelationships: QueryOptions['relationships'] = [
     {
-      table: 'role_permissions',
+      table: 'role_menu_items',
       foreignKey: 'role_id',
       nestedRelationships: [
         {
-          table: 'permissions',
-          foreignKey: 'permission_id',
-          select: ['id', 'code', 'name', 'description', 'module']
+          table: 'menu_items',
+          foreignKey: 'menu_item_id',
+          select: [
+            'id',
+            'parent_id',
+            'code',
+            'label',
+            'path',
+            'icon',
+            'sort_order',
+            'is_system',
+            'section',
+            'feature_key'
+          ]
         }
       ]
     }

--- a/src/models/role.model.ts
+++ b/src/models/role.model.ts
@@ -1,9 +1,11 @@
 import { BaseModel } from './base.model';
 import { Permission } from './permission.model';
+import { MenuItem } from './menuItem.model';
 
 export interface Role extends BaseModel {
   id: string;
   name: string;
   description: string | null;
   permissions?: { permission: Permission }[];
+  menu_items?: { menu_item: MenuItem }[];
 }


### PR DESCRIPTION
## Summary
- drop `role_permissions` join from `RoleAdapter`
- relate roles to menu item assignments

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686db14a8ab88326a779212ae5a273aa