### PR TITLE
Implement RequireAuth redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { handleError } from './utils/errorHandler';
 import { PathnameProvider } from './providers';
 import { usePermissions } from './hooks/usePermissions';
 import { useAdminModeStore } from './stores/adminModeStore';
+import RequireAuth from './components/RequireAuth';
 
 // Lazy load components
 const Login = React.lazy(() => import('./pages/auth/Login'));
@@ -132,8 +133,7 @@ function App() {
               />
 
               {/* Protected routes */}
-              {user ? (
-                <Route element={<Layout />}>
+              <Route element={<RequireAuth><Layout /></RequireAuth>}>
                   {superAdminMode && isSuperAdmin() ? (
                     <>
                       <Route path="/admin-panel/*" element={<SuperAdmin />} />
@@ -163,10 +163,8 @@ function App() {
                       <Route path="*" element={<Navigate to="/welcome" replace />} />
                     </>
                   )}
-                </Route>
-              ) : (
-                <Route path="*" element={<Navigate to="/" replace />} />
-              )}
+              </Route>
+              {!user && <Route path="*" element={<Navigate to="/" replace />} />}
               </Routes>
             </React.Suspense>
           </PathnameProvider>

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../stores/authStore';
+
+interface RequireAuthProps {
+  children: JSX.Element;
+}
+
+export default function RequireAuth({ children }: RequireAuthProps) {
+  const { user } = useAuthStore();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+}

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../components/ui2/card';
 import { Input } from '../../components/ui2/input';
@@ -21,6 +21,8 @@ function Login() {
   const [error, setError] = useState<string | null>(null);
   const [resetMode, setResetMode] = useState(false);
   const [resetSuccess, setResetSuccess] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,6 +36,8 @@ function Login() {
       });
 
       if (error) throw error;
+      const from = (location.state as any)?.from?.pathname || '/welcome';
+      navigate(from, { replace: true });
     } catch (error) {
       setError(error instanceof Error ? error.message : 'An error occurred');
     } finally {


### PR DESCRIPTION
## Summary
- add `RequireAuth` to capture attempted url
- wrap protected routes with `RequireAuth`
- redirect to previous path after successful login

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d14bb69483269c4d45929b3a5ed2