### PR TITLE
Update React Query staleTime

### DIFF
--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -8,7 +8,7 @@ export const queryClient = new QueryClient({
       // React Query v5 uses string literals; "never" disables refetch on focus
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      staleTime: Infinity, // Data considered fresh for 1 hour
+      staleTime: 15 * 60 * 1000, // Data considered fresh for 15 minutes
       onError: (error) => handleError(error),
     },
     mutations: {


### PR DESCRIPTION
## Summary
- set global React Query `staleTime` to 15 minutes

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687533fd1268832680ad51d9c36c0134