### PR TITLE
Use hsl colors for mui grid and printable report

### DIFF
--- a/src/components/ui2/PrintableReport.tsx
+++ b/src/components/ui2/PrintableReport.tsx
@@ -115,8 +115,8 @@ export function PrintableReport({ title, content, footer }: PrintableReportProps
           header {
             -webkit-print-color-adjust: exact !important;
             print-color-adjust: exact !important;
-            background-color: var(--primary) !important;
-            color: var(--primary-foreground) !important;
+            background-color: hsl(var(--primary)) !important;
+            color: hsl(var(--primary-foreground)) !important;
           }
         }
 
@@ -129,23 +129,23 @@ export function PrintableReport({ title, content, footer }: PrintableReportProps
         }
 
         .report-table th {
-          background-color: var(--background);
+          background-color: hsl(var(--background));
           padding: 0.75rem 1rem;
           text-align: left;
           font-weight: 600;
-          color: var(--muted-foreground);
-          border-bottom: 2px solid var(--border);
+          color: hsl(var(--muted-foreground));
+          border-bottom: 2px solid hsl(var(--border));
           white-space: nowrap;
         }
 
         .report-table td {
           padding: 0.75rem 1rem;
-          border-bottom: 1px solid var(--border);
+          border-bottom: 1px solid hsl(var(--border));
           vertical-align: middle;
         }
 
         .report-table tr:nth-child(even) {
-          background-color: var(--background);
+          background-color: hsl(var(--background));
         }
 
         .report-table .amount {
@@ -156,18 +156,18 @@ export function PrintableReport({ title, content, footer }: PrintableReportProps
 
         .report-table .total-row {
           font-weight: 600;
-          background-color: var(--muted);
+          background-color: hsl(var(--muted));
         }
 
         .report-table .total-row td {
-          border-top: 2px solid var(--border);
-          border-bottom: 2px solid var(--border);
+          border-top: 2px solid hsl(var(--border));
+          border-bottom: 2px solid hsl(var(--border));
         }
 
         /* Progress bar styles */
         .progress-bar {
           height: 0.5rem;
-          background-color: var(--border);
+          background-color: hsl(var(--border));
           border-radius: 9999px;
           overflow: hidden;
         }
@@ -178,9 +178,9 @@ export function PrintableReport({ title, content, footer }: PrintableReportProps
           transition: width 0.3s ease;
         }
 
-        .progress-bar-fill.success { background-color: var(--success); }
-        .progress-bar-fill.warning { background-color: var(--chart-4); }
-        .progress-bar-fill.danger { background-color: var(--destructive); }
+        .progress-bar-fill.success { background-color: hsl(var(--success)); }
+        .progress-bar-fill.warning { background-color: hsl(var(--chart-4)); }
+        .progress-bar-fill.danger { background-color: hsl(var(--destructive)); }
       `}</style>
     </div>
   );

--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -39,61 +39,61 @@ export interface DataGridProps<T> extends Omit<MuiDataGridProps<T>, 'rows'> {
 // Style the DataGrid to match our theme
 const StyledDataGrid = styled(MuiDataGrid)(({ theme }) => ({
   border: 'none',
-  backgroundColor: 'var(--background)',
-  color: 'var(--foreground)',
+  backgroundColor: 'hsl(var(--background))',
+  color: 'hsl(var(--foreground))',
   fontFamily: 'var(--font-sans)',
   borderRadius: 'var(--radius)',
   boxShadow: 'var(--tw-card-box-shadow)',
 
   '& .MuiDataGrid-main': {
-    backgroundColor: 'var(--background)',
+    backgroundColor: 'hsl(var(--background))',
   },
 
   '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: 'var(--secondary)',
-    borderBottom: '1px solid var(--border)',
-    color: 'var(--secondary-foreground)',
+    backgroundColor: 'hsl(var(--secondary))',
+    borderBottom: '1px solid hsl(var(--border))',
+    color: 'hsl(var(--secondary-foreground))',
     fontSize: '0.875rem',
     fontWeight: 600,
   },
 
   '& .MuiDataGrid-cell': {
-    borderBottom: '1px solid var(--border)',
-    color: 'var(--foreground)',
+    borderBottom: '1px solid hsl(var(--border))',
+    color: 'hsl(var(--foreground))',
     fontSize: '0.875rem',
   },
 
   '& .MuiDataGrid-row': {
     '&:hover': {
-      backgroundColor: 'var(--muted)',
+      backgroundColor: 'hsl(var(--muted))',
     },
     '&.Mui-selected': {
-      backgroundColor: 'var(--primary)',
-      color: 'var(--primary-foreground)',
+      backgroundColor: 'hsl(var(--primary))',
+      color: 'hsl(var(--primary-foreground))',
       '&:hover': {
-        backgroundColor: 'var(--primary)',
+        backgroundColor: 'hsl(var(--primary))',
       },
     },
   },
 
   '& .MuiDataGrid-footerContainer': {
-    borderTop: '1px solid var(--border)',
-    backgroundColor: 'var(--background)',
+    borderTop: '1px solid hsl(var(--border))',
+    backgroundColor: 'hsl(var(--background))',
   },
 
   '& .MuiTablePagination-root': {
-    color: 'var(--foreground)',
+    color: 'hsl(var(--foreground))',
   },
 
   '& .MuiDataGrid-toolbarContainer': {
     padding: theme.spacing(2),
-    backgroundColor: 'var(--background)',
-    borderBottom: '1px solid var(--border)',
+    backgroundColor: 'hsl(var(--background))',
+    borderBottom: '1px solid hsl(var(--border))',
     
     '& .MuiButton-root': {
-      color: 'var(--muted-foreground)',
+      color: 'hsl(var(--muted-foreground))',
       '&:hover': {
-        backgroundColor: 'var(--accent)',
+        backgroundColor: 'hsl(var(--accent))',
       },
     },
     
@@ -104,15 +104,15 @@ const StyledDataGrid = styled(MuiDataGrid)(({ theme }) => ({
   },
 
   '& .MuiDataGrid-menuIcon': {
-    color: 'var(--muted-foreground)',
+    color: 'hsl(var(--muted-foreground))',
   },
 
   '& .MuiDataGrid-sortIcon': {
-    color: 'var(--muted-foreground)',
+    color: 'hsl(var(--muted-foreground))',
   },
 
   '& .MuiDataGrid-filterIcon': {
-    color: 'var(--muted-foreground)',
+    color: 'hsl(var(--muted-foreground))',
   },
 
   // Quick filter input inherits shared input styles via className


### PR DESCRIPTION
## Summary
- normalize color variables in DataGrid
- adjust PrintableReport colors to use `hsl(var(--*))`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870daa045b08326a776246e4db08ad3