### PR TITLE
Update query client defaults

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -7,8 +7,8 @@ export const queryClient = new QueryClient({
       retry: 1,
       // React Query v5 uses string literals; "never" disables refetch on focus
       refetchOnWindowFocus: 'never',
-      refetchOnReconnect: false,
-      staleTime: 5 * 60 * 1000, // Data considered fresh for 5 minutes
+      refetchOnReconnect: 'never',
+      staleTime: 60 * 60 * 1000, // Data considered fresh for 1 hour
       onError: (error) => handleError(error),
     },
     mutations: {


### PR DESCRIPTION
## Summary
- extend data staleness to one hour
- prevent refetch on reconnect using `"never"`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715a63941083269fcdedbbde703af8