### PR TITLE
Update date range UI2 for improved labels and navigation

### DIFF
--- a/src/components/ui2/calendar.tsx
+++ b/src/components/ui2/calendar.tsx
@@ -1,6 +1,6 @@
 // src/components/ui2/calendar.tsx
 import * as React from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 import { cn } from "@/lib/utils";
 import { buttonVariants } from "./button";
@@ -22,6 +22,9 @@ function Calendar({
         month: 'space-y-4',
         caption: 'flex items-center justify-between pt-1',
         caption_label: 'text-sm font-medium',
+        caption_dropdowns: 'flex items-center gap-2',
+        dropdown: 'rounded-md border border-input bg-background py-1 pl-2 pr-6 text-sm focus:outline-none dark:bg-muted dark:border-border',
+        dropdown_icon: 'absolute right-2 h-4 w-4 text-muted-foreground',
         nav: 'flex items-center gap-1',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),
@@ -57,10 +60,10 @@ function Calendar({
       }}
       components={{
         IconLeft: ({ className, ...props }) => (
-          <ChevronLeft className={cn('h-4 w-4', className)} {...props} />
+          <ChevronsLeft className={cn('h-4 w-4', className)} {...props} />
         ),
         IconRight: ({ className, ...props }) => (
-          <ChevronRight className={cn('h-4 w-4', className)} {...props} />
+          <ChevronsRight className={cn('h-4 w-4', className)} {...props} />
         )
       }}
       {...props}

--- a/src/components/ui2/date-range-picker.tsx
+++ b/src/components/ui2/date-range-picker.tsx
@@ -324,21 +324,23 @@ export function DateRangePicker({
               </div>
             )}
             <div className="p-2 sm:p-3">
-              <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-3">
+              <div className="flex flex-col sm:flex-row sm:items-end gap-2 mb-3">
                 <Input
                   type="text"
                   value={fromInput}
                   placeholder="From"
                   onChange={handleFromInputChange}
                   className="w-full sm:w-[150px] dark:bg-muted dark:border-border"
+                  label="From"
                 />
-                <span className="text-sm text-muted-foreground">to</span>
+                <span className="text-sm text-muted-foreground sm:mb-2">to</span>
                 <Input
                   type="text"
                   value={toInput}
                   placeholder="To"
                   onChange={handleToInputChange}
                   className="w-full sm:w-[150px] dark:bg-muted dark:border-border"
+                  label="To"
                 />
               </div>
               <Calendar


### PR DESCRIPTION
## Summary
- add `From`/`To` labels inside the date range picker fields
- tweak calendar caption layout spacing and add dropdown styles
- switch month/year navigation buttons to use chevron icons with double arrows

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e31610108326851d499ee635c266