### PR TITLE
Improve input and checkbox borders

### DIFF
--- a/src/components/ui2/checkbox.tsx
+++ b/src/components/ui2/checkbox.tsx
@@ -36,7 +36,7 @@ const Checkbox = React.forwardRef<
             ref={ref}
             id={inputId}
             className={cn(
-              'peer shrink-0 rounded-sm border border-input bg-light-light ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-muted dark:border-border',
+              'peer shrink-0 rounded-sm border border-gray-300 dark:border-border bg-light-light ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-muted',
               sizeClasses[size],
               error && 'border-destructive',
               className

--- a/src/components/ui2/input.tsx
+++ b/src/components/ui2/input.tsx
@@ -6,7 +6,7 @@ import { Eye, EyeOff, X } from 'lucide-react';
 import { FormFieldProps } from './types';
 
 const inputVariants = cva(
-  'flex w-full rounded-md border border-input bg-light-light px-3 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-muted dark:border-border dark:placeholder:text-muted-foreground',
+  'flex w-full rounded-md border border-gray-300 dark:border-border bg-light-light px-3 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-muted dark:placeholder:text-muted-foreground',
   {
     variants: {
       size: {


### PR DESCRIPTION
## Summary
- tweak `ui2` Input and Checkbox borders to use `border-gray-300` in light mode for better visibility

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686ea5c6f57483269f38a4d3e5a92bbf