### PR TITLE
Update admin mode on layout change

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './layout/Sidebar';
 import Topbar from './layout/Topbar';
 import Footer from './Footer';
 import { SidebarProvider, useSidebar } from './ui2/sidebar';
 import { cn } from '@/lib/utils';
+import { useAdminModeStore } from '../stores/adminModeStore';
 
 function LayoutContent() {
   const { collapsed } = useSidebar();
   const location = useLocation();
+  const { setSuperAdminMode } = useAdminModeStore();
+
+  useEffect(() => {
+    setSuperAdminMode(location.pathname.startsWith('/admin-panel'));
+  }, [location.pathname, setSuperAdminMode]);
 
   // Check if current page is settings
   const isSettingsPage = location.pathname.startsWith('/settings');


### PR DESCRIPTION
## Summary
- import `useAdminModeStore` in layout
- update super admin mode when routing to admin panel

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fa8456ae08326b7b7edf210ef7bb6