### PR TITLE
Wrap app with pathname provider

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,14 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { SettingsProvider } from './providers/SettingsProvider';
+import { PathnameProvider } from './providers/PathnameProvider';
 import './styles/globals.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <SettingsProvider>
-      <App />
+      <PathnameProvider>
+        <App />
+      </PathnameProvider>
     </SettingsProvider>
-  </StrictMode>
-);
+  </StrictMode>);


### PR DESCRIPTION
## Summary
- wrap the application with `PathnameProvider`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686e958cf9d48326944676817b75a666