### PR TITLE
Add Chart of Account service layer

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -44,3 +44,4 @@ export * from './useFiscalYearRepository';
 export * from './useFiscalPeriodRepository';
 export * from './useTenantRepository';
 export * from './useLicensePlanRepository';
+export * from './useChartOfAccountService';

--- a/src/hooks/useChartOfAccountService.ts
+++ b/src/hooks/useChartOfAccountService.ts
@@ -1,0 +1,98 @@
+import { useQuery as useReactQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import type { QueryOptions } from '../adapters/base.adapter';
+import type { ChartOfAccount } from '../models/chartOfAccount.model';
+import { ChartOfAccountService } from '../services/ChartOfAccountService';
+import { NotificationService } from '../services/NotificationService';
+
+export function useChartOfAccountService() {
+  const service = container.get<ChartOfAccountService>(TYPES.ChartOfAccountService);
+  const queryClient = useQueryClient();
+
+  const useQuery = (options: QueryOptions = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['chart_of_accounts', serializedOptions],
+      queryFn: () => service.find(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useQueryAll = (options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['chart_of_accounts', 'all', serializedOptions],
+      queryFn: () => service.findAll(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useFindById = (id: string, options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['chart_of_accounts', id, serializedOptions],
+      queryFn: () => service.findById(id, options),
+      staleTime: 5 * 60 * 1000,
+      enabled: (enabled ?? true) && !!id,
+    });
+  };
+
+  const useCreate = () => {
+    return useMutation({
+      mutationFn: ({ data, relations, fieldsToRemove } : { data: Partial<ChartOfAccount>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.create(data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['chart_of_accounts'] });
+        NotificationService.showSuccess('Chart of Account created successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const useUpdate = () => {
+    return useMutation({
+      mutationFn: ({ id, data, relations, fieldsToRemove } : { id: string; data: Partial<ChartOfAccount>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.update(id, data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['chart_of_accounts'] });
+        NotificationService.showSuccess('Chart of Account updated successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const useDelete = () => {
+    return useMutation({
+      mutationFn: (id: string) => service.delete(id),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['chart_of_accounts'] });
+        NotificationService.showSuccess('Chart of Account deleted successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+  };
+
+  const getHierarchy = () => service.getHierarchy();
+
+  return {
+    useQuery,
+    useQueryAll,
+    useFindById,
+    useCreate,
+    useUpdate,
+    useDelete,
+    getHierarchy,
+  };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -149,6 +149,7 @@ import { SettingRepository, type ISettingRepository } from '../repositories/sett
 import { SupabaseSettingService, type SettingService } from '../services/SettingService';
 import { SupabaseAuditService, type AuditService } from '../services/AuditService';
 import { IncomeExpenseTransactionService } from '../services/IncomeExpenseTransactionService';
+import { ChartOfAccountService } from '../services/ChartOfAccountService';
 import { DonationImportService } from '../services/DonationImportService';
 import { SupabaseErrorLogService, type ErrorLogService } from '../services/ErrorLogService';
 import { SupabaseAnnouncementService, type AnnouncementService } from '../services/AnnouncementService';
@@ -315,6 +316,10 @@ container
 container
   .bind<AuditService>(TYPES.AuditService)
   .to(SupabaseAuditService)
+  .inSingletonScope();
+container
+  .bind<ChartOfAccountService>(TYPES.ChartOfAccountService)
+  .to(ChartOfAccountService)
   .inSingletonScope();
 container
   .bind<IncomeExpenseTransactionService>(TYPES.IncomeExpenseTransactionService)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,7 @@ export const TYPES = {
   AuditService: 'AuditService',
   ErrorLogService: 'ErrorLogService',
   ActivityLogService: 'ActivityLogService',
+  ChartOfAccountService: 'ChartOfAccountService',
   IncomeExpenseTransactionService: 'IncomeExpenseTransactionService',
   AnnouncementService: 'AnnouncementService',
   DonationImportService: 'DonationImportService',

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountAddEdit.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountAddEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useChartOfAccountRepository } from '../../../hooks/useChartOfAccountRepository';
+import { useChartOfAccountService } from '../../../hooks/useChartOfAccountService';
 import { ChartOfAccount } from '../../../models/chartOfAccount.model';
 import { Card, CardHeader, CardContent, CardFooter } from '../../../components/ui2/card';
 import { Input } from '../../../components/ui2/input';
@@ -29,7 +29,7 @@ function ChartOfAccountAddEdit() {
   const navigate = useNavigate();
   const isEditMode = !!id;
   
-  const { useQuery, useCreate, useUpdate } = useChartOfAccountRepository();
+  const { useQuery, useCreate, useUpdate } = useChartOfAccountService();
   
   // Form state
   const [formData, setFormData] = useState<Partial<ChartOfAccount>>({

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountList.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useChartOfAccountRepository } from '../../../hooks/useChartOfAccountRepository';
+import { useChartOfAccountService } from '../../../hooks/useChartOfAccountService';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
 import { Input } from '../../../components/ui2/input';
@@ -33,7 +33,7 @@ function ChartOfAccountList() {
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
   
   // Get accounts
-  const { useQuery, useDelete } = useChartOfAccountRepository();
+  const { useQuery, useDelete } = useChartOfAccountService();
   const { data: result, isLoading } = useQuery();
   const accounts = result?.data || [];
   

--- a/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
+++ b/src/pages/accounts/chart-of-accounts/ChartOfAccountProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useChartOfAccountRepository } from '../../../hooks/useChartOfAccountRepository';
+import { useChartOfAccountService } from '../../../hooks/useChartOfAccountService';
 import { useAccountingReports } from '../../../hooks/useAccountingReports';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -59,7 +59,7 @@ function ChartOfAccountProfile() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   
   // Get account details
-  const { useQuery, useDelete } = useChartOfAccountRepository();
+  const { useQuery, useDelete } = useChartOfAccountService();
   const {
     data: accountData,
     isLoading: isAccountLoading,

--- a/src/services/ChartOfAccountService.ts
+++ b/src/services/ChartOfAccountService.ts
@@ -1,0 +1,50 @@
+import { injectable, inject } from 'inversify';
+import type { IChartOfAccountRepository } from '../repositories/chartOfAccount.repository';
+import type { ChartOfAccount } from '../models/chartOfAccount.model';
+import type { QueryOptions } from '../adapters/base.adapter';
+import { TYPES } from '../lib/types';
+
+@injectable()
+export class ChartOfAccountService {
+  constructor(
+    @inject(TYPES.IChartOfAccountRepository)
+    private repository: IChartOfAccountRepository,
+  ) {}
+
+  find(options: QueryOptions = {}) {
+    return this.repository.find(options);
+  }
+
+  findAll(options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repository.findAll(options);
+  }
+
+  findById(id: string, options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repository.findById(id, options);
+  }
+
+  create(
+    data: Partial<ChartOfAccount>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repository.create(data, relations, fieldsToRemove);
+  }
+
+  update(
+    id: string,
+    data: Partial<ChartOfAccount>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repository.update(id, data, relations, fieldsToRemove);
+  }
+
+  delete(id: string) {
+    return this.repository.delete(id);
+  }
+
+  getHierarchy() {
+    return this.repository.getHierarchy();
+  }
+}


### PR DESCRIPTION
## Summary
- add `ChartOfAccountService` and related hook
- register service in container and types
- update chart of account pages to use service hook

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a58030510832689330f18aadd108d