### PR TITLE
Fix tabs context error in MemberProfile

### DIFF
--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -19,7 +19,7 @@ import { Button } from '../../components/ui2/button';
 import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui2/avatar';
 import { Badge } from '../../components/ui2/badge';
 import { Card, CardHeader, CardContent, CardTitle } from '../../components/ui2/card';
-import { Tabs, TabPanel } from '../../components/ui2/tabs';
+import { Tabs, TabsContent } from '../../components/ui2/tabs';
 import { 
   AlertDialog,
   AlertDialogAction,
@@ -198,8 +198,8 @@ function MemberProfile() {
             View and manage member information
           </p>
         </div>
-        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} className="w-full">
-          <TabPanel value="profile" className="p-0">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsContent value="profile" className="p-0">
             <div className="space-y-6">
               <Card className="w-fit">
                 <CardHeader>
@@ -228,7 +228,7 @@ function MemberProfile() {
                 </CardContent>
               </Card>
             </div>
-          </TabPanel>
+          </TabsContent>
         </Tabs>
       </div>
 


### PR DESCRIPTION
## Summary
- use `TabsContent` with Radix `Tabs` component
- switch to `onValueChange` prop on `Tabs`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a90faf0188326ae47da6f6ae5582a