### PR TITLE
Add deleted_at column to roles table

### DIFF
--- a/supabase/migrations/20250819001000_add_deleted_at_to_roles.sql
+++ b/supabase/migrations/20250819001000_add_deleted_at_to_roles.sql
@@ -1,0 +1,26 @@
+-- Add deleted_at column to roles table for soft deletes
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'roles'
+      AND column_name = 'deleted_at'
+  ) THEN
+    ALTER TABLE roles
+      ADD COLUMN deleted_at timestamptz;
+  END IF;
+END $$;
+
+-- Create index on deleted_at for faster queries
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE tablename = 'roles'
+      AND indexname = 'roles_deleted_at_idx'
+  ) THEN
+    CREATE INDEX roles_deleted_at_idx ON roles(deleted_at);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN roles.deleted_at IS 'Soft delete timestamp';


### PR DESCRIPTION
## Summary
- add migration to include `deleted_at` column in `roles` table
- create index for faster filtering

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e355cba7c832681da578c388e3592