### PR TITLE
Move QueryClientProvider to main

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { queryClient } from './lib/queryClient';
 import { useAuthStore } from './stores/authStore';
 import { supabase } from './lib/supabase';
 import { MessageHandler } from './components/MessageHandler';
@@ -89,10 +87,9 @@ function App() {
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ErrorBoundary>
-        <Router>
-          <PathnameProvider>
+    <ErrorBoundary>
+      <Router>
+        <PathnameProvider>
             <React.Suspense
               fallback={
                 <div className="min-h-screen flex items-center justify-center">
@@ -155,8 +152,8 @@ function App() {
               </Routes>
             </React.Suspense>
           </PathnameProvider>
-        </Router>
-      </ErrorBoundary>
-    </QueryClientProvider>
-  );
-}export default App;
+          </Router>
+        </ErrorBoundary>
+    );
+ }
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,16 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { SettingsProvider } from './providers/SettingsProvider';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './lib/queryClient';
 import './styles/globals.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <SettingsProvider>
-      <App />
-    </SettingsProvider>  </StrictMode>);
+    <QueryClientProvider client={queryClient}>
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </QueryClientProvider>
+  </StrictMode>,
+);


### PR DESCRIPTION
## Summary
- wrap the application with `QueryClientProvider` in `main.tsx`
- remove the redundant react-query provider from `App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9f9f5b888326b9e9e492a163a654