### PR TITLE
Fix avatar scaling

### DIFF
--- a/src/components/ui2/avatar.tsx
+++ b/src/components/ui2/avatar.tsx
@@ -78,7 +78,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
   />
 ));

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -117,7 +117,7 @@ function MemberProfile() {
         <div className="flex flex-col items-center text-center gap-4">
           {/* Profile picture and name */}
           <div className="flex flex-col items-center gap-2">
-            <Avatar className="h-24 w-24 border-2 border-primary">
+            <Avatar className="h-32 w-32 border-2 border-primary">
               {member.profile_picture_url && (
                 <AvatarImage
                   src={member.profile_picture_url}


### PR DESCRIPTION
## Summary
- enlarge profile image on the member profile page
- prevent avatar images from stretching by using `object-cover`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba36e7b883269f0ee27288674504