### PR TITLE
Expand member list DataGrid height

### DIFF
--- a/src/pages/members/MemberList.tsx
+++ b/src/pages/members/MemberList.tsx
@@ -291,7 +291,7 @@ function MemberList() {
       </div>
 
       <Card className="mt-6">
-        <div style={{ height: 600, width: '100%' }}>
+        <div className="w-full h-[600px] lg:h-[calc(100vh-20rem)]">
           <DataGrid<Member>
             data={filteredMembers}
             totalRows={filteredMembers.length}


### PR DESCRIPTION
## Summary
- allow the member list grid to occupy more space on desktop screens

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac05c08e08326a8968acbe6466c0c