### PR TITLE
Expand financial transaction types

### DIFF
--- a/src/models/financialTransaction.model.ts
+++ b/src/models/financialTransaction.model.ts
@@ -3,7 +3,18 @@ import { Member } from './member.model';
 import { ChartOfAccount } from './chartOfAccount.model';
 import { FinancialTransactionHeader } from './financialTransactionHeader.model';
 
-export type TransactionType = 'income' | 'expense';
+export type TransactionType =
+  | 'income'
+  | 'expense'
+  | 'transfer'
+  | 'adjustment'
+  | 'opening_balance'
+  | 'closing_entry'
+  | 'fund_rollover'
+  | 'reversal'
+  | 'allocation'
+  | 'reclass'
+  | 'refund';
 
 export interface FinancialTransaction extends BaseModel {
   id: string;

--- a/src/pages/finances/budgets/BudgetProfile.tsx
+++ b/src/pages/finances/budgets/BudgetProfile.tsx
@@ -10,6 +10,7 @@ import { Button } from '../../../components/ui2/button';
 import BackButton from '../../../components/BackButton';
 import { Badge } from '../../../components/ui2/badge';
 import { Progress } from '../../../components/ui2/progress';
+import type { TransactionType } from '../../../models/financialTransaction.model';
 import {
   PiggyBank,
   Calendar,
@@ -37,7 +38,7 @@ type Budget = {
 
 type Transaction = {
   id: string;
-  type: 'income' | 'expense';
+  type: TransactionType;
   category_id: string;
   debit: number;
   credit: number;

--- a/src/stores/incomeExpenseFilterStore.ts
+++ b/src/stores/incomeExpenseFilterStore.ts
@@ -1,7 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-export type TransactionType = 'income' | 'expense';
+export type TransactionType =
+  | 'income'
+  | 'expense'
+  | 'transfer'
+  | 'adjustment'
+  | 'opening_balance'
+  | 'closing_entry'
+  | 'fund_rollover'
+  | 'reversal'
+  | 'allocation'
+  | 'reclass'
+  | 'refund';
 
 type DateRange = { from: Date; to: Date };
 

--- a/supabase/migrations/20250823000000_expand_transaction_types.sql
+++ b/supabase/migrations/20250823000000_expand_transaction_types.sql
@@ -1,0 +1,10 @@
+-- Expand financial_transaction_type enum for double-entry accounting
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'transfer';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'adjustment';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'opening_balance';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'closing_entry';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'fund_rollover';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'reversal';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'allocation';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'reclass';
+ALTER TYPE financial_transaction_type ADD VALUE IF NOT EXISTS 'refund';


### PR DESCRIPTION
## Summary
- extend `financial_transaction_type` enum
- update models and store with new transaction types
- allow budget page to understand the new `TransactionType`
- add migration for the enum changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686efac2477483268b8c2f45015b747e