### PR TITLE
Ensure headers not deleted when reading transactions

### DIFF
--- a/src/adapters/financialTransactionHeader.adapter.ts
+++ b/src/adapters/financialTransactionHeader.adapter.ts
@@ -257,11 +257,13 @@ export class FinancialTransactionHeaderAdapter
         account_id,
         accounts_account_id,
         account:chart_of_accounts(id, code, name, account_type),
-        account_holder:accounts(id, name)
+        account_holder:accounts(id, name),
+        header:financial_transaction_headers(id, deleted_at)
       `
       )
       .eq('tenant_id', tenantId)
       .eq('header_id', headerId)
+      .is('financial_transaction_headers.deleted_at', null)
       .order('created_at', { ascending: true });
 
     if (error) throw error;


### PR DESCRIPTION
## Summary
- filter transaction header deletion when fetching entries for a header

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687afe793ae083269c595734a429345d