### PR TITLE
Add FinancialSource service and hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -47,3 +47,4 @@ export * from './useFiscalPeriodRepository';
 export * from './useTenantRepository';
 export * from './useLicensePlanRepository';
 export * from './useChartOfAccountService';
+export * from './useFinancialSourceService';

--- a/src/hooks/useFinancialSourceService.ts
+++ b/src/hooks/useFinancialSourceService.ts
@@ -1,0 +1,87 @@
+import { useQuery as useReactQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { container } from '../lib/container';
+import { TYPES } from '../lib/types';
+import { FinancialSourceService } from '../services/FinancialSourceService';
+import type { FinancialSource } from '../models/financialSource.model';
+import type { QueryOptions } from '../adapters/base.adapter';
+import { NotificationService } from '../services/NotificationService';
+
+export function useFinancialSourceService() {
+  const service = container.get<FinancialSourceService>(TYPES.FinancialSourceService);
+  const queryClient = useQueryClient();
+
+  const useQuery = (options: QueryOptions = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['financial_sources', serializedOptions],
+      queryFn: () => service.find(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useQueryAll = (options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['financial_sources', 'all', serializedOptions],
+      queryFn: () => service.findAll(options),
+      staleTime: 5 * 60 * 1000,
+      enabled: enabled ?? true,
+    });
+  };
+
+  const useFindById = (id: string, options: Omit<QueryOptions, 'pagination'> = {}) => {
+    const { enabled, ...rest } = options;
+    const serializedOptions = JSON.stringify(rest);
+    return useReactQuery({
+      queryKey: ['financial_sources', id, serializedOptions],
+      queryFn: () => service.findById(id, options),
+      staleTime: 5 * 60 * 1000,
+      enabled: (enabled ?? true) && !!id,
+    });
+  };
+
+  const useCreate = () =>
+    useMutation({
+      mutationFn: ({ data, relations, fieldsToRemove }:
+        { data: Partial<FinancialSource>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.create(data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['financial_sources'] });
+        NotificationService.showSuccess('Financial Source created successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  const useUpdate = () =>
+    useMutation({
+      mutationFn: ({ id, data, relations, fieldsToRemove }:
+        { id: string; data: Partial<FinancialSource>; relations?: Record<string, any[]>; fieldsToRemove?: string[] }) =>
+        service.update(id, data, relations, fieldsToRemove),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['financial_sources'] });
+        NotificationService.showSuccess('Financial Source updated successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  const useDelete = () =>
+    useMutation({
+      mutationFn: (id: string) => service.delete(id),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['financial_sources'] });
+        NotificationService.showSuccess('Financial Source deleted successfully');
+      },
+      onError: (error: Error) => {
+        NotificationService.showError(error.message, 5000);
+      },
+    });
+
+  return { useQuery, useQueryAll, useFindById, useCreate, useUpdate, useDelete };
+}

--- a/src/lib/container.ts
+++ b/src/lib/container.ts
@@ -157,6 +157,7 @@ import { SupabaseActivityLogService, type ActivityLogService } from '../services
 import { UserRoleService } from '../services/UserRoleService';
 import { LicenseService } from '../services/LicenseService';
 import { DefaultFundService, type FundService } from '../services/FundService';
+import { FinancialSourceService } from '../services/FinancialSourceService';
 import { SupabaseAccountService, type AccountService } from '../services/AccountService';
 import { MemberService } from '../services/MemberService';
 import { TYPES } from './types';
@@ -367,6 +368,10 @@ container
 container
   .bind<FundService>(TYPES.FundService)
   .to(DefaultFundService)
+  .inSingletonScope();
+container
+  .bind<FinancialSourceService>(TYPES.FinancialSourceService)
+  .to(FinancialSourceService)
   .inSingletonScope();
 
 // Register repositories

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,6 +84,7 @@ export const TYPES = {
   SettingService: 'SettingService',
   UserRoleService: 'UserRoleService',
   LicenseService: 'LicenseService',
+  FinancialSourceService: 'FinancialSourceService',
   FundService: 'FundService',
   MemberService: 'MemberService'
 };

--- a/src/pages/accounts/financial-sources/FinancialSourceAddEdit.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceAddEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useFinancialSourceRepository } from '../../../hooks/useFinancialSourceRepository';
+import { useFinancialSourceService } from '../../../hooks/useFinancialSourceService';
 import { useChartOfAccounts } from '../../../hooks/useChartOfAccounts';
 import { FinancialSource, SourceType } from '../../../models/financialSource.model';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
@@ -19,7 +19,7 @@ function FinancialSourceAddEdit() {
   const navigate = useNavigate();
   const isEditMode = !!id;
   
-  const { useQuery: useSourceQuery, useCreate, useUpdate } = useFinancialSourceRepository();
+  const { useQuery: useSourceQuery, useCreate, useUpdate } = useFinancialSourceService();
   const { useAccountOptions } = useChartOfAccounts();
   
   const [formData, setFormData] = useState<Partial<FinancialSource>>({

--- a/src/pages/accounts/financial-sources/FinancialSourceList.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useFinancialSourceRepository } from '../../../hooks/useFinancialSourceRepository';
+import { useFinancialSourceService } from '../../../hooks/useFinancialSourceService';
 import { FinancialSource } from '../../../models/financialSource.model';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
 import { Button } from '../../../components/ui2/button';
@@ -19,7 +19,7 @@ function FinancialSourceList() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   
-  const { useQuery: useSourcesQuery } = useFinancialSourceRepository();
+  const { useQuery: useSourcesQuery } = useFinancialSourceService();
   
   // Get sources
   const { data: result, isLoading, error } = useSourcesQuery();

--- a/src/pages/accounts/financial-sources/FinancialSourceProfile.tsx
+++ b/src/pages/accounts/financial-sources/FinancialSourceProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useFinancialSourceRepository } from '../../../hooks/useFinancialSourceRepository';
+import { useFinancialSourceService } from '../../../hooks/useFinancialSourceService';
 import { useSourceRecentTransactionRepository } from '../../../hooks/useSourceRecentTransactionRepository';
 import { useCurrencyStore } from '../../../stores/currencyStore';
 import { formatCurrency } from '../../../utils/currency';
@@ -36,7 +36,7 @@ function FinancialSourceProfile() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
 
-  const { useQuery: useSourceQuery, useDelete } = useFinancialSourceRepository();
+  const { useQuery: useSourceQuery, useDelete } = useFinancialSourceService();
   const { useRecentTransactions, useSourceBalance } = useSourceRecentTransactionRepository();
   const { currency } = useCurrencyStore();
   

--- a/src/services/FinancialSourceService.ts
+++ b/src/services/FinancialSourceService.ts
@@ -1,0 +1,46 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '../lib/types';
+import type { IFinancialSourceRepository } from '../repositories/financialSource.repository';
+import type { FinancialSource } from '../models/financialSource.model';
+import type { QueryOptions } from '../adapters/base.adapter';
+
+@injectable()
+export class FinancialSourceService {
+  constructor(
+    @inject(TYPES.IFinancialSourceRepository)
+    private repo: IFinancialSourceRepository,
+  ) {}
+
+  find(options: QueryOptions = {}) {
+    return this.repo.find(options);
+  }
+
+  findAll(options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repo.findAll(options);
+  }
+
+  findById(id: string, options: Omit<QueryOptions, 'pagination'> = {}) {
+    return this.repo.findById(id, options);
+  }
+
+  create(
+    data: Partial<FinancialSource>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repo.create(data, relations, fieldsToRemove);
+  }
+
+  update(
+    id: string,
+    data: Partial<FinancialSource>,
+    relations?: Record<string, any[]>,
+    fieldsToRemove: string[] = [],
+  ) {
+    return this.repo.update(id, data, relations, fieldsToRemove);
+  }
+
+  delete(id: string) {
+    return this.repo.delete(id);
+  }
+}

--- a/tests/financialSourceService.test.ts
+++ b/tests/financialSourceService.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FinancialSourceService } from '../src/services/FinancialSourceService';
+import type { IFinancialSourceRepository } from '../src/repositories/financialSource.repository';
+
+const repo: IFinancialSourceRepository = {
+  find: vi.fn().mockResolvedValue({ data: [] }),
+  findAll: vi.fn().mockResolvedValue({ data: [] }),
+  findById: vi.fn().mockResolvedValue({ data: null }),
+  create: vi.fn().mockResolvedValue({ id: '1' }),
+  update: vi.fn().mockResolvedValue({ id: '1' }),
+  delete: vi.fn().mockResolvedValue(undefined),
+} as unknown as IFinancialSourceRepository;
+
+const service = new FinancialSourceService(repo);
+
+describe('FinancialSourceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates find to repository', async () => {
+    await service.find();
+    expect(repo.find).toHaveBeenCalled();
+  });
+
+  it('delegates findAll to repository', async () => {
+    await service.findAll();
+    expect(repo.findAll).toHaveBeenCalled();
+  });
+
+  it('delegates findById to repository', async () => {
+    await service.findById('1');
+    expect(repo.findById).toHaveBeenCalledWith('1', {});
+  });
+
+  it('delegates create to repository', async () => {
+    await service.create({ name: 'test' });
+    expect(repo.create).toHaveBeenCalledWith({ name: 'test' }, undefined, []);
+  });
+
+  it('delegates update to repository', async () => {
+    await service.update('1', { name: 'x' });
+    expect(repo.update).toHaveBeenCalledWith('1', { name: 'x' }, undefined, []);
+  });
+
+  it('delegates delete to repository', async () => {
+    await service.delete('1');
+    expect(repo.delete).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `FinancialSourceService` with CRUD helpers
- register service with IoC container
- expose `useFinancialSourceService` React hook
- refactor financial source pages to use new hook
- export hook from index and define DI token
- add unit tests for service

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5af644688326bb7adc89e8751002