### PR TITLE
Ensure deleted members excluded

### DIFF
--- a/tests/memberServiceFinancial.test.ts
+++ b/tests/memberServiceFinancial.test.ts
@@ -25,7 +25,10 @@ describe('MemberService financial methods', () => {
     const totals = await service.getFinancialTotals('m1');
     expect(accountRepo.findAll).toHaveBeenCalledWith({
       select: 'id',
-      filters: { member_id: { operator: 'eq', value: 'm1' } },
+      filters: {
+        deleted_at: { operator: 'isEmpty', value: true },
+        member_id: { operator: 'eq', value: 'm1' },
+      },
     });
     expect(ftRepo.findAll).toHaveBeenCalledTimes(6);
     expect(totals).toEqual({


### PR DESCRIPTION
## Summary
- filter deleted members in `find` and `findAll`
- filter RPC results in birthday helpers
- exclude deleted accounts when locating member account
- filter deleted transactions in financial totals and trends

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ae0cc00048326bd9919c2917bc5ae