### PR TITLE
Ensure sequential row numbering in entry lists

### DIFF
--- a/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseAddEdit.tsx
@@ -185,7 +185,13 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
     );
   }, [sources, categories, entryRecords]);
 
-  const visibleEntries = React.useMemo(() => entries.filter(e => !e.isDeleted), [entries]);
+  const visibleEntries = React.useMemo(
+    () =>
+      entries
+        .filter(e => !e.isDeleted)
+        .sort((a, b) => (a.line ?? 0) - (b.line ?? 0)),
+    [entries]
+  );
 
   const totalAmount = React.useMemo(
     () => visibleEntries.reduce((sum, e) => sum + Number(e.amount || 0), 0),
@@ -353,7 +359,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                 </tr>
               </thead>
               <tbody>
-                {entries.filter(e => !e.isDeleted).map((entry) => {
+                {visibleEntries.map((entry, idx) => {
                   const rowIndex = entries.indexOf(entry);
                   return (
                   <tr key={rowIndex} className="border-b border-border dark:border-slate-700">
@@ -361,7 +367,7 @@ function IncomeExpenseAddEdit({ transactionType }: IncomeExpenseAddEditProps) {
                       <Input
                         type="number"
                         readOnly
-                        value={entry.line ?? rowIndex + 1}
+                        value={idx + 1}
                         disabled={isDisabled}
                       />
                     </td>

--- a/tests/incomeExpenseAddEditLines.test.ts
+++ b/tests/incomeExpenseAddEditLines.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+interface Entry {
+  line?: number;
+  isDeleted?: boolean;
+}
+
+function getVisibleEntries(entries: Entry[]) {
+  return entries
+    .filter(e => !e.isDeleted)
+    .sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+}
+
+describe('IncomeExpenseAddEdit line numbers', () => {
+  it('returns sequential numbers after delete and add', () => {
+    const entries: Entry[] = [
+      { line: 1 },
+      { line: 2 },
+      { line: 3 }
+    ];
+
+    // delete first entry
+    entries[0].isDeleted = true;
+    let visible = getVisibleEntries(entries);
+    const afterDelete = visible.map((_, idx) => idx + 1);
+    expect(afterDelete).toEqual([1, 2]);
+
+    // add new entry
+    entries.push({ line: entries.filter(e => !e.isDeleted).length + 1 });
+    visible = getVisibleEntries(entries);
+    const afterAdd = visible.map((_, idx) => idx + 1);
+    expect(afterAdd).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary
- sort visibleEntries by `line`
- iterate over sorted entries to render row numbers sequentially
- add unit test verifying sequential line numbers when adding/removing entries

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6314ead483268c0fbca3c3348038