### PR TITLE
Update Layout to auto enable super admin mode

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,15 +6,21 @@ import Footer from './Footer';
 import { SidebarProvider, useSidebar } from './ui2/sidebar';
 import { cn } from '@/lib/utils';
 import { useAdminModeStore } from '../stores/adminModeStore';
+import { usePermissions } from '../hooks/usePermissions';
 
 function LayoutContent() {
   const { collapsed } = useSidebar();
   const location = useLocation();
   const { setSuperAdminMode } = useAdminModeStore();
+  const { hasRole } = usePermissions();
 
   useEffect(() => {
-    setSuperAdminMode(location.pathname.startsWith('/admin-panel'));
-  }, [location.pathname, setSuperAdminMode]);
+    if (hasRole('super_admin')) {
+      setSuperAdminMode(true);
+    } else {
+      setSuperAdminMode(location.pathname.startsWith('/admin-panel'));
+    }
+  }, [location.pathname, hasRole, setSuperAdminMode]);
 
   // Check if current page is settings
   const isSettingsPage = location.pathname.startsWith('/settings');


### PR DESCRIPTION
## Summary
- import permissions hook in Layout
- enable super admin mode automatically when user has the role

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run lint --silent` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686facf6bf28832684c0cc778aeb5734