### PR TITLE
Add super admin support in permissions

### DIFF
--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -90,7 +90,7 @@ export function usePermissions() {
   const hasPermission = (permissionCode: string) => {
     if (isLoading || !userData) return false;
 
-    if (userData.adminRole === 'tenant_admin') {
+    if (userData.adminRole === 'tenant_admin' || userData.adminRole === 'super_admin') {
       return true;
     }
 
@@ -106,7 +106,9 @@ export function usePermissions() {
     return (
       hasRole('admin') ||
       hasRole('tenant_admin') ||
-      userData?.adminRole === 'tenant_admin'
+      hasRole('super_admin') ||
+      userData?.adminRole === 'tenant_admin' ||
+      userData?.adminRole === 'super_admin'
     );
   };
 

--- a/tests/usePermissions.test.ts
+++ b/tests/usePermissions.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { usePermissions } from '../src/hooks/usePermissions';
+
+const useQueryMock = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: useQueryMock
+}));
+
+vi.mock('../src/stores/authStore', () => ({
+  useAuthStore: () => ({ user: { id: 'u1' } })
+}));
+
+vi.mock('../src/components/MessageHandler', () => ({
+  useMessageStore: () => ({ addMessage: vi.fn() })
+}));
+
+vi.mock('../src/utils/tenantUtils', () => ({
+  tenantUtils: { getTenantId: vi.fn() }
+}));
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: {}
+}));
+
+describe('usePermissions admin roles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hasPermission allows tenant_admin and super_admin', () => {
+    useQueryMock.mockReturnValue({ data: { permissions: [], roles: [], adminRole: 'tenant_admin' }, isLoading: false });
+    let perms = usePermissions();
+    expect(perms.hasPermission('any')).toBe(true);
+
+    useQueryMock.mockReturnValue({ data: { permissions: [], roles: [], adminRole: 'super_admin' }, isLoading: false });
+    perms = usePermissions();
+    expect(perms.hasPermission('any')).toBe(true);
+  });
+
+  it('isAdmin recognizes all admin roles', () => {
+    useQueryMock.mockReturnValue({ data: { permissions: [], roles: [{ role_name: 'super_admin' }], adminRole: null }, isLoading: false });
+    let perms = usePermissions();
+    expect(perms.isAdmin()).toBe(true);
+
+    useQueryMock.mockReturnValue({ data: { permissions: [], roles: [], adminRole: 'super_admin' }, isLoading: false });
+    perms = usePermissions();
+    expect(perms.isAdmin()).toBe(true);
+
+    useQueryMock.mockReturnValue({ data: { permissions: [], roles: [], adminRole: 'tenant_admin' }, isLoading: false });
+    perms = usePermissions();
+    expect(perms.isAdmin()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- allow `super_admin` in permission checks
- detect `super_admin` role in `isAdmin`
- add unit tests for both admin roles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f90dbdf348326a3013e29aba094ec