### PR TITLE
Fix Layout useEffect dependency

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,14 +13,15 @@ function LayoutContent() {
   const location = useLocation();
   const { setSuperAdminMode } = useAdminModeStore();
   const { isSuperAdmin } = usePermissions();
+  const isSuper = isSuperAdmin();
 
   useEffect(() => {
-    if (isSuperAdmin()) {
+    if (isSuper) {
       setSuperAdminMode(true);
     } else {
       setSuperAdminMode(location.pathname.startsWith('/admin-panel'));
     }
-  }, [location.pathname, isSuperAdmin, setSuperAdminMode]);
+  }, [location.pathname, isSuper, setSuperAdminMode]);
 
   // Check if current page is settings
   const isSettingsPage = location.pathname.startsWith('/settings');


### PR DESCRIPTION
## Summary
- compute a boolean `isSuper` from `isSuperAdmin()`
- use `isSuper` in the `useEffect` dependency list

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686fbdc50a8c832695bf0b0532042773