### PR TITLE
Fix initial page reset on Members DataGrid

### DIFF
--- a/src/components/ui2/mui-datagrid.tsx
+++ b/src/components/ui2/mui-datagrid.tsx
@@ -193,9 +193,10 @@ export function DataGrid<T>({
   }, []); // run once on mount
 
   React.useEffect(() => {
+    if (loading || totalRows === null || totalRows === undefined) return;
     const lastPage = Math.max(0, Math.ceil(totalRows / pageSize) - 1);
     if (page > lastPage) onPageChange?.(lastPage);
-  }, [totalRows, pageSize, page]);
+  }, [totalRows, pageSize, page, loading]);
 
   // Handle pagination changes
   const handlePaginationModelChange = (model: GridPaginationModel) => {


### PR DESCRIPTION
## Summary
- prevent DataGrid from resetting to page 0 while loading

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a64e45f388326847dc5025ab80b17