### PR TITLE
Fix monthly stats join for deleted headers

### DIFF
--- a/supabase/migrations/20250826000000_update_finance_dashboard_account_type.sql
+++ b/supabase/migrations/20250826000000_update_finance_dashboard_account_type.sql
@@ -38,7 +38,9 @@ BEGIN
         END
       ) AS total
     FROM financial_transactions ft
-    JOIN financial_transaction_headers h ON h.id = ft.header_id
+    JOIN financial_transaction_headers h
+      ON h.id = ft.header_id
+     AND h.deleted_at IS NULL
     LEFT JOIN categories c ON c.id = ft.category_id
     LEFT JOIN chart_of_accounts coa ON ft.account_id = coa.id
     WHERE h.transaction_date BETWEEN p_start_date AND p_end_date


### PR DESCRIPTION
## Summary
- filter soft-deleted transaction headers in `finance_monthly_stats`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687afe06234883269dc56bbb1e5e0e16