### PR TITLE
Fix MemberProfile syntax error

### DIFF
--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -521,9 +521,8 @@ function MemberProfile() {
           <TabsContent value="financial" className="p-0">
             <FinancialTab memberId={member.id} />
           </TabsContent>
-        </Tabs>
-      </div>
-    </div>
+          </Tabs>
+        </div>
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>


### PR DESCRIPTION
## Summary
- fix improper closing tag in MemberProfile page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a996ff84c83269d03e9e0bc9d053b