### PR TITLE
Fix member financial totals

### DIFF
--- a/tests/memberServiceFinancial.test.ts
+++ b/tests/memberServiceFinancial.test.ts
@@ -11,7 +11,7 @@ const accountRepo: IAccountRepository = {
 } as unknown as IAccountRepository;
 
 const ftRepo: IFinancialTransactionRepository = {
-  findAll: vi.fn().mockResolvedValue({ data: [{ debit: 10, credit: 0 }] }),
+  findAll: vi.fn().mockResolvedValue({ data: [{ credit: 10 }] }),
 } as unknown as IFinancialTransactionRepository;
 
 const service = new MemberService(memberRepo, accountRepo, ftRepo);
@@ -42,6 +42,7 @@ describe('MemberService financial methods', () => {
     expect(ftRepo.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
         order: { column: 'date', ascending: false },
+        pagination: { page: 1, pageSize: 10 },
       }),
     );
   });


### PR DESCRIPTION
## Summary
- calculate giving from credit side only and skip double-entry
- only return credit amounts for trends and recent activity
- fetch last 10 transactions in financial tab
- update member service tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa2862f6c8326bd9aedb9384d14f4