### PR TITLE
Fix line validation error in income/expense service

### DIFF
--- a/src/services/IncomeExpenseTransactionService.ts
+++ b/src/services/IncomeExpenseTransactionService.ts
@@ -115,7 +115,7 @@ export class IncomeExpenseTransactionService {
       source_id: line.source_id,
       account_id: line.accounts_account_id,
       header_id: headerId,
-      line: line.line ?? null,
+      line: line.line ?? undefined,
     };
   }
 


### PR DESCRIPTION
## Summary
- preserve undefined line numbers when creating entry objects

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686e44218b548326b8dc1e836342f1bc