### PR TITLE
Add super admin mode

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,6 +22,8 @@ import {
   ChevronDown
 } from 'lucide-react';
 import { navigation as baseNavigation, NavItem } from '../../config/navigation';
+import { superAdminNavigation } from '../../config/superAdminNavigation';
+import { useAdminModeStore } from '../../stores/adminModeStore';
 
 function Sidebar() {
   const {
@@ -92,9 +94,13 @@ function Sidebar() {
     return userRoles?.[0]?.role_name || 'User';
   }, [userRoles]);
 
-  const { data: navigation = baseNavigation } = useMenuItems(
+  const { superAdminMode } = useAdminModeStore();
+
+  const { data: dynamicNavigation = baseNavigation } = useMenuItems(
     userRoles?.map((r: any) => r.role_id) || []
   );
+
+  const navigation = superAdminMode ? superAdminNavigation : dynamicNavigation;
 
   const menuItemCount = useMemo(() => {
     let count = 0;

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -6,13 +6,16 @@ import {
   Sun,
   Moon,
   PanelLeft,
-  PanelLeftClose
+  PanelLeftClose,
+  Shield
 } from 'lucide-react';
 import { Button } from '../ui2/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '../ui2/dropdown-menu';
 import { Input } from '../ui2/input';
 import { useThemeSwitcher } from '@/hooks';
 import { useAuthStore } from '../../stores/authStore';
+import { usePermissions } from '../../hooks/usePermissions';
+import { useAdminModeStore } from '../../stores/adminModeStore';
 import { useNavigate } from 'react-router-dom';
 import ChurchBranding from '../ChurchBranding';
 import { SidebarTrigger, useSidebar } from '../ui2/sidebar';
@@ -22,6 +25,8 @@ import { cn } from '@/lib/utils';
 function Topbar() {
   const { collapsed, setCollapsed } = useSidebar();
   const { user, signOut } = useAuthStore();
+  const { hasRole } = usePermissions();
+  const { superAdminMode, toggleSuperAdminMode } = useAdminModeStore();
   const navigate = useNavigate();
   const { settings, handleThemeToggle } = useThemeSwitcher();
   // No direct notification listener here. The dropdown handles fetching
@@ -134,6 +139,17 @@ function Topbar() {
                 <User className="mr-2 h-4 w-4" />
                 <span>Profile</span>
               </DropdownMenuItem>
+              {hasRole('super_admin') && (
+                <DropdownMenuItem
+                  onClick={() => {
+                    toggleSuperAdminMode();
+                    navigate(!superAdminMode ? '/admin-panel/welcome' : '/welcome');
+                  }}
+                >
+                  <Shield className="mr-2 h-4 w-4" />
+                  <span>{superAdminMode ? 'Exit Super Admin Mode' : 'Super Admin Mode'}</span>
+                </DropdownMenuItem>
+              )}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={handleSignOut}>Log out</DropdownMenuItem>

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,2 +1,3 @@
 export * from './settings.config';
 export * from './navigation';
+export * from './superAdminNavigation';

--- a/src/config/superAdminNavigation.ts
+++ b/src/config/superAdminNavigation.ts
@@ -1,0 +1,47 @@
+import {
+  Home,
+  LayoutDashboard,
+  Building2,
+  BadgeCheck,
+  ListChecks,
+} from 'lucide-react';
+import type { NavItem } from './navigation';
+
+export const superAdminNavigation: NavItem[] = [
+  {
+    name: 'Welcome',
+    href: '/admin-panel/welcome',
+    icon: Home,
+    permission: null,
+    section: 'General',
+  },
+  {
+    name: 'Dashboard',
+    href: '/admin-panel/dashboard',
+    icon: LayoutDashboard,
+    permission: null,
+    section: 'General',
+  },
+  {
+    name: 'Tenants',
+    href: '/admin-panel/tenants',
+    icon: Building2,
+    permission: null,
+    section: 'Management',
+  },
+  {
+    name: 'License Plans',
+    href: '/admin-panel/license-plans',
+    icon: BadgeCheck,
+    permission: null,
+    section: 'Management',
+  },
+  {
+    name: 'Menus',
+    href: '/admin-panel/menus',
+    icon: ListChecks,
+    permission: null,
+    section: 'Management',
+  },
+];
+

--- a/src/pages/super-admin/SuperAdmin.tsx
+++ b/src/pages/super-admin/SuperAdmin.tsx
@@ -4,16 +4,18 @@ import Dashboard from './SuperAdminDashboard';
 import Tenants from './Tenants';
 import LicensePlans from './LicensePlans';
 import MenuManagement from './MenuManagement';
+import SuperAdminWelcome from './SuperAdminWelcome';
 
 function SuperAdmin() {
   return (
     <Routes>
-      <Route index element={<Dashboard />} />
+      <Route index element={<SuperAdminWelcome />} />
+      <Route path="welcome" element={<SuperAdminWelcome />} />
       <Route path="dashboard" element={<Dashboard />} />
       <Route path="tenants/*" element={<Tenants />} />
       <Route path="license-plans/*" element={<LicensePlans />} />
       <Route path="menus" element={<MenuManagement />} />
-      <Route path="*" element={<Navigate to="dashboard" replace />} />
+      <Route path="*" element={<Navigate to="welcome" replace />} />
     </Routes>
   );
 }

--- a/src/pages/super-admin/SuperAdminWelcome.tsx
+++ b/src/pages/super-admin/SuperAdminWelcome.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui2/card';
+
+function SuperAdminWelcome() {
+  return (
+    <div className="space-y-6 w-full px-4 sm:px-6 lg:px-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Welcome Super Admin</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">
+            Use the navigation to manage tenants, license plans and menus.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default SuperAdminWelcome;
+

--- a/src/stores/adminModeStore.ts
+++ b/src/stores/adminModeStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface AdminModeState {
+  superAdminMode: boolean;
+  toggleSuperAdminMode: () => void;
+  setSuperAdminMode: (value: boolean) => void;
+}
+
+export const useAdminModeStore = create<AdminModeState>()(
+  persist(
+    (set) => ({
+      superAdminMode: false,
+      toggleSuperAdminMode: () =>
+        set((state) => ({ superAdminMode: !state.superAdminMode })),
+      setSuperAdminMode: (value) => set({ superAdminMode: value }),
+    }),
+    { name: 'admin-mode' }
+  )
+);
+


### PR DESCRIPTION
## Summary
- expose super admin navigation
- show super admin only navigation in the sidebar
- add toggle for super admin mode in user menu
- create a welcome page for super admins

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fa373424c832685fd5e00d2add9ad