### PR TITLE
Increase collapsed sidebar logo size

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -378,7 +378,7 @@ function Sidebar() {
             <img
               src={collapsed ? '/logo_square.svg' : '/logo_long.svg'}
               alt="StewardTrack Logo"
-              className={collapsed ? 'h-8' : 'h-10'}
+              className={collapsed ? 'h-12' : 'h-10'}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- enlarge the collapsed sidebar logo so it's easier to see

## Testing
- `npx tsc -p tests --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687538cbc9ec8326b4ab70d8d4674111