### PR TITLE
Introduce fund service layer

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -13,6 +13,7 @@ export * from './usePermissions';
 export * from './useSubscriptionLimits';
 export * from './useThemeSwitcher';
 export * from './useFundRepository';
+export * from './useFundService';
 export * from './useFundBalanceRepository';
 export * from './useOfferingBatchRepository';
 export * from './useCategoryRepository';

--- a/src/hooks/useFundService.ts
+++ b/src/hooks/useFundService.ts
@@ -1,0 +1,98 @@
+import { useQuery as useReactQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { FundService } from '../services/FundService';
+import type { Fund } from '../models/fund.model';
+import { QueryOptions } from '../adapters/base.adapter';
+import { NotificationService } from '../services/NotificationService';
+
+export function useFundService() {
+  const service = container.get<FundService>(TYPES.FundService);
+  const queryClient = useQueryClient();
+
+  const useQuery = (options: QueryOptions = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['funds', serializedOptions],
+      queryFn: () => service.find(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useQueryAll = (options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['funds', 'all', serializedOptions],
+      queryFn: () => service.findAll(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useFindById = (id: string, options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['funds', id, serializedOptions],
+      queryFn: () => service.findById(id, options),
+      staleTime: 5 * 60 * 1000,
+      enabled: (enabled ?? true) && !!id,
+    });
+  };
+
+  const useCreate = () => {
+    return useMutation({
+      mutationFn: ({ data, relations, fieldsToRemove }:
+        { data: Partial<Fund>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.create(data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['funds'] });
+        NotificationService.showSuccess('Fund created successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const useUpdate = () => {
+    return useMutation({
+      mutationFn: ({ id, data, relations, fieldsToRemove }:
+        { id: string; data: Partial<Fund>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.update(id, data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['funds'] });
+        NotificationService.showSuccess('Fund updated successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const useDelete = () => {
+    return useMutation({
+      mutationFn: (id: string) => service.delete(id),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['funds'] });
+        NotificationService.showSuccess('Fund deleted successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const useBalance = (id: string) => {
+    return useReactQuery({
+      queryKey: ['fund-balance', id],
+      queryFn: () => service.getBalance(id),
+      enabled: !!id,
+    });
+  };
+
+  return { useQuery, useQueryAll, useFindById, useCreate, useUpdate, useDelete, useBalance };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -155,6 +155,7 @@ import { SupabaseAnnouncementService, type AnnouncementService } from '../servic
 import { SupabaseActivityLogService, type ActivityLogService } from '../services/ActivityLogService';
 import { UserRoleService } from '../services/UserRoleService';
 import { LicenseService } from '../services/LicenseService';
+import { DefaultFundService, type FundService } from '../services/FundService';
 import { TYPES } from './types';
 
 const container = new Container();
@@ -347,6 +348,10 @@ container
 container
   .bind<UserRoleService>(TYPES.UserRoleService)
   .to(UserRoleService)
+  .inSingletonScope();
+container
+  .bind<FundService>(TYPES.FundService)
+  .to(DefaultFundService)
   .inSingletonScope();
 
 // Register repositories

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,5 +81,6 @@ export const TYPES = {
   DonationImportService: 'DonationImportService',
   SettingService: 'SettingService',
   UserRoleService: 'UserRoleService',
-  LicenseService: 'LicenseService'
+  LicenseService: 'LicenseService',
+  FundService: 'FundService'
 };

--- a/src/pages/finances/funds/FundAddEdit.tsx
+++ b/src/pages/finances/funds/FundAddEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFundRepository } from '../../../hooks/useFundRepository';
+import { useFundService } from '../../../hooks/useFundService';
 import { Fund, FundType } from '../../../models/fund.model';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Input } from '../../../components/ui2/input';
@@ -16,7 +16,7 @@ function FundAddEdit() {
   const navigate = useNavigate();
   const isEditMode = !!id;
 
-  const { useQuery: useFundQuery, useCreate, useUpdate } = useFundRepository();
+  const { useQuery: useFundQuery, useCreate, useUpdate } = useFundService();
 
   const [formData, setFormData] = useState<Partial<Fund>>({
     code: '',

--- a/src/pages/finances/funds/FundList.tsx
+++ b/src/pages/finances/funds/FundList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useFundRepository } from '../../../hooks/useFundRepository';
+import { useFundService } from '../../../hooks/useFundService';
 import { Fund } from '../../../models/fund.model';
 import { Card, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -18,7 +18,7 @@ function FundList() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
-  const { useQuery: useFundsQuery } = useFundRepository();
+  const { useQuery: useFundsQuery } = useFundService();
 
   const { data: result, isLoading, error } = useFundsQuery({
     pagination: { page: page + 1, pageSize },

--- a/src/pages/finances/funds/FundProfile.tsx
+++ b/src/pages/finances/funds/FundProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFundRepository } from '../../../hooks/useFundRepository';
+import { useFundService } from '../../../hooks/useFundService';
 import { useSourceRecentTransactionRepository } from '../../../hooks/useSourceRecentTransactionRepository';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -40,7 +40,7 @@ function FundProfile() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
 
-  const { useQuery: useFundQuery, useDelete } = useFundRepository();
+  const { useQuery: useFundQuery, useDelete, useBalance } = useFundService();
   const { currency } = useCurrencyStore();
 
   const { data: fundData, isLoading } = useFundQuery({
@@ -50,10 +50,10 @@ function FundProfile() {
 
   const fund = fundData?.data?.[0];
 
-  const { useFundBalance, useRecentTransactionsByFund } =
+  const { useRecentTransactionsByFund } =
     useSourceRecentTransactionRepository();
 
-  const { data: balance, isLoading: balanceLoading } = useFundBalance(id || '');
+  const { data: balance, isLoading: balanceLoading } = useBalance(id || '');
 
   const { data: transactionsData, isLoading: transactionsLoading } =
     useRecentTransactionsByFund(id || '');

--- a/src/services/FundService.ts
+++ b/src/services/FundService.ts
@@ -1,0 +1,61 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { IFundRepository } from '../repositories/fund.repository';
+import type { IFundBalanceRepository } from '../repositories/fundBalance.repository';
+import type { Fund } from '../models/fund.model';
+import { QueryOptions } from '../adapters/base.adapter';
+
+export interface FundService {
+  find(options?: QueryOptions): ReturnType<IFundRepository['find']>;
+  findAll(options?: Omit<QueryOptions, 'pagination'>): ReturnType<IFundRepository['findAll']>;
+  findById(id: string, options?: Omit<QueryOptions, 'pagination'>): ReturnType<IFundRepository['findById']>;
+  create(data: Partial<Fund>, relations?: Record<string, any[]>, fieldsToRemove?: string[]): Promise<Fund>;
+  update(id: string, data: Partial<Fund>, relations?: Record<string, any[]>, fieldsToRemove?: string[]): Promise<Fund>;
+  delete(id: string): Promise<void>;
+  getBalance(id: string): Promise<number>;
+}
+
+@injectable()
+export class DefaultFundService implements FundService {
+  constructor(
+    @inject(TYPES.IFundRepository) private repo: IFundRepository,
+    @inject(TYPES.IFundBalanceRepository) private balanceRepo: IFundBalanceRepository,
+  ) {}
+
+  find(options: QueryOptions = {}) {
+    return this.repo.find(options);
+  }
+
+  findAll(options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repo.findAll(options);
+  }
+
+  findById(id: string, options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repo.findById(id, options);
+  }
+
+  create(
+    data: Partial<Fund>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repo.create(data, relations, fieldsToRemove);
+  }
+
+  update(
+    id: string,
+    data: Partial<Fund>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repo.update(id, data, relations, fieldsToRemove);
+  }
+
+  delete(id: string) {
+    return this.repo.delete(id);
+  }
+
+  getBalance(id: string) {
+    return this.balanceRepo.getBalance(id);
+  }
+}


### PR DESCRIPTION
## Summary
- create `FundService` implementing repository-adapter pattern
- expose new `useFundService` hook
- register `FundService` in the IoC container and export constant
- update fund pages to use the service instead of repositories

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a57c084d48326b1a989896ebdeaba