### PR TITLE
Fix ui2 date range inputs

### DIFF
--- a/src/components/ui2/calendar.tsx
+++ b/src/components/ui2/calendar.tsx
@@ -24,7 +24,7 @@ function Calendar({
         caption_label: 'text-sm font-medium',
         caption_dropdowns: 'flex items-center gap-2',
         dropdown: 'rounded-md border border-input bg-background py-1 pl-2 pr-6 text-sm focus:outline-none dark:bg-muted dark:border-border',
-        dropdown_icon: 'absolute right-2 h-4 w-4 text-muted-foreground',
+        dropdown_icon: '',
         nav: 'flex items-center gap-1',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),

--- a/src/components/ui2/date-range-picker.tsx
+++ b/src/components/ui2/date-range-picker.tsx
@@ -332,8 +332,8 @@ export function DateRangePicker({
                   onChange={handleFromInputChange}
                   className="w-full sm:w-[150px] dark:bg-muted dark:border-border"
                   label="From"
+                  icon={<CalendarIcon className="h-4 w-4" />}
                 />
-                <span className="text-sm text-muted-foreground sm:mb-2">to</span>
                 <Input
                   type="text"
                   value={toInput}
@@ -341,6 +341,7 @@ export function DateRangePicker({
                   onChange={handleToInputChange}
                   className="w-full sm:w-[150px] dark:bg-muted dark:border-border"
                   label="To"
+                  icon={<CalendarIcon className="h-4 w-4" />}
                 />
               </div>
               <Calendar


### PR DESCRIPTION
## Summary
- add calendar icons in date range inputs
- remove extra `to` label
- hide duplicate dropdown arrows on calendar

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ec0cdfd08326a79f830246980743