### PR TITLE
Fix React Query focus refetch

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -5,7 +5,8 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 1,
-      refetchOnWindowFocus: false,
+      // React Query v5 uses string literals; "never" disables refetch on focus
+      refetchOnWindowFocus: 'never',
       refetchOnReconnect: false,
       staleTime: 5 * 60 * 1000, // Data considered fresh for 5 minutes
       onError: (error) => handleError(error),


### PR DESCRIPTION
## Summary
- disable refetching on window focus for React Query v5
- document why string literal is used for `refetchOnWindowFocus`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68714f3796dc83268063c21e9949cec1