### PR TITLE
Improve input and checkbox borders

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -37,7 +37,7 @@
   --destructive: 0 84% 60%;
   --destructive-foreground: 0 0% 100%;
   --border: 214 32% 91% / 0.8;
-  --input: 0 0% 100%;
+  --input: 214 32% 91%;
   --input-background: 0 0% 100%;
   --switch-background: hsl(214 32% 91%);
   --ring: 142 71% 45%;


### PR DESCRIPTION
## Summary
- tweak `ui2` Input and Checkbox borders to use the theme's default border color
- adjust the CSS variable `--input` so border-input uses gray in light mode

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686ea5c6f57483269f38a4d3e5a92bbf