### PR TITLE
Implement AccountService with React hooks

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -22,6 +22,7 @@ export * from './useIncomeExpenseTransactionRepository';
 export * from './useFinanceDashboardData';
 export * from './useIncomeExpenseService';
 export * from "./useAnnouncementRepository";
+export * from './useAccountService';
 export * from './useActivityLogRepository';
 export * from './useMessageThreadRepository';
 export * from './useMessageRepository';

--- a/src/hooks/useAccountService.ts
+++ b/src/hooks/useAccountService.ts
@@ -1,0 +1,75 @@
+import { useQuery as useReactQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { AccountService } from '../services/AccountService';
+import { NotificationService } from '../services/NotificationService';
+import { QueryOptions } from '../adapters/base.adapter';
+
+export function useAccountService() {
+  const service = container.get<AccountService>(TYPES.AccountService);
+  const queryClient = useQueryClient();
+
+  const useQuery = (options: QueryOptions = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['accounts', serializedOptions],
+      queryFn: () => service.getAll(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useFindById = (id: string, options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['accounts', id, serializedOptions],
+      queryFn: () => service.getById(id, options),
+      staleTime: 5 * 60 * 1000,
+      enabled: (enabled ?? true) && !!id,
+    });
+  };
+
+  const useCreate = () =>
+    useMutation({
+      mutationFn: ({ data, relations, fieldsToRemove }:
+        { data: Parameters<AccountService['create']>[0]; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.create(data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['accounts'] });
+        NotificationService.showSuccess('Account created successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  const useUpdate = () =>
+    useMutation({
+      mutationFn: ({ id, data, relations, fieldsToRemove }:
+        { id: string; data: Parameters<AccountService['update']>[1]; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.update(id, data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['accounts'] });
+        NotificationService.showSuccess('Account updated successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  const useDelete = () =>
+    useMutation({
+      mutationFn: (id: string) => service.remove(id),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['accounts'] });
+        NotificationService.showSuccess('Account deleted successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  return { useQuery, useFindById, useCreate, useUpdate, useDelete };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -155,6 +155,7 @@ import { SupabaseAnnouncementService, type AnnouncementService } from '../servic
 import { SupabaseActivityLogService, type ActivityLogService } from '../services/ActivityLogService';
 import { UserRoleService } from '../services/UserRoleService';
 import { LicenseService } from '../services/LicenseService';
+import { SupabaseAccountService, type AccountService } from '../services/AccountService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -335,6 +336,10 @@ container
 container
   .bind<AnnouncementService>(TYPES.AnnouncementService)
   .to(SupabaseAnnouncementService)
+  .inSingletonScope();
+container
+  .bind<AccountService>(TYPES.AccountService)
+  .to(SupabaseAccountService)
   .inSingletonScope();
 container
   .bind<SettingService>(TYPES.SettingService)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ export const TYPES = {
   ActivityLogService: 'ActivityLogService',
   IncomeExpenseTransactionService: 'IncomeExpenseTransactionService',
   AnnouncementService: 'AnnouncementService',
+  AccountService: 'AccountService',
   DonationImportService: 'DonationImportService',
   SettingService: 'SettingService',
   UserRoleService: 'UserRoleService',

--- a/src/pages/accounts/account/AccountAddEdit.tsx
+++ b/src/pages/accounts/account/AccountAddEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useAccountRepository } from '../../../hooks/useAccountRepository';
+import { useAccountService } from '../../../hooks/useAccountService';
 import { useMemberRepository } from '../../../hooks/useMemberRepository';
 import { Account, AccountType } from '../../../models/account.model';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
@@ -38,7 +38,7 @@ function AccountAddEdit() {
   const navigate = useNavigate();
   const isEditMode = !!id;
   
-  const { useQuery: useAccountQuery, useCreate, useUpdate } = useAccountRepository();
+  const { useQuery: useAccountQuery, useCreate, useUpdate } = useAccountService();
   const { useQuery: useMembersQuery } = useMemberRepository();
   
   const [formData, setFormData] = useState<Partial<Account>>({

--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useAccountRepository } from "../../../hooks/useAccountRepository";
+import { useAccountService } from "../../../hooks/useAccountService";
 import { Account } from "../../../models/account.model";
 import { Card, CardHeader, CardContent } from "../../../components/ui2/card";
 import { Button } from "../../../components/ui2/button";
@@ -50,7 +50,7 @@ function AccountList() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
-  const { useQuery: useAccountsQuery, useDelete } = useAccountRepository();
+  const { useQuery: useAccountsQuery, useDelete } = useAccountService();
 
   // Get accounts
   const { data: result, isLoading, error } = useAccountsQuery();

--- a/src/pages/accounts/account/AccountProfile.tsx
+++ b/src/pages/accounts/account/AccountProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useAccountRepository } from '../../../hooks/useAccountRepository';
+import { useAccountService } from '../../../hooks/useAccountService';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
@@ -53,7 +53,7 @@ function AccountProfile() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   
-  const { useQuery: useAccountQuery, useDelete } = useAccountRepository();
+  const { useQuery: useAccountQuery, useDelete } = useAccountService();
   
   // Fetch account data
   const { data: accountData, isLoading } = useAccountQuery({

--- a/src/services/AccountService.ts
+++ b/src/services/AccountService.ts
@@ -1,0 +1,52 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { IAccountRepository } from '../repositories/account.repository';
+import type { Account } from '../models/account.model';
+import type { QueryOptions } from '../adapters/base.adapter';
+
+export interface AccountService {
+  getAll(options?: Omit<QueryOptions, 'pagination'>): Promise<Account[]>;
+  getById(id: string, options?: Omit<QueryOptions, 'pagination'>): Promise<Account | null>;
+  create(data: Partial<Account>, relations?: Record<string, any[]>, fieldsToRemove?: string[]): Promise<Account>;
+  update(id: string, data: Partial<Account>, relations?: Record<string, any[]>, fieldsToRemove?: string[]): Promise<Account>;
+  remove(id: string): Promise<void>;
+}
+
+@injectable()
+export class SupabaseAccountService implements AccountService {
+  constructor(
+    @inject(TYPES.IAccountRepository)
+    private repo: IAccountRepository,
+  ) {}
+
+  async getAll(options: Omit<QueryOptions, 'pagination'> = {}): Promise<Account[]> {
+    const { data } = await this.repo.findAll(options);
+    return data ?? [];
+  }
+
+  async getById(id: string, options: Omit<QueryOptions, 'pagination'> = {}): Promise<Account | null> {
+    const { data } = await this.repo.findById(id, options);
+    return data ?? null;
+  }
+
+  async create(
+    data: Partial<Account>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ): Promise<Account> {
+    return this.repo.create(data, relations, fieldsToRemove);
+  }
+
+  async update(
+    id: string,
+    data: Partial<Account>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ): Promise<Account> {
+    return this.repo.update(id, data, relations, fieldsToRemove);
+  }
+
+  async remove(id: string): Promise<void> {
+    return this.repo.delete(id);
+  }
+}

--- a/tests/accountService.test.ts
+++ b/tests/accountService.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SupabaseAccountService } from '../src/services/AccountService';
+import type { IAccountRepository } from '../src/repositories/account.repository';
+
+const repo: IAccountRepository = {
+  findAll: vi.fn().mockResolvedValue({ data: [] }),
+  findById: vi.fn().mockResolvedValue({ data: null }),
+  create: vi.fn().mockResolvedValue({ id: '1' }),
+  update: vi.fn().mockResolvedValue({ id: '1' }),
+  delete: vi.fn().mockResolvedValue(undefined),
+} as unknown as IAccountRepository;
+
+const service = new SupabaseAccountService(repo);
+
+describe('AccountService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates getAll to repository', async () => {
+    await service.getAll();
+    expect(repo.findAll).toHaveBeenCalled();
+  });
+
+  it('delegates getById to repository', async () => {
+    await service.getById('1');
+    expect(repo.findById).toHaveBeenCalledWith('1', {});
+  });
+
+  it('delegates create to repository', async () => {
+    await service.create({ name: 'test' });
+    expect(repo.create).toHaveBeenCalledWith({ name: 'test' }, undefined, []);
+  });
+
+  it('delegates update to repository', async () => {
+    await service.update('1', { name: 'x' });
+    expect(repo.update).toHaveBeenCalledWith('1', { name: 'x' }, undefined, []);
+  });
+
+  it('delegates remove to repository', async () => {
+    await service.remove('1');
+    expect(repo.delete).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add `AccountService` with CRUD methods
- register service in the IoC container and types map
- expose `useAccountService` hook
- refactor account pages to use the new hook
- export the hook from hooks index
- test AccountService to verify repository delegation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a577108408326836c62f39c3b238c