### PR TITLE
Add date-range filters for giving trends

### DIFF
--- a/src/hooks/useMemberService.ts
+++ b/src/hooks/useMemberService.ts
@@ -106,10 +106,13 @@ export function useMemberService() {
       enabled: !!memberId,
     });
 
-  const useFinancialTrends = (memberId: string) =>
+  const useFinancialTrends = (
+    memberId: string,
+    range: 'current' | 'thisYear' | 'lastYear' = 'current',
+  ) =>
     useReactQuery({
-      queryKey: ['member-financial-trends', memberId],
-      queryFn: () => service.getFinancialTrends(memberId),
+      queryKey: ['member-financial-trends', memberId, range],
+      queryFn: () => service.getFinancialTrends(memberId, range),
       staleTime: 5 * 60 * 1000,
       enabled: !!memberId,
     });

--- a/src/pages/members/tabs/FinancialTab.tsx
+++ b/src/pages/members/tabs/FinancialTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../components/ui2/card';
 import { TrendingUp } from 'lucide-react';
 import { Charts } from '../../../components/ui2/charts';
+import { Tabs, TabsList, TabsTrigger } from '../../../components/ui2/tabs';
 import { useCurrencyStore } from '../../../stores/currencyStore';
 import { formatCurrency } from '../../../utils/currency';
 import { Loader2 } from 'lucide-react';
@@ -26,9 +27,11 @@ export default function FinancialTab({ memberId }: FinancialTabProps) {
     useRecentTransactions,
   } = useMemberService();
 
+  const [trendRange, setTrendRange] = React.useState<'current' | 'thisYear' | 'lastYear'>('current');
+
   const { data: totals, isLoading: totalsLoading } = useFinancialTotals(memberId);
 
-  const { data: trends, isLoading: trendsLoading } = useFinancialTrends(memberId);
+  const { data: trends, isLoading: trendsLoading } = useFinancialTrends(memberId, trendRange);
 
   const { data: recent } = useRecentTransactions(memberId);
 
@@ -97,7 +100,22 @@ export default function FinancialTab({ memberId }: FinancialTabProps) {
 
       <Card className="overflow-hidden">
         <CardHeader className="border-b border-border">
-          <CardTitle>Giving Trend</CardTitle>
+          <div className="flex items-center justify-between gap-4">
+            <CardTitle>Giving Trend</CardTitle>
+            <Tabs value={trendRange} onValueChange={v => setTrendRange(v as any)}>
+              <TabsList className="grid grid-cols-3 bg-muted p-1 rounded-full">
+                <TabsTrigger value="current" className="flex-1 text-xs font-medium px-3 py-1.5 rounded-full data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm">
+                  Current
+                </TabsTrigger>
+                <TabsTrigger value="thisYear" className="flex-1 text-xs font-medium px-3 py-1.5 rounded-full data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm">
+                  This Year
+                </TabsTrigger>
+                <TabsTrigger value="lastYear" className="flex-1 text-xs font-medium px-3 py-1.5 rounded-full data-[state=active]:bg-white dark:data-[state=active]:bg-muted data-[state=active]:text-black dark:data-[state=active]:text-foreground data-[state=active]:shadow-sm">
+                  Last Year
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
         </CardHeader>
         <CardContent>
           {trendsLoading ? (


### PR DESCRIPTION
## Summary
- expose new `range` argument in `MemberService.getFinancialTrends`
- allow `useFinancialTrends` hook to request different ranges
- add filter tabs in member Financial tab to choose **Current**, **This Year**, or **Last Year**

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac320ad708326a3755ae357322b59