### PR TITLE
Add giving metrics with trend info

### DIFF
--- a/src/pages/members/tabs/FinancialTab.tsx
+++ b/src/pages/members/tabs/FinancialTab.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { useMemberService } from '../../../hooks/useMemberService';
 
 import MetricCard from '../../../components/dashboard/MetricCard';
-import { Card, CardHeader, CardContent, CardTitle } from '../../../components/ui2/card';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardTitle,
+} from '../../../components/ui2/card';
+import { TrendingUp } from 'lucide-react';
 import { Charts } from '../../../components/ui2/charts';
 import { useCurrencyStore } from '../../../stores/currencyStore';
 import { formatCurrency } from '../../../utils/currency';
@@ -53,20 +59,39 @@ export default function FinancialTab({ memberId }: FinancialTabProps) {
     );
   }
 
+  const yearColor = (totals?.yearChange || 0) >= 0 ? 'success' : 'destructive';
+  const monthColor = (totals?.monthChange || 0) >= 0 ? 'success' : 'destructive';
+  const weekColor = (totals?.weekChange || 0) >= 0 ? 'success' : 'destructive';
+
   return (
     <div className="space-y-6">
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-3">
         <MetricCard
           label="Giving this Year"
           value={formatCurrency(totals?.year || 0, currency)}
+          icon={TrendingUp}
+          iconClassName={`text-${yearColor}`}
+          barClassName={`bg-${yearColor}`}
+          subtext={`${(totals?.yearChange || 0).toFixed(1)}% from last year`}
+          subtextClassName={`text-${yearColor}/70`}
         />
         <MetricCard
           label="Giving this Month"
           value={formatCurrency(totals?.month || 0, currency)}
+          icon={TrendingUp}
+          iconClassName={`text-${monthColor}`}
+          barClassName={`bg-${monthColor}`}
+          subtext={`${(totals?.monthChange || 0).toFixed(1)}% from last month`}
+          subtextClassName={`text-${monthColor}/70`}
         />
         <MetricCard
           label="Giving this Week"
           value={formatCurrency(totals?.week || 0, currency)}
+          icon={TrendingUp}
+          iconClassName={`text-${weekColor}`}
+          barClassName={`bg-${weekColor}`}
+          subtext={`${(totals?.weekChange || 0).toFixed(1)}% from last week`}
+          subtextClassName={`text-${weekColor}/70`}
         />
       </div>
 

--- a/tests/memberServiceFinancial.test.ts
+++ b/tests/memberServiceFinancial.test.ts
@@ -27,14 +27,28 @@ describe('MemberService financial methods', () => {
       select: 'id',
       filters: { member_id: { operator: 'eq', value: 'm1' } },
     });
-    expect(ftRepo.findAll).toHaveBeenCalledTimes(3);
-    expect(totals).toEqual({ year: 10, month: 10, week: 10 });
+    expect(ftRepo.findAll).toHaveBeenCalledTimes(6);
+    expect(totals).toEqual({
+      year: 10,
+      month: 10,
+      week: 10,
+      yearChange: 0,
+      monthChange: 0,
+      weekChange: 0,
+    });
   });
 
   it('returns zeros when account missing', async () => {
     (accountRepo.findAll as any).mockResolvedValueOnce({ data: [] });
     const totals = await service.getFinancialTotals('m2');
-    expect(totals).toEqual({ year: 0, month: 0, week: 0 });
+    expect(totals).toEqual({
+      year: 0,
+      month: 0,
+      week: 0,
+      yearChange: 0,
+      monthChange: 0,
+      weekChange: 0,
+    });
   });
 
   it('gets recent transactions', async () => {


### PR DESCRIPTION
## Summary
- compute previous period totals and percentage change in `MemberService`
- show percent change, icons, and bottom bar on member FinancialTab metric cards
- adjust financial totals unit test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aaee8b5e88326a6a7d0ef80ce1833