### PR TITLE
Refactor MemberProfile ministry and notes layout

### DIFF
--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -292,122 +292,118 @@ function MemberProfile() {
                   <CardTitle>Ministry Information</CardTitle>
                 </CardHeader>
                 <CardContent className="p-6 border-border border-b">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                      <h3 className="text-lg font-medium mb-4">Ministry Involvement</h3>
-                      <div className="space-y-4">
-                        {member.leadership_position && (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Leadership Position</h4>
-                            <p className="mt-1">{member.leadership_position}</p>
-                          </div>
+                  <dl className="divide-y divide-border">
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Leadership Position:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.leadership_position ? (
+                          member.leadership_position
+                        ) : (
+                          <span className="text-muted-foreground">None</span>
                         )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Ministries:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
                         {member.ministries && member.ministries.length > 0 ? (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Ministries</h4>
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {member.ministries.map((ministry: string, index: number) => (
-                                <Badge key={index} variant="outline">
-                                  {ministry}
-                                </Badge>
-                              ))}
-                            </div>
+                          <div className="flex flex-wrap gap-2">
+                            {member.ministries.map((ministry: string, index: number) => (
+                              <Badge key={index} variant="outline">
+                                {ministry}
+                              </Badge>
+                            ))}
                           </div>
                         ) : (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Ministries</h4>
-                            <p className="mt-1 text-muted-foreground">No ministries listed</p>
-                          </div>
+                          <span className="text-muted-foreground">No ministries listed</span>
                         )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Small Groups:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
                         {member.small_groups && member.small_groups.length > 0 ? (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Small Groups</h4>
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {member.small_groups.map((group: string, index: number) => (
-                                <Badge key={index} variant="outline">
-                                  {group}
-                                </Badge>
-                              ))}
-                            </div>
+                          <div className="flex flex-wrap gap-2">
+                            {member.small_groups.map((group: string, index: number) => (
+                              <Badge key={index} variant="outline">
+                                {group}
+                              </Badge>
+                            ))}
                           </div>
                         ) : (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Small Groups</h4>
-                            <p className="mt-1 text-muted-foreground">No small groups listed</p>
-                          </div>
+                          <span className="text-muted-foreground">No small groups listed</span>
                         )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Volunteer Roles:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
                         {member.volunteer_roles && member.volunteer_roles.length > 0 ? (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Volunteer Roles</h4>
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {member.volunteer_roles.map((role: string, index: number) => (
-                                <Badge key={index} variant="outline">
-                                  {role}
-                                </Badge>
-                              ))}
-                            </div>
+                          <div className="flex flex-wrap gap-2">
+                            {member.volunteer_roles.map((role: string, index: number) => (
+                              <Badge key={index} variant="outline">
+                                {role}
+                              </Badge>
+                            ))}
                           </div>
                         ) : (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Volunteer Roles</h4>
-                            <p className="mt-1 text-muted-foreground">No volunteer roles listed</p>
-                          </div>
+                          <span className="text-muted-foreground">No volunteer roles listed</span>
                         )}
-                      </div>
+                      </dd>
                     </div>
-
-                    <div>
-                      <h3 className="text-lg font-medium mb-4">Spiritual Information</h3>
-                      <div className="space-y-4">
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Spiritual Gifts:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
                         {member.spiritual_gifts && member.spiritual_gifts.length > 0 ? (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Spiritual Gifts</h4>
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {member.spiritual_gifts.map((gift: string, index: number) => (
-                                <Badge key={index} variant="secondary">
-                                  {gift}
-                                </Badge>
-                              ))}
-                            </div>
+                          <div className="flex flex-wrap gap-2">
+                            {member.spiritual_gifts.map((gift: string, index: number) => (
+                              <Badge key={index} variant="secondary">
+                                {gift}
+                              </Badge>
+                            ))}
                           </div>
                         ) : (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Spiritual Gifts</h4>
-                            <p className="mt-1 text-muted-foreground">No spiritual gifts listed</p>
-                          </div>
+                          <span className="text-muted-foreground">No spiritual gifts listed</span>
                         )}
-                        {member.ministry_interests && member.ministry_interests.length > 0 ? (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Ministry Interests</h4>
-                            <div className="flex flex-wrap gap-2 mt-2">
-                              {member.ministry_interests.map((interest: string, index: number) => (
-                                <Badge key={index} variant="outline">
-                                  {interest}
-                                </Badge>
-                              ))}
-                            </div>
-                          </div>
-                        ) : (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Ministry Interests</h4>
-                            <p className="mt-1 text-muted-foreground">No ministry interests listed</p>
-                          </div>
-                        )}
-                        {member.attendance_rate !== null && (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Attendance Rate</h4>
-                            <p className="mt-1">{member.attendance_rate}%</p>
-                          </div>
-                        )}
-                        {member.last_attendance_date && (
-                          <div>
-                            <h4 className="text-sm font-medium text-muted-foreground">Last Attendance</h4>
-                            <p className="mt-1">{new Date(member.last_attendance_date).toLocaleDateString()}</p>
-                          </div>
-                        )}
-                      </div>
+                      </dd>
                     </div>
-                  </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Ministry Interests:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.ministry_interests && member.ministry_interests.length > 0 ? (
+                          <div className="flex flex-wrap gap-2">
+                            {member.ministry_interests.map((interest: string, index: number) => (
+                              <Badge key={index} variant="outline">
+                                {interest}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-muted-foreground">No ministry interests listed</span>
+                        )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Attendance Rate:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.attendance_rate !== null && member.attendance_rate !== undefined ? (
+                          `${member.attendance_rate}%`
+                        ) : (
+                          <span className="text-muted-foreground">N/A</span>
+                        )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Last Attendance:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.last_attendance_date ? (
+                          new Date(member.last_attendance_date).toLocaleDateString()
+                        ) : (
+                          <span className="text-muted-foreground">N/A</span>
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
                 </CardContent>
               </Card>
 
@@ -416,25 +412,33 @@ function MemberProfile() {
                 <CardHeader className="border-b border-border">
                   <CardTitle>Pastoral Notes</CardTitle>
                 </CardHeader>
-                <CardContent className="p-6 space-y-6 border-border border-b">
-                  {member.pastoral_notes ? (
-                    <p className="whitespace-pre-line">{member.pastoral_notes}</p>
-                  ) : (
-                    <p className="text-muted-foreground">No pastoral notes recorded.</p>
-                  )}
-
-                  <div>
-                    <h4 className="text-sm font-medium mb-2">Prayer Requests</h4>
-                    {member.prayer_requests && member.prayer_requests.length > 0 ? (
-                      <ul className="list-disc pl-4 space-y-1">
-                        {member.prayer_requests.map((request, index) => (
-                          <li key={index}>{request}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-muted-foreground">No prayer requests recorded.</p>
-                    )}
-                  </div>
+                <CardContent className="p-6 border-border border-b">
+                  <dl className="divide-y divide-border">
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Notes:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.pastoral_notes ? (
+                          <p className="whitespace-pre-line">{member.pastoral_notes}</p>
+                        ) : (
+                          <span className="text-muted-foreground">No pastoral notes recorded.</span>
+                        )}
+                      </dd>
+                    </div>
+                    <div className="py-3 grid grid-cols-3 gap-4">
+                      <dt className="text-sm font-medium text-muted-foreground">Prayer Requests:</dt>
+                      <dd className="text-sm text-foreground col-span-2">
+                        {member.prayer_requests && member.prayer_requests.length > 0 ? (
+                          <ul className="list-disc pl-4 space-y-1">
+                            {member.prayer_requests.map((request, index) => (
+                              <li key={index}>{request}</li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <span className="text-muted-foreground">No prayer requests recorded.</span>
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
                 </CardContent>
               </Card>
             </div>


### PR DESCRIPTION
## Summary
- standardize ministry information card using description lists
- update pastoral notes section to match description list style

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aaf3253788326b5ebc15e3abfd3cc