### PR TITLE
Switch FundProfile to income-expense repo

### DIFF
--- a/tests/incomeExpenseTransactionRepository.test.ts
+++ b/tests/incomeExpenseTransactionRepository.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { IncomeExpenseTransactionRepository } from '../src/repositories/incomeExpenseTransaction.repository';
+import type { IIncomeExpenseTransactionAdapter } from '../src/adapters/incomeExpenseTransaction.adapter';
+
+const adapter: IIncomeExpenseTransactionAdapter & { getByHeaderId: any } = {
+  fetch: vi.fn(),
+  fetchAll: vi.fn(),
+  fetchById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getByHeaderId: vi.fn().mockResolvedValue([])
+} as any;
+
+describe('IncomeExpenseTransactionRepository', () => {
+  it('delegates getByHeaderId to adapter', async () => {
+    const repo = new IncomeExpenseTransactionRepository(adapter);
+    await repo.getByHeaderId('h1');
+    expect(adapter.getByHeaderId).toHaveBeenCalledWith('h1');
+  });
+});


### PR DESCRIPTION
## Summary
- use `useIncomeExpenseTransactionRepository` in `FundProfile`
- fetch fund transactions with filtering and ordering
- render table using `IncomeExpenseTransaction` fields
- add test covering repository `getByHeaderId` call

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a725c65a883269f05449c203dca7a