### PR TITLE
Fix accounts grid data loading

### DIFF
--- a/src/pages/accounts/account/AccountAddEdit.tsx
+++ b/src/pages/accounts/account/AccountAddEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useAccountService } from '../../../hooks/useAccountService';
+import { useAccountRepository } from '../../../hooks/useAccountRepository';
 import { useMemberRepository } from '../../../hooks/useMemberRepository';
 import { Account, AccountType } from '../../../models/account.model';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
@@ -38,7 +38,7 @@ function AccountAddEdit() {
   const navigate = useNavigate();
   const isEditMode = !!id;
   
-  const { useQuery: useAccountQuery, useCreate, useUpdate } = useAccountService();
+  const { useQuery: useAccountQuery, useCreate, useUpdate } = useAccountRepository();
   const { useQuery: useMembersQuery } = useMemberRepository();
   
   const [formData, setFormData] = useState<Partial<Account>>({

--- a/src/pages/accounts/account/AccountList.tsx
+++ b/src/pages/accounts/account/AccountList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useAccountService } from "../../../hooks/useAccountService";
+import { useAccountRepository } from "../../../hooks/useAccountRepository";
 import { Account } from "../../../models/account.model";
 import { Card, CardHeader, CardContent } from "../../../components/ui2/card";
 import { Button } from "../../../components/ui2/button";
@@ -50,7 +50,7 @@ function AccountList() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
-  const { useQuery: useAccountsQuery, useDelete } = useAccountService();
+  const { useQuery: useAccountsQuery, useDelete } = useAccountRepository();
 
   // Get accounts
   const { data: result, isLoading, error } = useAccountsQuery();

--- a/src/pages/accounts/account/AccountProfile.tsx
+++ b/src/pages/accounts/account/AccountProfile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useAccountService } from '../../../hooks/useAccountService';
+import { useAccountRepository } from '../../../hooks/useAccountRepository';
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { supabase } from '../../../lib/supabase';
 import { Card, CardHeader, CardContent } from '../../../components/ui2/card';
@@ -53,7 +53,7 @@ function AccountProfile() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [retryCount, setRetryCount] = useState(0);
   
-  const { useQuery: useAccountQuery, useDelete } = useAccountService();
+  const { useQuery: useAccountQuery, useDelete } = useAccountRepository();
   
   // Fetch account data
   const { data: accountData, isLoading } = useAccountQuery({


### PR DESCRIPTION
## Summary
- switch to `useAccountRepository` in account pages so queries return `{ data }`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae3a3ea408326bbed9497f0cd085b