### PR TITLE
Refactor role permission handling

### DIFF
--- a/src/adapters/permission.adapter.ts
+++ b/src/adapters/permission.adapter.ts
@@ -33,13 +33,13 @@ export class PermissionAdapter
 
   protected override async onBeforeDelete(id: string): Promise<void> {
     const { data, error } = await supabase
-      .from('role_permissions')
-      .select('role_id')
+      .from('menu_permissions')
+      .select('menu_item_id')
       .eq('permission_id', id)
       .limit(1);
     if (error) throw error;
     if (data?.length) {
-      throw new Error('Cannot delete permission with assigned roles');
+      throw new Error('Cannot delete permission with assigned menu items');
     }
   }
 


### PR DESCRIPTION
## Summary
- remove `role_permissions` references
- update RoleRepository to work with menu-based permissions
- update PermissionAdapter for new relation
- fix updateRolePermissions test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e22c947908326bb2e2290d2591c92