### PR TITLE
Enable super admin tenant access

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ A helper function `can_user(permission text)` allows the frontend to quickly ver
 ## Changelog
 
 - Dates are now stored and parsed using local `yyyy-MM-dd` format instead of ISO strings.
+- Super admins can now query data across all tenants.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from './expenseSummaryPdf';
 export * from './churchFinancialStatementPdf';
 export * from './memberUtils';
 export * from './access';
+export * from './userRoleUtils';

--- a/src/utils/userRoleUtils.ts
+++ b/src/utils/userRoleUtils.ts
@@ -1,0 +1,72 @@
+import { supabase } from '../lib/supabase';
+
+export interface UserRoleDataProvider {
+  fetchIsSuperAdmin(): Promise<boolean>;
+}
+
+class SupabaseUserRoleDataProvider implements UserRoleDataProvider {
+  async fetchIsSuperAdmin(): Promise<boolean> {
+    const { data, error } = await supabase.rpc('is_super_admin');
+    if (error) throw error;
+    return data === true;
+  }
+}
+
+export class UserRoleUtils {
+  private static instance: UserRoleUtils;
+  private isSuperAdminCache: boolean | null = null;
+  private lastFetch = 0;
+  private readonly CACHE_DURATION =
+    parseInt(import.meta.env.VITE_ROLE_CACHE_DURATION_MS) || 5 * 60 * 1000;
+  private fetchPromise: Promise<boolean> | null = null;
+
+  private constructor(private provider: UserRoleDataProvider = new SupabaseUserRoleDataProvider()) {}
+
+  public static getInstance(provider: UserRoleDataProvider = new SupabaseUserRoleDataProvider()): UserRoleUtils {
+    if (!UserRoleUtils.instance) {
+      UserRoleUtils.instance = new UserRoleUtils(provider);
+    }
+    return UserRoleUtils.instance;
+  }
+
+  public async isSuperAdmin(forceRefresh = false): Promise<boolean> {
+    const now = Date.now();
+
+    if (
+      !forceRefresh &&
+      this.isSuperAdminCache !== null &&
+      now - this.lastFetch < this.CACHE_DURATION
+    ) {
+      return this.isSuperAdminCache;
+    }
+
+    if (this.fetchPromise) {
+      return this.fetchPromise;
+    }
+
+    this.fetchPromise = this.provider
+      .fetchIsSuperAdmin()
+      .then(result => {
+        this.isSuperAdminCache = result;
+        this.lastFetch = now;
+        return result;
+      })
+      .catch(error => {
+        console.error('Error checking super admin:', error);
+        return false;
+      })
+      .finally(() => {
+        this.fetchPromise = null;
+      });
+
+    return this.fetchPromise;
+  }
+
+  public clearCache(): void {
+    this.isSuperAdminCache = null;
+    this.lastFetch = 0;
+    this.fetchPromise = null;
+  }
+}
+
+export const userRoleUtils = UserRoleUtils.getInstance();

--- a/tests/superAdminAccess.test.ts
+++ b/tests/superAdminAccess.test.ts
@@ -1,5 +1,34 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queryChain = {
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  range: vi.fn().mockReturnThis(),
+  then: vi.fn((resolve) => Promise.resolve({ data: [], error: null, count: 0 }).then(resolve))
+};
+
+vi.mock('../src/utils/tenantUtils', () => ({
+  tenantUtils: { getTenantId: vi.fn() }
+}));
+
+vi.mock('../src/utils/userRoleUtils', () => ({
+  userRoleUtils: { isSuperAdmin: vi.fn() }
+}));
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: { from: vi.fn(() => queryChain) }
+}));
+
 import { computeAccess } from '../src/utils/access';
+import { BaseAdapter } from '../src/adapters/base.adapter';
+import { tenantUtils } from '../src/utils/tenantUtils';
+import { userRoleUtils } from '../src/utils/userRoleUtils';
+
+class TestAdapter extends BaseAdapter<any> {
+  protected tableName = 'items';
+}
 
 describe('super admin access', () => {
   it('grants access when user is super admin', () => {
@@ -11,5 +40,31 @@ describe('super admin access', () => {
       true
     );
     expect(allowed).toBe(true);
+  });
+});
+
+describe('BaseAdapter fetch super admin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips tenant filter when super admin', async () => {
+    (tenantUtils.getTenantId as any).mockResolvedValue(null);
+    (userRoleUtils.isSuperAdmin as any).mockResolvedValue(true);
+
+    const adapter = new TestAdapter();
+    await adapter.fetch();
+
+    expect(queryChain.eq).not.toHaveBeenCalledWith('tenant_id', expect.anything());
+  });
+
+  it('applies tenant filter for regular user', async () => {
+    (tenantUtils.getTenantId as any).mockResolvedValue('t1');
+    (userRoleUtils.isSuperAdmin as any).mockResolvedValue(false);
+
+    const adapter = new TestAdapter();
+    await adapter.fetch();
+
+    expect(queryChain.eq).toHaveBeenCalledWith('tenant_id', 't1');
   });
 });


### PR DESCRIPTION
## Summary
- add `userRoleUtils` to cache `is_super_admin` RPC calls
- use `userRoleUtils` in `BaseAdapter` and skip tenant filter when super admin
- export new util
- test super admin fetch behaviour
- document new super admin ability

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb806e8f083269fb9c358fce4fa2c