### PR TITLE
Change sidebar gradient to darker tones

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -396,7 +396,7 @@ module.exports = {
       },
       backgroundImage: {
         'primary-gradient':
-          'linear-gradient(to bottom, #4ADE80, #15803D)'
+          'linear-gradient(to bottom, #22C55E, #166534)'
       },
       //begin: Shadcn UI Animations
       keyframes: {


### PR DESCRIPTION
## Summary
- darken the primary gradient to give the sidebar a deeper tone

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753441f63c8326b1f37eba26843690