### PR TITLE
Fix finance profile data handling

### DIFF
--- a/src/pages/finances/fiscal-years/FiscalYearAddEdit.tsx
+++ b/src/pages/finances/fiscal-years/FiscalYearAddEdit.tsx
@@ -19,8 +19,8 @@ function FiscalYearAddEdit() {
   const updateMutation = useUpdate();
 
   useEffect(() => {
-    if (isEditMode && data?.data?.[0]) {
-      setFormData(data.data[0]);
+    if (isEditMode && data) {
+      setFormData(data);
     }
   }, [isEditMode, data]);
 

--- a/src/pages/finances/fiscal-years/FiscalYearProfile.tsx
+++ b/src/pages/finances/fiscal-years/FiscalYearProfile.tsx
@@ -11,7 +11,7 @@ function FiscalYearProfile() {
   const navigate = useNavigate();
   const { useFindById } = useFiscalYearRepository();
   const { data, isLoading } = useFindById(id || '');
-  const year = data?.data?.[0];
+  const year = data;
 
   if (isLoading) {
     return (

--- a/src/pages/finances/opening-balances/OpeningBalanceAddEdit.tsx
+++ b/src/pages/finances/opening-balances/OpeningBalanceAddEdit.tsx
@@ -28,8 +28,8 @@ function OpeningBalanceAddEdit() {
   const { data: years } = useYearQuery();
 
   useEffect(() => {
-    if (isEditMode && balanceData?.data?.[0]) {
-      setFormData(balanceData.data[0]);
+    if (isEditMode && balanceData) {
+      setFormData(balanceData);
     }
   }, [isEditMode, balanceData]);
 

--- a/src/pages/finances/opening-balances/OpeningBalanceProfile.tsx
+++ b/src/pages/finances/opening-balances/OpeningBalanceProfile.tsx
@@ -11,7 +11,7 @@ function OpeningBalanceProfile() {
   const navigate = useNavigate();
   const { useFindById } = useOpeningBalanceRepository();
   const { data, isLoading } = useFindById(id || '');
-  const balance = data?.data?.[0];
+  const balance = data;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- update fiscal year and opening balance components to expect single object from `useFindById`
- load existing record data directly into form

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee148311c8326a07fe2af24823290