### PR TITLE
Add optional color bar to metric cards

### DIFF
--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -18,6 +18,10 @@ interface MetricCardProps {
    * Optional CSS classes for the sub label element.
    */
   subtextClassName?: string;
+  /**
+   * Optional CSS classes for the bottom color barline.
+   */
+  barClassName?: string;
 }
 
 export default function MetricCard({
@@ -27,6 +31,7 @@ export default function MetricCard({
   iconClassName,
   subtext,
   subtextClassName,
+  barClassName,
 }: MetricCardProps) {
   return (
     <Card
@@ -47,6 +52,11 @@ export default function MetricCard({
         <p className={cn('mt-1 text-sm text-gray-500 dark:text-gray-400', subtextClassName)}>
           {subtext}
         </p>
+      )}
+      {barClassName && (
+        <div
+          className={cn('absolute bottom-0 left-0 right-0 h-1 rounded-b-2xl', barClassName)}
+        />
       )}
     </Card>
   );

--- a/src/pages/expenses/ExpensesDashboard.tsx
+++ b/src/pages/expenses/ExpensesDashboard.tsx
@@ -191,6 +191,7 @@ function ExpensesDashboard() {
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisMonthTotal.toFixed(2)}` : metrics.thisMonthTotal.toFixed(2),
       icon: DollarSign,
       iconClassName: 'text-success',
+      barClassName: 'bg-success',
       subtext: `${metrics.monthChange.toFixed(1)}% from last month`,
       subtextClassName: 'text-success/70',
     },
@@ -199,6 +200,7 @@ function ExpensesDashboard() {
       value: metrics.payeeCount,
       icon: Users,
       iconClassName: 'text-primary',
+      barClassName: 'bg-primary',
       subtext: 'Active payees',
       subtextClassName: 'text-primary/70',
     },
@@ -207,6 +209,7 @@ function ExpensesDashboard() {
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.thisWeekTotal.toFixed(2)}` : metrics.thisWeekTotal.toFixed(2),
       icon: Calendar,
       iconClassName: 'text-info',
+      barClassName: 'bg-info',
       subtext: `From ${metrics.weekCount} expenses`,
       subtextClassName: 'text-info/70',
     },
@@ -215,6 +218,7 @@ function ExpensesDashboard() {
       value: metrics.currency ? `${metrics.currency.symbol}${metrics.avgExpense.toFixed(2)}` : metrics.avgExpense.toFixed(2),
       icon: HandCoins,
       iconClassName: 'text-warning',
+      barClassName: 'bg-warning',
       subtext: 'Per transaction',
       subtextClassName: 'text-warning/70',
     },
@@ -258,6 +262,7 @@ function ExpensesDashboard() {
                 value={h.value}
                 icon={h.icon}
                 iconClassName={h.iconClassName}
+                barClassName={h.barClassName}
                 subtext={h.subtext}
                 subtextClassName={h.subtextClassName}
               />

--- a/src/pages/finances/FinancialOverviewDashboard.tsx
+++ b/src/pages/finances/FinancialOverviewDashboard.tsx
@@ -352,6 +352,7 @@ function FinancialOverviewDashboard() {
               value={formatCurrency(totalIncome, currency)}
               icon={TrendingUp}
               iconClassName="text-success"
+              barClassName="bg-success"
               subtext={`${incomeChange.toFixed(1)}% from last month`}
               subtextClassName={incomeChangeColor}
             />
@@ -360,6 +361,7 @@ function FinancialOverviewDashboard() {
               value={formatCurrency(totalExpenses, currency)}
               icon={TrendingDown}
               iconClassName="text-destructive"
+              barClassName="bg-destructive"
               subtext={`${expenseChange.toFixed(1)}% from last month`}
               subtextClassName={expenseChangeColor}
             />
@@ -368,6 +370,7 @@ function FinancialOverviewDashboard() {
               value={formatCurrency(netIncome, currency)}
               icon={Banknote}
               iconClassName={netIncome >= 0 ? 'text-success' : 'text-destructive'}
+              barClassName={netIncome >= 0 ? 'bg-success' : 'bg-destructive'}
               subtext={`${netChange.toFixed(1)}% from last month`}
               subtextClassName={netChangeColor}
             />
@@ -376,6 +379,7 @@ function FinancialOverviewDashboard() {
               value={`${expenseRatio.toFixed(1)}%`}
               icon={Percent}
               iconClassName="text-warning"
+              barClassName="bg-warning"
               subtext={getExpenseRating(expenseRatio)}
               subtextClassName="text-warning/70"
             />

--- a/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
+++ b/src/pages/finances/incomeExpense/IncomeExpenseList.tsx
@@ -198,30 +198,35 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
         value: statusCounts.draft,
         icon: FileText,
         iconClassName: "text-secondary",
+        barClassName: "bg-secondary",
       },
       {
         name: "Submitted",
         value: statusCounts.submitted,
         icon: FileText,
         iconClassName: "text-info",
+        barClassName: "bg-info",
       },
       {
         name: "Approved",
         value: statusCounts.approved,
         icon: Check,
         iconClassName: "text-warning",
+        barClassName: "bg-warning",
       },
       {
         name: "Posted",
         value: statusCounts.posted,
         icon: Check,
         iconClassName: "text-success",
+        barClassName: "bg-success",
       },
       {
         name: "Voided",
         value: statusCounts.voided,
         icon: X,
         iconClassName: "text-destructive",
+        barClassName: "bg-destructive",
       },
     ],
     [statusCounts],
@@ -594,6 +599,7 @@ function IncomeExpenseList({ transactionType }: IncomeExpenseListProps) {
             value={m.value}
             icon={m.icon}
             iconClassName={m.iconClassName}
+            barClassName={m.barClassName}
           />
         ))}
       </div>

--- a/src/pages/members/MembersDashboard.tsx
+++ b/src/pages/members/MembersDashboard.tsx
@@ -145,6 +145,7 @@ function MembersDashboard() {
       value: totalMembers || 0,
       icon: Users,
       iconClassName: "text-primary",
+      barClassName: "bg-primary",
       subtext: "Active members",
       subtextClassName: "text-primary/70",
     },
@@ -153,6 +154,7 @@ function MembersDashboard() {
       value: newMembers || 0,
       icon: UserPlus,
       iconClassName: "text-success",
+      barClassName: "bg-success",
       subtext: "Joined this month",
       subtextClassName: "text-success/70",
     },
@@ -161,6 +163,7 @@ function MembersDashboard() {
       value: visitorCount || 0,
       icon: UserCheck,
       iconClassName: "text-info",
+      barClassName: "bg-info",
       subtext: "Current visitors",
       subtextClassName: "text-info/70",
     },
@@ -169,6 +172,7 @@ function MembersDashboard() {
       value: familyCount || 0,
       icon: Heart,
       iconClassName: "text-warning",
+      barClassName: "bg-warning",
       subtext: "Family groups",
       subtextClassName: "text-warning/70",
     },
@@ -226,6 +230,7 @@ function MembersDashboard() {
             value={h.value}
             icon={h.icon}
             iconClassName={h.iconClassName}
+            barClassName={h.barClassName}
             subtext={h.subtext}
             subtextClassName={h.subtextClassName}
           />

--- a/src/pages/offerings/OfferingsDashboard.tsx
+++ b/src/pages/offerings/OfferingsDashboard.tsx
@@ -191,6 +191,7 @@ function OfferingsDashboard() {
       value: formatCurrency(metrics.thisMonthTotal, currency),
       icon: DollarSign,
       iconClassName: 'text-success',
+      barClassName: 'bg-success',
       subtext: `${metrics.monthChange.toFixed(1)}% from last month`,
       subtextClassName: 'text-success/70',
     },
@@ -199,6 +200,7 @@ function OfferingsDashboard() {
       value: metrics.donorCount,
       icon: Users,
       iconClassName: 'text-primary',
+      barClassName: 'bg-primary',
       subtext: 'Active contributors',
       subtextClassName: 'text-primary/70',
     },
@@ -207,6 +209,7 @@ function OfferingsDashboard() {
       value: formatCurrency(metrics.thisWeekTotal, currency),
       icon: Calendar,
       iconClassName: 'text-info',
+      barClassName: 'bg-info',
       subtext: `From ${metrics.weekCount} donations`,
       subtextClassName: 'text-info/70',
     },
@@ -215,6 +218,7 @@ function OfferingsDashboard() {
       value: formatCurrency(metrics.avgDonation, currency),
       icon: HandCoins,
       iconClassName: 'text-warning',
+      barClassName: 'bg-warning',
       subtext: 'Per contribution',
       subtextClassName: 'text-warning/70',
     },
@@ -258,6 +262,7 @@ function OfferingsDashboard() {
                 value={h.value}
                 icon={h.icon}
                 iconClassName={h.iconClassName}
+                barClassName={h.barClassName}
                 subtext={h.subtext}
                 subtextClassName={h.subtextClassName}
               />


### PR DESCRIPTION
## Summary
- support `barClassName` prop in `MetricCard`
- style metrics with colored bottom bars in dashboard pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687530774d90832693c43e870093d99b