### PR TITLE
Add sitemap and robots files

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <title>Steward Track</title>
   </head>
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/</loc></url>
+  <url><loc>/login</loc></url>
+  <url><loc>/register</loc></url>
+  <url><loc>/register-member</loc></url>
+  <url><loc>/member-onboarding</loc></url>
+  <url><loc>/onboarding</loc></url>
+  <url><loc>/welcome</loc></url>
+  <url><loc>/activity</loc></url>
+  <url><loc>/dashboard</loc></url>
+  <url><loc>/members</loc></url>
+  <url><loc>/finances</loc></url>
+  <url><loc>/expenses</loc></url>
+  <url><loc>/offerings</loc></url>
+  <url><loc>/accounts</loc></url>
+  <url><loc>/announcements</loc></url>
+  <url><loc>/support</loc></url>
+  <url><loc>/admin</loc></url>
+  <url><loc>/administration</loc></url>
+  <url><loc>/admin-panel</loc></url>
+  <url><loc>/settings</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add `public/robots.txt` that references the sitemap
- generate `public/sitemap.xml` with top-level routes
- link the sitemap from `index.html`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687037264554832694f3d82ce6369ff3