### PR TITLE
Fix recent contributions calculations

### DIFF
--- a/src/pages/members/tabs/FinancialTab.tsx
+++ b/src/pages/members/tabs/FinancialTab.tsx
@@ -112,7 +112,7 @@ export default function FinancialTab({ memberId }: FinancialTabProps) {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {recent.map(t => (
+                {recent.slice(0, 10).map(t => (
                   <tr key={t.id} className="hover:bg-muted/50">
                     <td className="px-4 py-2 whitespace-nowrap text-sm">
                       {new Date(t.date).toLocaleDateString()}
@@ -122,7 +122,7 @@ export default function FinancialTab({ memberId }: FinancialTabProps) {
                     </td>
                     <td className="px-4 py-2 text-sm">{t.description}</td>
                     <td className="px-4 py-2 whitespace-nowrap text-sm text-right">
-                      {formatCurrency(Number(t.debit || 0) - Number(t.credit || 0), currency)}
+                      {formatCurrency(Number(t.credit || 0) - Number(t.debit || 0), currency)}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- limit contributions to 10 entries in member financial tab
- show contribution amounts as positive values

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687aa4f9ec948326bbacace0f560f346