### PR TITLE
Fix role permissions undefined handling

### DIFF
--- a/src/pages/admin/roles/RoleList.tsx
+++ b/src/pages/admin/roles/RoleList.tsx
@@ -103,7 +103,7 @@ function RoleList() {
                     <TableCell>{role.description || '-'}</TableCell>
                     <TableCell>
                       <div className="flex flex-wrap gap-1">
-                        {role.permissions.map((rp, index) => (
+                        {role.permissions?.map((rp, index) => (
                           <Badge key={index} variant="secondary">
                             {rp.permission.name}
                           </Badge>

--- a/src/pages/admin/roles/RolePermissions.tsx
+++ b/src/pages/admin/roles/RolePermissions.tsx
@@ -52,7 +52,7 @@ function RolePermissions() {
   }, {}) ?? {};
 
   useEffect(() => {
-    if (role) {
+    if (role?.permissions) {
       setSelected(role.permissions.map(rp => rp.permission.id));
     }
   }, [role]);


### PR DESCRIPTION
## Summary
- safeguard against undefined role permissions when listing roles
- guard role permissions effect

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e36d511b48326a5d7f8c84599bb7f